### PR TITLE
loadFilterConfig's source add classloader which loaded FilterManager sel...

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/FilterManager.java
+++ b/src/main/java/com/alibaba/druid/filter/FilterManager.java
@@ -59,6 +59,7 @@ public class FilterManager {
         Properties filterProperties = new Properties();
 
         loadFilterConfig(filterProperties, ClassLoader.getSystemClassLoader());
+        loadFilterConfig(filterProperties, FilterManager.class.getClassLoader());
         loadFilterConfig(filterProperties, Thread.currentThread().getContextClassLoader());
 
         return filterProperties;

--- a/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
@@ -13,6 +13,17 @@ import com.alibaba.druid.filter.FilterManager;
 
 public class FilterManagerTest extends TestCase {
 
+	static {
+		ClassLoader current = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(null);
+			
+			Assert.assertNotNull(FilterManager.getFilter("stat"));
+		} finally {
+			Thread.currentThread().setContextClassLoader(current);
+		}
+	}
+	
     public void test_instance() throws Exception {
         new FilterManager();
     }
@@ -38,6 +49,7 @@ public class FilterManagerTest extends TestCase {
         }
         Assert.assertNotNull(error);
     }
+    
 
     public static class ErrorFilter extends FilterAdapter {
 


### PR DESCRIPTION
loadFilterConfig的ClassLoader加入了加载FilterManager自身的ClassLoader，防止当druid运行在隔离容器中，导致无法加载到Filter别名。