### PR TITLE
fix postgresql parenthesized bug

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectQueryBlock.java
@@ -31,6 +31,7 @@ public class SQLSelectQueryBlock extends SQLObjectImpl implements SQLSelectQuery
     protected SQLExprTableSource        into;
     protected SQLExpr                   where;
     protected SQLSelectGroupByClause    groupBy;
+    protected boolean parenthesized = false;
 
     public SQLSelectQueryBlock(){
 
@@ -90,7 +91,15 @@ public class SQLSelectQueryBlock extends SQLObjectImpl implements SQLSelectQuery
         this.from = from;
     }
 
-    @Override
+    public boolean isParenthesized() {
+		return parenthesized;
+	}
+
+	public void setParenthesized(boolean parenthesized) {
+		this.parenthesized = parenthesized;
+	}
+
+	@Override
     protected void accept0(SQLASTVisitor visitor) {
         if (visitor.visit(this)) {
             acceptChild(visitor, this.selectList);
@@ -105,6 +114,7 @@ public class SQLSelectQueryBlock extends SQLObjectImpl implements SQLSelectQuery
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + (Boolean.valueOf(parenthesized).hashCode());
         result = prime * result + distionOption;
         result = prime * result + ((from == null) ? 0 : from.hashCode());
         result = prime * result + ((groupBy == null) ? 0 : groupBy.hashCode());
@@ -120,6 +130,7 @@ public class SQLSelectQueryBlock extends SQLObjectImpl implements SQLSelectQuery
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         SQLSelectQueryBlock other = (SQLSelectQueryBlock) obj;
+        if (parenthesized ^ other.parenthesized) return false;
         if (distionOption != other.distionOption) return false;
         if (from == null) {
             if (other.from != null) return false;

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -22,6 +22,7 @@ import com.alibaba.druid.sql.ast.SQLSetQuantifier;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.ast.statement.SQLTableSource;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGParameter;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
@@ -56,6 +57,18 @@ public class PGSelectParser extends SQLSelectParser {
             this.exprParser.exprList(valuesQuery.getValues(), valuesQuery);
             accept(Token.RPAREN);
             return queryRest(valuesQuery);
+        }
+        
+        if (lexer.token() == Token.LPAREN) {
+            lexer.nextToken();
+
+            SQLSelectQuery select = query();
+			if (select instanceof SQLSelectQueryBlock) {
+				((SQLSelectQueryBlock) select).setParenthesized(true);
+			}
+            accept(Token.RPAREN);
+
+            return queryRest(select);
         }
         
         PGSelectQueryBlock queryBlock = new PGSelectQueryBlock();

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGSelectTest1.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGSelectTest1.java
@@ -21,6 +21,9 @@ import org.junit.Assert;
 
 import com.alibaba.druid.sql.PGTest;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGSchemaStatVisitor;
 
@@ -45,6 +48,26 @@ public class PGSelectTest1 extends PGTest {
 
         Assert.assertEquals(0, visitor.getColumns().size());
         Assert.assertEquals(2, visitor.getTables().size());
+    }
+    
+    public void test_1() throws Exception {
+    	String sql = "(select * from a) union select * from b";
+    	 PGSQLStatementParser parser = new PGSQLStatementParser(sql);
+         List<SQLStatement> statementList = parser.parseStatementList();
+         SQLStatement statemen = statementList.get(0);
+         print(statementList);
+
+		Assert.assertEquals(1, statementList.size());
+		assertTrue(statemen instanceof PGSelectStatement);
+		PGSelectStatement select = (PGSelectStatement) statemen;
+		assertTrue(select.getSelect().getQuery() instanceof SQLUnionQuery);
+		SQLUnionQuery unionQuery = (SQLUnionQuery) select.getSelect()
+				.getQuery();
+		assertTrue(unionQuery.getLeft() instanceof SQLSelectQueryBlock);
+		assertTrue(unionQuery.getRight() instanceof SQLSelectQueryBlock);
+		SQLSelectQueryBlock leftQueryBlock = (SQLSelectQueryBlock) unionQuery
+				.getLeft();
+		assertTrue(leftQueryBlock.isParenthesized());
     }
 
 }


### PR DESCRIPTION
example:
1、(select * from a)
2、(select * from a) union all select * from b;
pg以括号开头的select语句会陷入死循环。