### PR TITLE
DruidDataSource.getStatDataForMBean() should use getActiveCount for A…

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2170,7 +2170,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
 
             // 5 - 9
             map.put("CloseCount", this.getCloseCount());
-            map.put("ActiveCount", this.getActivePeak());
+            map.put("ActiveCount", this.getActiveCount());
             map.put("PoolingCount", this.getPoolingCount());
             map.put("LockQueueLength", this.getLockQueueLength());
             map.put("WaitThreadCount", this.getNotEmptyWaitThreadPeak());


### PR DESCRIPTION
DruidDataSource.getStatDataForMBean() should use getActiveCount for ActiveCount, just as getStatData() does.