### PR TITLE
解决PagerUtils.limit 不支持PostgreSQL的bug

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -40,6 +40,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock.Limit;
 import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.PGLimit;
 import com.alibaba.druid.sql.dialect.sqlserver.ast.SQLServerSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.sqlserver.ast.SQLServerTop;
 import com.alibaba.druid.util.JdbcConstants;
@@ -112,9 +113,30 @@ public class PagerUtils {
             return limitMySqlQueryBlock((MySqlSelectQueryBlock) queryBlock, dbType, offset, count);
         }
 
+        if (JdbcConstants.POSTGRESQL.equals(dbType))
+        {
+        	return limitPostgreSQLQueryBlock((PGSelectQueryBlock) queryBlock, dbType, offset, count);
+        }
         throw new UnsupportedOperationException();
     }
 
+    private static String limitPostgreSQLQueryBlock(PGSelectQueryBlock queryBlock, String dbType,
+    	int offset, int count) {
+    		if (queryBlock.getLimit() != null)
+    		{
+    		throw new IllegalArgumentException("limit already exists.");
+    		}
+
+    		    PGLimit limit = new PGLimit();
+    		    if (offset > 0)
+    		    {
+    		        limit.setOffset(new SQLNumberExpr(offset));
+    		    }
+    		    limit.setRowCount(new SQLNumberExpr(count));
+    		    queryBlock.setLimit(limit);
+
+    		    return SQLUtils.toSQLString(queryBlock, dbType);
+    		}
     private static String limitDB2(SQLSelect select, String dbType, int offset, int count) {
         SQLSelectQuery query = select.getQuery();
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitor.java
@@ -27,6 +27,10 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public interface PGASTVisitor extends SQLASTVisitor {
+	
+	boolean visit(PGSelectQueryBlock.PGLimit x);
+
+	void endVisit(PGSelectQueryBlock.PGLimit x);
 
     void endVisit(PGSelectQueryBlock x);
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitorAdapter.java
@@ -24,6 +24,7 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.FetchClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.ForClause;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.PGLimit;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.WindowClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
@@ -155,5 +156,15 @@ public class PGASTVisitorAdapter extends SQLASTVisitorAdapter implements PGASTVi
     public boolean visit(PGFunctionTableSource x) {
         return true;
     }
+
+	@Override
+	public boolean visit(PGLimit x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(PGLimit x) {
+		
+	}
 
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -27,6 +27,7 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.FetchClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.ForClause;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.PGLimit;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.WindowClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
@@ -469,5 +470,15 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
     public void endVisit(PGFunctionTableSource x) {
 
     }
+
+	@Override
+	public boolean visit(PGLimit x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(PGLimit x) {
+		
+	}
 
 }

--- a/src/test/java/com/alibaba/druid/postgresql/PGLimitTest.java
+++ b/src/test/java/com/alibaba/druid/postgresql/PGLimitTest.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.postgresql;
+
+import com.alibaba.druid.util.JdbcConstants;
+
+/**
+ * 
+ * @author lizongbo
+ * 
+ */
+public class PGLimitTest {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		String dbType = JdbcConstants.POSTGRESQL;// "postgresql";
+		// dbType = "mysql";
+		String sql = " select * from brandinfo where 1=1 and brandid > 100 order by brandid asc";
+		String sqlLimit = com.alibaba.druid.sql.PagerUtils.limit(sql, dbType,
+				2499, 100);
+		System.out.println("sqlLimit == " + sqlLimit);
+		String sqlCount = com.alibaba.druid.sql.PagerUtils.count(sql, dbType);
+		System.out.println("sqlCount == " + sqlCount);
+
+	}
+
+}


### PR DESCRIPTION
参考MySQL的Limit实现，增加PGLimit实现PagerUtils.limit 支持生成PostgreSQL的分页查询sql语句
