### PR TITLE
WallFilter增加支持cobar driver

### DIFF
--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -360,8 +360,7 @@ public final class JdbcUtils implements JdbcConstants {
         } else if (rawUrl.startsWith("jdbc:mariadb:")) {
             return MARIADB_DRIVER;
         } else if (rawUrl.startsWith("jdbc:oracle:") //
-                || rawUrl.startsWith("JDBC:oracle:")
-                ) {
+                   || rawUrl.startsWith("JDBC:oracle:")) {
             return ORACLE_DRIVER;
         } else if (rawUrl.startsWith("jdbc:alibaba:oracle:")) {
             return ALI_ORACLE_DRIVER;
@@ -425,7 +424,7 @@ public final class JdbcUtils implements JdbcConstants {
 
         if (rawUrl.startsWith("jdbc:derby:")) {
             return DERBY;
-        } else if (rawUrl.startsWith("jdbc:mysql:")) {
+        } else if (rawUrl.startsWith("jdbc:mysql:") || rawUrl.startsWith("jdbc:cobar:")) {
             return MYSQL;
         } else if (rawUrl.startsWith("jdbc:log4jdbc:")) {
             return LOG4JDBC;


### PR DESCRIPTION
使用com.alibaba.cobar.jdbc.Driver的时候，rawUrl是以jdbc:cobar为前缀。
WallFilter通过JdbcUtils.getDbType方法来确定数据库类型，“jdbc:cobar”开头的rawUrl没有做处理，所以目前不支持，WallFilter初始化的时候会出抛“dbType not support ”的异常。
增加了对“jdbc:cobar:”前缀的判断，采用与mysql相同的provider。
