### PR TITLE
Enhancement for Teradata select and insert clauses

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
@@ -28,6 +28,7 @@ public enum SQLBinaryOperator {
     Multiply("*", 60), 
     Divide("/", 60), 
     Modulus("%", 60), 
+    Mod("MOD", 60),
     
     Add("+", 70), 
     Subtract("-", 70), 

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/stmt/TeradataSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/stmt/TeradataSelectQueryBlock.java
@@ -1,6 +1,7 @@
 package com.alibaba.druid.sql.dialect.teradata.ast.stmt;
 
 import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLOrderBy;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.teradata.visitor.TeradataASTVisitor;
@@ -8,6 +9,7 @@ import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class TeradataSelectQueryBlock extends SQLSelectQueryBlock {
 	private SQLOrderBy    orderBy;
+	private SQLExpr qualifyClause;
 	
 	public TeradataSelectQueryBlock() {
 		
@@ -30,6 +32,7 @@ public class TeradataSelectQueryBlock extends SQLSelectQueryBlock {
             acceptChild(visitor, this.from);
             acceptChild(visitor, this.where);
             acceptChild(visitor, this.groupBy);
+            acceptChild(visitor, this.qualifyClause);
             acceptChild(visitor, this.orderBy);
         }
         visitor.endVisit(this);
@@ -41,6 +44,17 @@ public class TeradataSelectQueryBlock extends SQLSelectQueryBlock {
 
     public void setOrderBy(SQLOrderBy orderBy) {
         this.orderBy = orderBy;
+    }
+    
+    public SQLExpr getQualifyClause() {
+    	return qualifyClause;
+    }
+    
+    public void setQualifyClause(SQLExpr qualify) {
+    	if (qualify != null) {
+    		qualify.setParent(this);
+    	}
+    	this.qualifyClause = qualify;
     }
     
     public String toString() {

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
@@ -45,6 +45,10 @@ public class TeradataLexer extends Lexer {
         
         map.put("FORMAT", Token.FORMAT);
         
+        map.put("QUALIFY", Token.QUALIFY);
+        
+        map.put("MOD", Token.MOD);
+        
         DEFAULT_TD_KEYWORDS = new Keywords(map);
     }
     

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataStatementParser.java
@@ -118,7 +118,8 @@ public class TeradataStatementParser extends SQLStatementParser {
                 break;
             }
 
-        } else if (lexer.token() == (Token.SELECT)) {
+        } else if (lexer.token() == (Token.SELECT) 
+        		|| lexer.token() == (Token.SEL)) {
             SQLSelect select = this.exprParser.createSelectParser().select();
             select.setParent(insertStatement);
             insertStatement.setQuery(select);

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
@@ -17,6 +17,7 @@ package com.alibaba.druid.sql.dialect.teradata.visitor;
 
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
@@ -37,4 +38,8 @@ public interface TeradataASTVisitor extends SQLASTVisitor {
 	boolean visit(TeradataIntervalExpr x);
 	
 	void endVisit(TeradataIntervalExpr x);
+	
+	boolean visit(SQLSubqueryTableSource x);
+	
+	void endVisit(SQLSubqueryTableSource x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
@@ -15,6 +15,10 @@
  */
 package com.alibaba.druid.sql.dialect.teradata.visitor;
 
+import java.util.Map;
+
+import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
+import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
@@ -54,5 +58,31 @@ public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements Tera
 	public void endVisit(TeradataIntervalExpr x) {
 
 	}
+	
+	@Override
+	public boolean visit(SQLSubqueryTableSource x) {
+		accept(x.getSelect());
+		
+		String table = (String) x.getSelect().getAttribute(ATTR_TABLE);
+		if (aliasMap != null && x.getAlias() != null) {
+			if (table != null) {
+				this.aliasMap.put(x.getAlias(), table);
+			}
+			addSubQuery(x.getAlias(), x.getSelect());
+			this.setCurrentTable(x.getAlias());
+		}
+		
+		if (table != null) {
+			x.putAttribute(ATTR_TABLE, table);
+		}
+		
+		return false;
+	}
+	
+	@Override
+	public void endVisit(SQLSubqueryTableSource x) {
+		
+	}
+	
 
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
@@ -17,12 +17,17 @@ package com.alibaba.druid.sql.dialect.teradata.visitor;
 
 import java.util.Map;
 
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat.Column;
 import com.alibaba.druid.util.JdbcUtils;
 
 public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements TeradataASTVisitor {
@@ -82,6 +87,35 @@ public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements Tera
 	@Override
 	public void endVisit(SQLSubqueryTableSource x) {
 		
+	}
+	
+	public boolean visit(SQLSelectItem x) {
+		x.getExpr().accept(this);
+        
+        String alias = x.getAlias();
+        
+        Map<String, String> aliasMap = this.getAliasMap();
+        if (alias != null && (!alias.isEmpty()) && aliasMap != null) {
+            if (x.getExpr() instanceof SQLName) {
+                putAliasMap(aliasMap, alias, x.getExpr().toString());
+            } else if (x.getExpr() instanceof SQLAggregateExpr 
+            		|| x.getExpr() instanceof SQLMethodInvokeExpr) {
+            	TeradataSchemaStatVisitor visitor = new TeradataSchemaStatVisitor(); 
+            	x.getExpr().accept(visitor);
+            	for (Column col : visitor.getColumns()) {
+            		if (col.getTable().equalsIgnoreCase("unknown") 
+            				|| this.getCurrentTable() != null) {
+            			col.setTable(this.currentTable);
+            		}
+            		putAliasMap(aliasMap, alias, col.toString());
+            	}            	
+            } 
+            else {
+                putAliasMap(aliasMap, alias, null);
+            }
+        }
+        
+        return false;
 	}
 	
 

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -382,7 +382,8 @@ public class SQLSelectParser extends SQLParser {
         if (lexer.token() == Token.LPAREN) {
             lexer.nextToken();
             SQLTableSource tableSource;
-            if (lexer.token() == Token.SELECT || lexer.token() == Token.WITH) {
+            if (lexer.token() == Token.SELECT || lexer.token() == Token.WITH
+            		|| lexer.token == Token.SEL) {
                 SQLSelect select = select();
                 accept(Token.RPAREN);
                 SQLSelectQuery query = queryRest(select.getQuery());

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -271,6 +271,7 @@ public enum Token {
     POSITION("POSITION"),
     RANGE_N("RANGE_N"),
     FORMAT("FORMAT"),
+    QUALIFY("QUALIFY"),
 
     LPAREN("("), 
     RPAREN(")"), 

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -272,6 +272,7 @@ public enum Token {
     RANGE_N("RANGE_N"),
     FORMAT("FORMAT"),
     QUALIFY("QUALIFY"),
+    MOD("MOD"),
 
     LPAREN("("), 
     RPAREN(")"), 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
@@ -760,12 +760,14 @@ public class SchemaStatVisitor extends SQLASTVisitorAdapter {
         Map<String, String> aliasMap = getAliasMap();
 
         if (aliasMap != null) {
-            if (aliasMap.containsKey(name)) {
+            if (aliasMap.containsKey(name)
+            		&& aliasMap.get(name) != null) {
                 return aliasMap.get(name);
             }
             
             String name_lcase = name.toLowerCase();
-            if (name_lcase != name && aliasMap.containsKey(name_lcase)) {
+            if (name_lcase != name && aliasMap.containsKey(name_lcase)
+            		&& aliasMap.get(name_lcase) != null) {
                 return aliasMap.get(name_lcase);
             }
             


### PR DESCRIPTION
This PR mainly focuses on bug fix and new tokens added to TD **Select** and **Insert** clause.

1. bug fix for `SchemaStatVisitor` as column will return `null` if key exists whilst value is null;
1. add support for `SEL`, `MOD` and `QUALIFY`;
1. add support for `SQLSubqueryTableSource` for TD;
1. add `aliasQueryMap` to store mapping from alias to expression, as there may exist `null` in alias map. This feature mainly enables us to track the mapping between **real target columns** and **real source columns**.