### PR TITLE
为非时间类型的字段添加字符串到日期的转换函数

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -40,6 +40,9 @@ import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.support.logging.Log;
 import com.alibaba.druid.support.logging.LogFactory;
 import com.alibaba.druid.util.JdbcUtils;
+import com.alibaba.druid.util.JdbcConstants;
+import com.alibaba.druid.util.StringUtils;
+
 
 public class SQLUtils {
 
@@ -239,4 +242,37 @@ public class SQLUtils {
         }
         return stmtList;
     }
+	
+	 /**
+     * @author owenludong.lud
+     * @param  columnName
+     * @param  tableAlias 
+     * @param  pattern if pattern is null,it will be set {%Y-%m-%d %H:%i:%s} as mysql default value and set {yyyy-mm-dd hh24:mi:ss} as oracle default value
+     * @param  dbType  {@link JdbcConstants} if dbType is null ,it will be set the mysql as a default value
+     */
+    public static String buildToDate(String columnName,String tableAlias,String pattern,String dbType){    	
+     	StringBuilder sql = new StringBuilder();    	
+     	if(StringUtils.isEmpty(columnName))
+     		return "";  			
+     	if(StringUtils.isEmpty(dbType))    dbType = JdbcConstants.MYSQL;   
+     	String formatMethod = "";
+     	if(JdbcConstants.MYSQL.equalsIgnoreCase(dbType)){
+     		formatMethod = "STR_TO_DATE";
+     		if(StringUtils.isEmpty(pattern)) pattern = "%Y-%m-%d %H:%i:%s";
+     	}else if(JdbcConstants.ORACLE.equalsIgnoreCase(dbType)){
+     		formatMethod = "TO_DATE";
+     		if(StringUtils.isEmpty(pattern)) pattern = "yyyy-mm-dd hh24:mi:ss";
+     	}else{     		
+     		return "";
+     		//expand date's handle method for other database 
+     	}
+     	sql.append(formatMethod).append("(");        	
+ 		if(!StringUtils.isEmpty(tableAlias))
+ 			sql.append(tableAlias).append("."); 
+ 		sql.append(columnName).append(",");
+ 		sql.append("'");
+ 		sql.append(pattern);
+ 		sql.append("')");     	   	
+     	return sql.toString();
+     }
 }

--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -682,37 +682,4 @@ public final class JdbcUtils implements JdbcConstants {
 
         return sql.toString();
     }
-    
-    
-    /**
-     * @author owenludong.lud
-     * @param  columnName
-     * @param  tableAlias 
-     * @param  pattern if pattern is null,it will be set {%Y-%m-%d %H:%i:%s} as mysql default value and set {yyyy-mm-dd hh24:mi:ss} as oracle default value
-     * @param  dbType  {@link JdbcConstants} if dbType is null ,it will be set the mysql as a default value
-     */
-    public static String formatStrToDateColumn(String columnName,String tableAlias,String pattern,String dbType){    	
-     	StringBuilder sql = new StringBuilder();    	
-     	if(!StringUtils.isEmpty(columnName)){    		
-         	if(StringUtils.isEmpty(dbType))    dbType = JdbcConstants.MYSQL;   
-         	String formatMethod = "";
-         	if(MYSQL.equalsIgnoreCase(dbType)){
-         		formatMethod = "STR_TO_DATE";
-         		if(StringUtils.isEmpty(pattern)) pattern = "%Y-%m-%d %H:%i:%s";
-         	}else if(ORACLE.equalsIgnoreCase(dbType)){
-         		formatMethod = "TO_DATE";
-         		if(StringUtils.isEmpty(pattern)) pattern = "yyyy-mm-dd hh24:mi:ss";
-         	}else{
-         		//expand date's handle method for other database 
-         	}
-         	sql.append(formatMethod).append("(");        	
-     		if(!StringUtils.isEmpty(tableAlias))
-     			sql.append(tableAlias).append("."); 
-     		sql.append(columnName).append(",");
-     		sql.append("'");
-     		sql.append(pattern);
-     		sql.append("')");
-     	}    	
-     	return sql.toString();
-     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtilsTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtilsTest.java
@@ -23,7 +23,6 @@ import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.util.JdbcConstants;
 import com.alibaba.druid.util.JdbcUtils;
 
 public class JdbcUtilsTest extends TestCase {
@@ -79,13 +78,5 @@ public class JdbcUtilsTest extends TestCase {
             List<Map<String, Object>> list = JdbcUtils.executeQuery(dataSource, "select * from user");
             Assert.assertEquals(0, list.size());
         }
-    }
-    
-    public void test_formatColumnToDateType(){
-    	String colunExp = JdbcUtils.formatStrToDateColumn("gmt_create","oo","",JdbcConstants.ORACLE);
-		Assert.assertEquals("TO_DATE(oo.gmt_create,'yyyy-mm-dd hh24:mi:ss')", colunExp);
-		
-		String colunExp2 = JdbcUtils.formatStrToDateColumn("gmt_create","oo","",JdbcConstants.MYSQL);
-		Assert.assertEquals("STR_TO_DATE(oo.gmt_create,'%Y-%m-%d %H:%i:%s')", colunExp2);	
-    }
+    }   
 }


### PR DESCRIPTION
hi wenshao,
添加的代码在JdbcUtils的formatStrToDateColumn的函数。
应用场景： 在表中有一个通用字段，该字段的数据库类型为varchar，现在这个字段在某一场景下存放是订单的到期时间，因此需要转换为时间类型才能 基于该字段进行一系列的日期相加减。
