### PR TITLE
因上一次的修改不完整，再次修改ConfigFilter

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
@@ -213,8 +213,12 @@ public class ConfigFilter extends FilterAdapter {
     }
 
     public PublicKey getPublicKey(Properties connectinProperties, Properties configFileProperties) {
-        String key = configFileProperties.getProperty(CONFIG_KEY);
+        String key = "";
 
+        if(configFileProperties!=null){
+        	key=configFileProperties.getProperty(CONFIG_KEY);
+        }
+        
         if (StringUtils.isEmpty(key) && connectinProperties != null) {
             key = connectinProperties.getProperty(CONFIG_KEY);
         }


### PR DESCRIPTION
当 configFileProperties 为 null 时，之前的做法会抛出异常，且没有被捕获
