### PR TITLE
修复：SQL 语句解析是 schema 不支持 `-` 符号

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
@@ -115,7 +115,7 @@ public class MySqlLexer extends Lexer {
         if (commentHandler != null && commentHandler.handle(lastToken, stringVal)) {
             return;
         }
-        
+
         endOfComment = isEOF();
 
         if (!isAllowComment() && (isEOF() || !isSafeComment(stringVal))) {
@@ -393,7 +393,7 @@ public class MySqlLexer extends Lexer {
 
     public void scanComment() {
         Token lastToken = this.token;
-        
+
         if (ch == '-') {
             char next_2 = charAt(pos + 2);
             if (isDigit(next_2)) {
@@ -455,7 +455,7 @@ public class MySqlLexer extends Lexer {
             }
 
             endOfComment = isEOF();
-            
+
             if (commentHandler != null && commentHandler.handle(lastToken, stringVal)) {
                 return;
             }
@@ -504,7 +504,7 @@ public class MySqlLexer extends Lexer {
             }
 
             endOfComment = isEOF();
-            
+
             if (!isAllowComment() && (isEOF() || !isSafeComment(stringVal))) {
                 throw new NotAllowCommentException();
             }
@@ -513,8 +513,21 @@ public class MySqlLexer extends Lexer {
         }
     }
 
+    private final static boolean[] identifierFlags = new boolean[256];
+    static {
+        identifierFlags['-'] = true;
+    }
+
+    private boolean isIdentifierChar0(char c) {
+        if (c <= identifierFlags.length) {
+            return identifierFlags[c];
+        }
+
+        return c != '　' && c != '，';
+    }
+
     private boolean isIdentifierChar(char c) {
-        return c != '#' && CharTypes.isIdentifierChar(c);
+        return c != '#' && (CharTypes.isIdentifierChar(c) || isIdentifierChar0(c));
     }
 
     public void scanNumber() {

--- a/src/test/java/com/alibaba/druid/sql/parser/MySQLCharSetTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/MySQLCharSetTest.java
@@ -1,7 +1,9 @@
 package com.alibaba.druid.sql.parser;
 
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlShowTablesStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import junit.framework.TestCase;
 import org.junit.Assert;
@@ -54,5 +56,16 @@ public class MySQLCharSetTest extends TestCase{
         System.out.println(sqlStatements.get(0).toString());
         Assert.assertTrue(sqlStatements.get(0).toString().equals(resultSql));
 
+    }
+
+    public void testHasMinusChar() {
+        String stmt = "SHOW FULL TABLES FROM 'crm-ds' WHERE Table_type != 'VIEW'";
+
+        MySqlStatementParser parser = new MySqlStatementParser(stmt);
+        MySqlShowTablesStatement statement = (MySqlShowTablesStatement) parser.parseStatement();
+
+        SQLName database = statement.getDatabase();
+
+        Assert.assertEquals("'crm-ds'", database.getSimpleName());
     }
 }


### PR DESCRIPTION
解析 MySQL 语句 "SHOW FULL TABLES FROM test-db WHERE Table_type != 'VIEW'" 时，通过 MySqlShowTablesStatement.getDatabase() 获取 database 名字不正确
issues #1002