### PR TITLE
新增对simple-jndi的支持，就可以在kettle的simple-jndi中配置druid数据库连接池了

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>simple-jndi</groupId>
+			<artifactId>simple-jndi</artifactId>
+			<version>0.11.4.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.transaction</groupId>
 			<artifactId>jta</artifactId>
 			<version>1.1</version>

--- a/src/main/java/com/alibaba/druid/pool/DruidDataSourceConverter.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSourceConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.druid.pool;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.osjava.sj.loader.convert.Converter;
+
+import com.alibaba.druid.support.logging.Log;
+import com.alibaba.druid.support.logging.LogFactory;
+
+/**
+ * 支持simple-jndi <br/>
+ * <h1>配置示例：</h1>
+ * <pre>
+pgDruidTest/converter=com.alibaba.druid.pool.DruidDataSourceConverter
+pgDruidTest/type=javax.sql.DataSource
+pgDruidTest/driverClassName=org.postgresql.Driver
+pgDruidTest/url=jdbc:postgresql://127.0.0.1:5432/kettleRep
+pgDruidTest/username=postgres
+pgDruidTest/password=postgres
+pgDruidTest/maxActive=50
+pgDruidTest/minIdle=10
+pgDruidTest/initialSize=5
+pgDruidTest/validationQuery=SELECT 1
+pgDruidTest/maxWait=10000
+pgDruidTest/removeabandoned=true
+pgDruidTest/removeabandonedtimeout=60
+pgDruidTest/logabandoned=false
+pgDruidTest/filters=stat,config,log4j
+pgDruidTest/connectionProperties=druid.log.stmt.executableSql=true
+   </pre>
+ * date: 2016年1月31日 下午12:54:10 <br/>
+ * @author jinjuma@yeah.net
+ */
+public class DruidDataSourceConverter implements Converter {
+
+    private final static Log      LOG                                      = LogFactory.getLog(DruidDataSourceConverter.class);
+	/**
+	 * 
+	 * @see org.osjava.sj.loader.convert.Converter#convert(java.util.Properties, java.lang.String)
+	 */
+	@Override
+	public Object convert(Properties properties, String type) {
+        try {
+            DruidDataSource dataSource = new DruidDataSource();
+        	DruidDataSourceFactory.config(dataSource, properties);
+        	return dataSource;
+		} catch (SQLException e) {
+			LOG.error("properties:"+properties, e);
+		}
+        return null;
+	}
+
+}

--- a/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceConverterTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceConverterTest.java
@@ -1,0 +1,43 @@
+package com.alibaba.druid.bvt.pool;
+
+import java.sql.Connection;
+import java.util.Properties;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.osjava.sj.SimpleContext;
+
+import com.alibaba.druid.pool.DruidDataSource;
+
+public class DruidDataSourceConverterTest extends TestCase {
+
+	private DruidDataSource dataSource;
+
+	protected void setUp() throws Exception {
+		String root = DruidDataSourceConverterTest.class
+				.getResource("/com/alibaba/druid/pool/simplejndi/").toString();
+		if (root.startsWith("file:/"))
+			root = root.substring("file://".length() - 1);
+		Properties props = new Properties();
+		props.put("org.osjava.sj.root", root);
+		props.put("java.naming.factory.initial",
+				"org.osjava.sj.SimpleContextFactory");
+		props.put("org.osjava.sj.delimiter", "/");
+		javax.naming.Context ctx = new SimpleContext(props);
+		dataSource = (DruidDataSource) ctx.lookup("jdbc/druidTest");
+		dataSource.init();
+	}
+
+	protected void tearDown() throws Exception {
+		dataSource.close();
+	}
+
+	public void test_conn() throws Exception {
+		Assert.assertEquals(true, dataSource.isInited());
+		Connection conn = dataSource.getConnection();
+		Assert.assertEquals(1, dataSource.getActiveCount());
+		conn.close();
+		Assert.assertEquals(0, dataSource.getActiveCount());
+	}
+}

--- a/src/test/resources/com/alibaba/druid/pool/simplejndi/jdbc.properties
+++ b/src/test/resources/com/alibaba/druid/pool/simplejndi/jdbc.properties
@@ -1,0 +1,16 @@
+druidTest/converter=com.alibaba.druid.pool.DruidDataSourceConverter
+druidTest/type=javax.sql.DataSource
+druidTest/driverClassName=com.alibaba.druid.mock.MockDriver
+druidTest/url=jdbc:fake:dragoon_v25masterdb
+druidTest/username=dragoon25
+druidTest/password=dragoon25
+druidTest/maxActive=50
+druidTest/minIdle=10
+druidTest/initialSize=5
+druidTest/validationQuery=SELECT 1
+druidTest/maxWait=10000
+druidTest/removeabandoned=true
+druidTest/removeabandonedtimeout=60
+druidTest/logabandoned=false
+druidTest/filters=stat,config,log4j
+druidTest/connectionProperties=druid.log.stmt.executableSql=true;druid.stat.logSlowSql=true


### PR DESCRIPTION
kettle资源库job达到一定数据量慢得让人无法忍受，想了很多方法发现慢的原因，最后用改造后的druid打印出kettle运行的sql发现，打开一个job需要查询几千次数据库，当然这只是慢得部分原因。但druid支持simple-jndi还是有意义的。