### PR TITLE
1.修复自定义加密key的bug;2.修改生成加密密码的main方法。

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/config/ConfigFilter.java
@@ -215,7 +215,7 @@ public class ConfigFilter extends FilterAdapter {
     public PublicKey getPublicKey(Properties connectinProperties, Properties configFileProperties) {
         String key = null;
         if (configFileProperties != null) {
-            configFileProperties.getProperty(CONFIG_KEY);
+            key = configFileProperties.getProperty(CONFIG_KEY);
         }
 
         if (StringUtils.isEmpty(key) && connectinProperties != null) {

--- a/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -46,8 +46,11 @@ public class ConfigTools {
 	public static final String DEFAULT_PUBLIC_KEY_STRING = "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKHGwq7q2RmwuRgKxBypQHw0mYu4BQZ3eMsTrdK8E6igRcxsobUC7uT0SoxIjl1WveWniCASejoQtn/BY6hVKWsCAwEAAQ==";
 
 	public static void main(String[] args) throws Exception {
-		String password = args[0];
-		System.out.println(encrypt(password));
+        String password = args[0];
+        String[] arr = genKeyPair(512);
+        System.out.println("privateKey:" + arr[0]);
+        System.out.println("publicKey:" + arr[1]);
+        System.out.println("password:" + encrypt(arr[0], password));
 	}
 
 	public static String decrypt(String cipherText) throws Exception {


### PR DESCRIPTION
1.修复自定义加密key的获取之后没有设置值的bug。
2.修改ConfigTools 类，生成加密密码的main方法，之前无法指定privateKey，如果都按默认的，则加密意义不大。