### PR TITLE
Update JdbcConstants.java

### DIFF
--- a/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -36,7 +36,7 @@ public interface JdbcConstants {
     public static final String SQL_SERVER_DRIVER = "com.microsoft.jdbc.sqlserver.SQLServerDriver";
 
     public static final String ORACLE            = "oracle";
-    public static final String ORACLE_DRIVER     = "oracle.jdbc.driver.OracleDriver";
+    public static final String ORACLE_DRIVER     = "oracle.jdbc.OracleDriver";
 
     public static final String ALI_ORACLE        = "AliOracle";
     public static final String ALI_ORACLE_DRIVER = "com.alibaba.jdbc.AlibabaDriver";


### PR DESCRIPTION
oracle.jdbc.driver is deprecated. Now oracle.jdbc is supported.
For more information, see here [http://www.oracle.com/technetwork/database/enterprise-edition/111070-readme-083278.html](http://www.oracle.com/technetwork/database/enterprise-edition/111070-readme-083278.html).