### PR TITLE
增加可以通过系统变量来选择日志实现

### DIFF
--- a/src/main/java/com/alibaba/druid/support/logging/LogFactory.java
+++ b/src/main/java/com/alibaba/druid/support/logging/LogFactory.java
@@ -23,8 +23,21 @@ public class LogFactory {
     private static Constructor logConstructor;
 
     static {
-        // TODO add slf4j logging
-
+        String logType= System.getProperty("druid.logType");
+        if(logType != null){
+            if(logType.equalsIgnoreCase("slf4j")){
+                tryImplementation("org.slf4j.Logger", "com.alibaba.druid.support.logging.SLF4JImpl");
+            }else if(logType.equalsIgnoreCase("log4j")){
+                tryImplementation("org.apache.log4j.Logger", "com.alibaba.druid.support.logging.Log4jImpl");
+            }else if(logType.equalsIgnoreCase("log4j2")){
+                tryImplementation("org.apache.logging.log4j.Logger", "com.alibaba.druid.support.logging.Log4j2Impl");
+            }else if(logType.equalsIgnoreCase("commonsLog")){
+                tryImplementation("org.apache.commons.logging.LogFactory",
+                        "com.alibaba.druid.support.logging.JakartaCommonsLoggingImpl");
+            }else if(logType.equalsIgnoreCase("jdkLog")){
+                tryImplementation("java.util.logging.Logger", "com.alibaba.druid.support.logging.Jdk14LoggingImpl");
+            }
+        }
         // 优先选择log4j,而非Apache Common Logging. 因为后者无法设置真实Log调用者的信息
         tryImplementation("org.apache.log4j.Logger", "com.alibaba.druid.support.logging.Log4jImpl");
         tryImplementation("org.apache.logging.log4j.Logger", "com.alibaba.druid.support.logging.Log4j2Impl");


### PR DESCRIPTION
如果类依赖中不小心依赖了`org.apache.log4j.Logger`,按照现在的实现方式，日志就选用log4j了。
我们使用了logback，而且为了避免遇到多个日志实现导致`slf4j`不可用的问题，我们使用了`log4j-over-slf4j`,此包中也有`org.apache.log4j.Logger`类（主要用于去掉对log4j的api依赖），由于有此类存在，导致现在的方式在选择日志时，也选择了log4j。故提供通过系统变量来让使用者选择使用何种日志。