### PR TITLE
#414 issues ConfigFilter中getPublicKey的方法代码错误的修复

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
@@ -213,7 +213,7 @@ public class ConfigFilter extends FilterAdapter {
     }
 
     public PublicKey getPublicKey(Properties connectinProperties, Properties configFileProperties) {
-        String key = connectinProperties.getProperty(CONFIG_KEY);
+        String key = configFileProperties.getProperty(CONFIG_KEY);
 
         if (StringUtils.isEmpty(key) && connectinProperties != null) {
             key = connectinProperties.getProperty(CONFIG_KEY);


### PR DESCRIPTION
应当先从 configFileProperties 中查找 CONFIG_KEY。
原文件中 先从connectinProperties 中查找，与 219 行的代码造成重复，导致configFileProperties 的配置不起作用
