### PR TITLE
当session很多的时候，修复ConcurrentModificationException异常

### DIFF
--- a/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
+++ b/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
@@ -505,7 +505,6 @@ public class WebAppStat {
 
     public List<Map<String, Object>> getSessionStatDataList() {
         List<Map<String, Object>> sessionStatDataList = new ArrayList<Map<String, Object>>(this.sessionStatMap.size());
-        //去除ConcurrentModificationException的异常
         for (WebSessionStat sessionStat : Collections.unmodifiableCollection(this.sessionStatMap.values())) {
             Map<String, Object> sessionStatData = sessionStat.getStatData();
 


### PR DESCRIPTION
快速for循环的时候，如果集合的内容发生了改变，会抛出ConcurrentModificationException，这样就会造成在会话监控页面打开的时候是空白。
