### PR TITLE
修复 OracleOutputVisitor.java 在输出hint时候 输出错误的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -566,20 +566,18 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
     }
 
     public boolean visit(OracleSelectQueryBlock x) {
-        print("SELECT ");
+        print("SELECT ");       
 
+        if (x.getHints().size() > 0) {           
+            printAndAccept(x.getHints(), ", ");           
+        }
+        
         if (SQLSetQuantifier.ALL == x.getDistionOption()) {
             print("ALL ");
         } else if (SQLSetQuantifier.DISTINCT == x.getDistionOption()) {
             print("DISTINCT ");
         } else if (SQLSetQuantifier.UNIQUE == x.getDistionOption()) {
             print("UNIQUE ");
-        }
-
-        if (x.getHints().size() > 0) {
-            print("/*+");
-            printAndAccept(x.getHints(), ", ");
-            print("*/ ");
         }
 
         printSelectList(x.getSelectList());

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -1301,7 +1301,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter {
     public boolean visit(SQLCommentHint x) {
         print("/*");
         print(x.getText());
-        print("*/");
+        print("*/ ");
         return false;
     }
 

--- a/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleHintTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleHintTest.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.bvt.sql.oracle;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.PagerUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleOutputVisitor;
+import com.alibaba.druid.util.JdbcUtils;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+public class OracleHintTest extends TestCase {
+
+	public void test_hint1() throws Exception {
+		 String sql = "SELECT /*+leading(e) index(e ORD_ORDER_ITEM_GS_BS_DI_IND)*/ distinct e.id from ord_order_item e where e.F1 = Date '2011-10-01'";
+		
+	     OracleStatementParser parser = new OracleStatementParser(sql);
+	     List<SQLStatement> statementList = parser.parseStatementList();
+	     SQLStatement stmt = statementList.get(0);
+	     
+	     StringBuilder out = new StringBuilder();
+	     stmt.accept(new OracleOutputVisitor(out, true));
+
+	     String newSQL = out.toString();	     
+	     Assert.assertEquals("SELECT /*+leading(e) index(e ORD_ORDER_ITEM_GS_BS_DI_IND)*/ DISTINCT e.id\nFROM ord_order_item e\nWHERE e.F1 = DATE '2011-10-01';\n", newSQL); 
+	     
+	}
+	
+	public void test_hint2() throws Exception {
+		String sql = "SELECT /*+leading(e) index(e ORD_ORDER_ITEM_GS_BS_DI_IND)*/ distinct e.id from ord_order_item e where e.F1 = Date '2011-10-01'";
+		String countSQL = PagerUtils.count(sql, JdbcUtils.ORACLE);		
+		Assert.assertEquals("SELECT /*+leading(e) index(e ORD_ORDER_ITEM_GS_BS_DI_IND)*/ DISTINCT COUNT(*)\nFROM ord_order_item e\nWHERE e.F1 = DATE '2011-10-01'", countSQL);
+	}
+}


### PR DESCRIPTION
1 修复 OracleOutputVisitor.java 在输出hint时候 输出错误
2 hint必须放在select后面否则走不上索引
3 统一分隔，所有符号后面加一个空格
