### PR TITLE
Update WebStatFilter.java

### DIFF
--- a/src/main/java/com/alibaba/druid/support/http/WebStatFilter.java
+++ b/src/main/java/com/alibaba/druid/support/http/WebStatFilter.java
@@ -315,8 +315,8 @@ public class WebStatFilter extends AbstractWebStatImpl implements Filter {
     }
 
     public final static class StatHttpServletResponseWrapper extends HttpServletResponseWrapper implements HttpServletResponse {
-
-        private int status;
+        //初始值应该设置为：HttpServletResponse.SC_OK，而不是 0。
+        private int status = HttpServletResponse.SC_OK;
 
         public StatHttpServletResponseWrapper(HttpServletResponse response){
             super(response);


### PR DESCRIPTION
StatHttpServletResponseWrapper.status 的初始值设定有问题。
对于基于 Servlet 3.0 的应用来说，HttpServletResponse 原生的支持 getStatus() 方法；因此在 service 里面调用 respone.getStatus() 将获取到 0 。