### PR TITLE
修改一个XSD地址

### DIFF
--- a/src/test/resources/com/alibaba/druid/stat/spring-config-stat-annotation.xml
+++ b/src/test/resources/com/alibaba/druid/stat/spring-config-stat-annotation.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aop="http://www.springframework.org/schema/aop"
 	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.alibaba.com/schema/stat http://www.alibaba.com/schema/stat.xsd
+		http://www.alibaba.com/schema/stat https://raw.githubusercontent.com/alibaba/druid/master/src/main/resources/META-INF/stat.xsd
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
 		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd


### PR DESCRIPTION
由于http://www.alibaba.com/schema/stat.xsd 地址是没有这个xsd文件的，所以在eclipse里面，如果使用默认设置，会检查这个路径, 导致这个文件报错，具体问题我提交过issues: https://github.com/alibaba/druid/issues/780

现在改成git上的这个地址，可以解决这个报错。
https://raw.githubusercontent.com/alibaba/druid/master/src/main/resources/META-INF/stat.xsd