### PR TITLE
Add a new profile: mac-profile-oracle-jdk to support jdk 1.7+ on mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,33 @@
 				</dependency>
 			</dependencies>
 		</profile>
+
+        <profile>
+            <id>mac-profile-oracle-jdk</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>${java.home}/../lib/jconsole.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.alibaba</groupId>
+                    <artifactId>jconsole</artifactId>
+                    <version>1.8.0</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/jconsole.jar</systemPath>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.alibaba</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>1.8.0</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
 	</profiles>
 
 	<dependencies>


### PR DESCRIPTION
This fix issue #553: https://github.com/alibaba/druid/issues/553
