### PR TITLE
请加入conn有效性的判断

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
+++ b/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
@@ -63,7 +63,7 @@ public class OracleValidConnectionChecker extends ValidConnectionCheckerAdapter 
         }
 
         try {
-            if (conn.isClosed()) {
+            if (conn.isClosed() || conn.isValid(timeout)) {
                 return false;
             }
         } catch (SQLException ex) {


### PR DESCRIPTION
在conn链接未关闭的前提下，判断conn连接有效性时出现等待16mins的情况，加入一个超时判断conn有效性的逻辑可以解决这个问题。