### PR TITLE
加载配置文件里的filter时trim一下

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1177,7 +1177,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         String[] filterArray = filters.split("\\,");
 
         for (String item : filterArray) {
-            FilterManager.loadFilter(this.filters, item);
+            FilterManager.loadFilter(this.filters, item.trim());
         }
     }
 


### PR DESCRIPTION
比如
&lt;property name="filters" value="stat, slf4j" /&gt;
这里逗号后面多一个空格就会导致slf4j filter加载失败
