### PR TITLE
解决ddl改变字符编码的时候发生语法错误

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -15,9 +15,6 @@
  */
 package com.alibaba.druid.sql.dialect.mysql.visitor;
 
-import java.util.List;
-import java.util.Map;
-
 import com.alibaba.druid.sql.ast.SQLCommentHint;
 import com.alibaba.druid.sql.ast.SQLDataType;
 import com.alibaba.druid.sql.ast.SQLExpr;
@@ -151,6 +148,9 @@ import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUnionQuery;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUnlockTablesStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+
+import java.util.List;
+import java.util.Map;
 
 public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTVisitor {
 
@@ -290,6 +290,11 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         print(' ');
         x.getDataType().accept(this);
 
+        for (SQLColumnConstraint item : x.getConstraints()) {
+            print(' ');
+            item.accept(this);
+        }
+
         if (x.getDefaultExpr() != null) {
             if (x.getDefaultExpr() instanceof SQLNullExpr) {
                 print(" NULL");
@@ -312,11 +317,6 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
 
         if (mysqlColumn != null && mysqlColumn.isAutoIncrement()) {
             print(" AUTO_INCREMENT");
-        }
-
-        for (SQLColumnConstraint item : x.getConstraints()) {
-            print(' ');
-            item.accept(this);
         }
 
         if (x.getComment() != null) {


### PR DESCRIPTION
There is a bug will result in abnormal alter table ddl generation on druid as below:
original sql:
alter table user default charset utf8mb4;

generated sql by druid's MySqlOutputVisitor:
ALTER TABLE user
        MODIFY COLUMN user_name varchar(20) CHARACTER SET utf8mb4 DEFAULT '' NOT NULL COMMENT 'user_name表示就是 昵称，不是唯一的'

the expected sql should be:
ALTER TABLE user
        MODIFY COLUMN user_name varchar(20) CHARACTER SET utf8mb4 NOT NULL DEFAULT ''  COMMENT 'user_name表示就是 昵称，不是唯一的'

the constraint section should be ahead of default value section refer to ddl defination:
http://dev.mysql.com/doc/refman/5.6/en/create-table.html
column_definition:
    data_type [NOT NULL | NULL] [DEFAULT default_value]... 
