### PR TITLE
Fix a few spelling errors and a function name typo in SQLEvalVisitorUtils#registerBaseFunctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ out/
 *.iws
 *.iml
 /bin
-/target

--- a/src/main/java/com/alibaba/druid/filter/Filter.java
+++ b/src/main/java/com/alibaba/druid/filter/Filter.java
@@ -15,6 +15,17 @@
  */
 package com.alibaba.druid.filter;
 
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidPooledConnection;
+import com.alibaba.druid.proxy.jdbc.CallableStatementProxy;
+import com.alibaba.druid.proxy.jdbc.ClobProxy;
+import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
+import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
+import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
+import com.alibaba.druid.proxy.jdbc.ResultSetMetaDataProxy;
+import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
+import com.alibaba.druid.proxy.jdbc.StatementProxy;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
@@ -44,17 +55,6 @@ import java.sql.Wrapper;
 import java.util.Calendar;
 import java.util.Properties;
 
-import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.pool.DruidPooledConnection;
-import com.alibaba.druid.proxy.jdbc.CallableStatementProxy;
-import com.alibaba.druid.proxy.jdbc.ClobProxy;
-import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
-import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
-import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
-import com.alibaba.druid.proxy.jdbc.ResultSetMetaDataProxy;
-import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
-import com.alibaba.druid.proxy.jdbc.StatementProxy;
-
 /**
  * @author wenshao<szujobs@hotmail.com>
  */
@@ -62,7 +62,7 @@ public interface Filter extends Wrapper {
 
     void init(DataSourceProxy dataSource);
 
-    void destory();
+    void destroy();
 
     void configFromProperties(Properties properties);
 

--- a/src/main/java/com/alibaba/druid/filter/FilterAdapter.java
+++ b/src/main/java/com/alibaba/druid/filter/FilterAdapter.java
@@ -15,6 +15,18 @@
  */
 package com.alibaba.druid.filter;
 
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidPooledConnection;
+import com.alibaba.druid.proxy.jdbc.CallableStatementProxy;
+import com.alibaba.druid.proxy.jdbc.ClobProxy;
+import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
+import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
+import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
+import com.alibaba.druid.proxy.jdbc.ResultSetMetaDataProxy;
+import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
+import com.alibaba.druid.proxy.jdbc.StatementProxy;
+
+import javax.management.NotificationBroadcasterSupport;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -40,19 +52,6 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.management.NotificationBroadcasterSupport;
-
-import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.pool.DruidPooledConnection;
-import com.alibaba.druid.proxy.jdbc.CallableStatementProxy;
-import com.alibaba.druid.proxy.jdbc.ClobProxy;
-import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
-import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
-import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
-import com.alibaba.druid.proxy.jdbc.ResultSetMetaDataProxy;
-import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
-import com.alibaba.druid.proxy.jdbc.StatementProxy;
-
 /**
  * 提供JdbcFilter的基本实现，使得实现一个JdbcFilter更容易。
  * 
@@ -65,7 +64,7 @@ public abstract class FilterAdapter extends NotificationBroadcasterSupport imple
     }
 
     @Override
-    public void destory() {
+    public void destroy() {
 
     }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -15,23 +15,6 @@
  */
 package com.alibaba.druid.sql.visitor;
 
-import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_ERROR;
-import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_EXPR;
-import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_VALUE;
-import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_VALUE_NULL;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
 import com.alibaba.druid.DruidRuntimeException;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLExpr;
@@ -94,6 +77,23 @@ import com.alibaba.druid.util.JdbcUtils;
 import com.alibaba.druid.util.Utils;
 import com.alibaba.druid.wall.spi.WallVisitorUtils;
 import com.alibaba.druid.wall.spi.WallVisitorUtils.WallConditionContext;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_ERROR;
+import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_EXPR;
+import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_VALUE;
+import static com.alibaba.druid.sql.visitor.SQLEvalVisitor.EVAL_VALUE_NULL;
 
 public class SQLEvalVisitorUtils {
 
@@ -209,7 +209,7 @@ public class SQLEvalVisitorUtils {
         functions.put("trim", Trim.instance);
         functions.put("ucase", Ucase.instance);
         functions.put("upper", Ucase.instance);
-        functions.put("ucase", Lcase.instance);
+        functions.put("lcase", Lcase.instance);
         functions.put("lower", Lcase.instance);
         functions.put("hex", Hex.instance);
         functions.put("unhex", Unhex.instance);

--- a/src/test/java/com/alibaba/druid/TestRollBack.java
+++ b/src/test/java/com/alibaba/druid/TestRollBack.java
@@ -1,11 +1,9 @@
 package com.alibaba.druid;
 
-import java.beans.PropertyVetoException;
-import java.sql.SQLException;
-
-import org.junit.Assert;
-
+import com.alibaba.druid.pool.DruidDataSource;
+import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -17,8 +15,8 @@ import org.nutz.dao.impl.NutDao;
 import org.nutz.trans.Atom;
 import org.nutz.trans.Trans;
 
-import com.alibaba.druid.pool.DruidDataSource;
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import java.beans.PropertyVetoException;
+import java.sql.SQLException;
 
 /*
  * Copyright 1999-2011 Alibaba Group Holding Ltd.
@@ -79,7 +77,7 @@ public class TestRollBack {
 	}
 
 	@AfterClass
-	public static void destory() {
+	public static void destroy() {
 		c3p0.close();
 		druid.close();
 	}

--- a/src/test/java/com/alibaba/druid/bvt/pool/property/PropertyTest_useGlobalDataSourceStat.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/property/PropertyTest_useGlobalDataSourceStat.java
@@ -8,23 +8,23 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.util.JdbcUtils;
 
 
-public class PropertyTest_useGloalDataSourceStat extends TestCase {
+public class PropertyTest_useGlobalDataSourceStat extends TestCase {
     private DruidDataSource dataSource;
 
     public void test_true() {
-        System.setProperty("druid.useGloalDataSourceStat", "true");
+        System.setProperty("druid.useGlobalDataSourceStat", "true");
         dataSource = new DruidDataSource();
-        Assert.assertTrue(dataSource.isUseGloalDataSourceStat());
+        Assert.assertTrue(dataSource.isUseGlobalDataSourceStat());
     }
     
     public void test_false() {
-        System.setProperty("druid.useGloalDataSourceStat", "false");
+        System.setProperty("druid.useGlobalDataSourceStat", "false");
         dataSource = new DruidDataSource();
-        Assert.assertFalse(dataSource.isUseGloalDataSourceStat());
+        Assert.assertFalse(dataSource.isUseGlobalDataSourceStat());
     }
     
     protected void tearDown() throws Exception {
-        System.clearProperty("druid.useGloalDataSourceStat");
+        System.clearProperty("druid.useGlobalDataSourceStat");
         JdbcUtils.close(dataSource);
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/proxy/filter/GlobalStatTest0.java
+++ b/src/test/java/com/alibaba/druid/bvt/proxy/filter/GlobalStatTest0.java
@@ -28,12 +28,12 @@ public class GlobalStatTest0 extends TestCase {
         dataSourceA = new DruidDataSource();
         dataSourceA.setUrl("jdbc:mock:xx_A");
         dataSourceA.setFilters("stat");
-        dataSourceA.setUseGloalDataSourceStat(true);
+        dataSourceA.setUseGlobalDataSourceStat(true);
 
         dataSourceB = new DruidDataSource();
         dataSourceB.setUrl("jdbc:mock:xx_A");
         dataSourceB.setFilters("stat");
-        dataSourceB.setUseGloalDataSourceStat(true);
+        dataSourceB.setUseGlobalDataSourceStat(true);
     }
 
     protected void tearDown() throws Exception {

--- a/src/test/java/com/alibaba/druid/bvt/proxy/filter/GlobalStatTest1.java
+++ b/src/test/java/com/alibaba/druid/bvt/proxy/filter/GlobalStatTest1.java
@@ -25,12 +25,12 @@ public class GlobalStatTest1 extends TestCase {
         dataSourceA = new DruidDataSource();
         dataSourceA.setUrl("jdbc:mock:xx_A");
         dataSourceA.setFilters("stat");
-        dataSourceA.setUseGloalDataSourceStat(true);
+        dataSourceA.setUseGlobalDataSourceStat(true);
 
         dataSourceB = new DruidDataSource();
         dataSourceB.setUrl("jdbc:mock:xx_A");
         dataSourceB.setFilters("stat");
-        dataSourceB.setUseGloalDataSourceStat(true);
+        dataSourceB.setUseGlobalDataSourceStat(true);
     }
 
     protected void tearDown() throws Exception {


### PR DESCRIPTION
As per title.

BTW, All unit tests are passing after this simple fix.
