### PR TITLE
增加MySQL存储过程语法中定义异常语法的识别(区别于上次提交，上次是异常处理，这次是异常定义)

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/clause/MySqlDeclareConditionStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/clause/MySqlDeclareConditionStatement.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.mysql.ast.clause;
+
+
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlStatementImpl;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
+/**
+ * 
+ * @author zhujun [455910092@qq.com]
+ * @date 2016-04-14
+ */
+public class MySqlDeclareConditionStatement extends MySqlStatementImpl{
+	
+	/*
+	DECLARE condition_name CONDITION FOR condition_value
+
+	condition_value:
+	    SQLSTATE [VALUE] sqlstate_value
+	  | mysql_error_code
+	*/
+	
+	//condition_name
+	private String conditionName; 
+	//sp statement
+	private ConditionValue conditionValue;
+	
+	public String getConditionName() {
+		return conditionName;
+	}
+
+	public void setConditionName(String conditionName) {
+		this.conditionName = conditionName;
+	}
+
+	public ConditionValue getConditionValue() {
+		return conditionValue;
+	}
+
+	public void setConditionValue(ConditionValue conditionValue) {
+		this.conditionValue = conditionValue;
+	}
+
+	@Override
+	public void accept0(MySqlASTVisitor visitor) {
+		// TODO Auto-generated method stub
+		visitor.visit(this);
+	    visitor.endVisit(this);
+		
+	}
+
+}
+

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
@@ -25,6 +25,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.MysqlForeignKey;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement.MySqlWhenStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCursorDeclareStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareConditionStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareHandlerStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlIterateStatement;
@@ -586,5 +587,9 @@ public interface MySqlASTVisitor extends SQLASTVisitor {
     boolean visit(MySqlDeclareHandlerStatement x);
 
     void endVisit(MySqlDeclareHandlerStatement x);
+    
+    boolean visit(MySqlDeclareConditionStatement x);
+
+    void endVisit(MySqlDeclareConditionStatement x);
 
 } //

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitorAdapter.java
@@ -26,6 +26,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.clause.ConditionValue;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement.MySqlWhenStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCursorDeclareStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareConditionStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareHandlerStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlIterateStatement;
@@ -1288,6 +1289,18 @@ public class MySqlASTVisitorAdapter extends SQLASTVisitorAdapter implements MySq
 
 	@Override
 	public void endVisit(MySqlDeclareHandlerStatement x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(MySqlDeclareConditionStatement x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(MySqlDeclareConditionStatement x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -59,6 +59,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.clause.ConditionValue.ConditionTy
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement.MySqlWhenStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCursorDeclareStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareConditionStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareHandlerStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlIterateStatement;
@@ -3429,7 +3430,6 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
 
 	@Override
 	public boolean visit(MySqlDeclareHandlerStatement x) {
-		// TODO Auto-generated method stub
 		
 		print0(ucase ? "DECLARE " : "declare ");
         print0(ucase ? x.getHandleType().toString().toUpperCase() : x.getHandleType().toString().toLowerCase());
@@ -3458,7 +3458,28 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
 
 	@Override
 	public void endVisit(MySqlDeclareHandlerStatement x) {
-		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(MySqlDeclareConditionStatement x) {
+		print0(ucase ? "DECLARE " : "declare ");
+        print0(x.getConditionName());
+        print0(ucase ? " CONDITION FOR " : " condition for ");
+        
+        if (x.getConditionValue().getType() == ConditionType.SQLSTATE) {
+			print0(ucase ? "SQLSTATE " : "sqlstate ");
+			print0(x.getConditionValue().getValue());
+		} else {
+			print0(x.getConditionValue().getValue());
+		}
+        
+        println();
+		return false;
+	}
+
+	@Override
+	public void endVisit(MySqlDeclareConditionStatement x) {
 		
 	}
 } //

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlSchemaStatVisitor.java
@@ -39,6 +39,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.MysqlForeignKey;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCaseStatement.MySqlWhenStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlCursorDeclareStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareConditionStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareHandlerStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlDeclareStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlIterateStatement;
@@ -1398,6 +1399,18 @@ public class MySqlSchemaStatVisitor extends SchemaStatVisitor implements MySqlAS
 
 	@Override
 	public void endVisit(MySqlDeclareHandlerStatement x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(MySqlDeclareConditionStatement x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(MySqlDeclareConditionStatement x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
@@ -157,6 +157,7 @@ public class Keywords {
         map.put("SQLWARNING", Token.SQLWARNING);
         map.put("SQLEXCEPTION", Token.SQLEXCEPTION);
         map.put("FOUND", Token.FOUND);
+        map.put("CONDITION", Token.CONDITION);
         
         DEFAULT_KEYWORDS = new Keywords(map);
     }

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -145,6 +145,7 @@ public enum Token {
     SQLWARNING("SQLWARNING"),
     SQLEXCEPTION("SQLEXCEPTION"),
     FOUND("FOUND"),
+    CONDITION("CONDITION"),
     
     //postgresql
     WINDOW("WINDOW"),

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlCreateProcedureTest9.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlCreateProcedureTest9.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.mysql;
+
+import java.util.List;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.stat.TableStat.Column;
+
+/**
+ * 
+ * @Description: 测试异常声明
+ * @author zhujun [455910092@qq.com]
+ * @date 2016-4-17
+ * @version V1.0
+ */
+public class MySqlCreateProcedureTest9 extends MysqlTest {
+
+    public void test_0() throws Exception {
+    	String sql = "create or replace procedure sp_name(level int,age int)"+
+				" begin"+
+				" declare test1 CONDITION FOR SQLSTATE '02000';"+
+				" end";
+    	
+    	MySqlStatementParser parser=new MySqlStatementParser(sql);
+    	List<SQLStatement> statementList = parser.parseStatementList();
+    	SQLStatement statemen = statementList.get(0);
+    	print(statementList);
+        Assert.assertEquals(1, statementList.size());
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        statemen.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
+        
+        Assert.assertEquals(0, visitor.getTables().size());
+        Assert.assertEquals(0, visitor.getColumns().size());
+        Assert.assertEquals(0, visitor.getConditions().size());
+    }
+    
+    public void test_2() throws Exception {
+    	String sql = "create or replace procedure sp_name(level int,age int)"+
+				" begin"+
+				" declare condition_name CONDITION FOR 1002;"+
+				" end";
+    	
+    	MySqlStatementParser parser=new MySqlStatementParser(sql);
+    	List<SQLStatement> statementList = parser.parseStatementList();
+    	SQLStatement statemen = statementList.get(0);
+    	print(statementList);
+        Assert.assertEquals(1, statementList.size());
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        statemen.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
+        
+        Assert.assertEquals(0, visitor.getTables().size());
+        Assert.assertEquals(0, visitor.getColumns().size());
+        Assert.assertEquals(0, visitor.getConditions().size());
+    }
+    
+    public void test_3() throws Exception {
+    	String sql="create or replace procedure test_cursor (in param int(10),out result varchar(90))  "
+    			+" begin" 
+    			+" declare name varchar(20);"  
+    			+" declare pass varchar(20);"  
+    			+" declare done int;"  
+    			+" declare cur_test CURSOR for select user_name,user_pass from test;" 
+    			+" declare condition_name CONDITION FOR 1002;"
+    			+" declare continue handler FOR condition_name SET done = 1;"  
+    			+" if param then"  
+    			+" 		select concat_ws(',',user_name,user_pass) into result from test.users where id=param;"  
+    			+" else"  
+    			+" 		open cur_test;"  
+    			+" 		repeat"  
+    			+" 		fetch cur_test into name, pass;"  
+    			+" 		select concat_ws(',',result,name,pass) into result;"  
+    			+" 		until done end repeat;"  
+    			+" 		close cur_test;"  
+    			+" end if;"  
+    			+" end;";
+	
+    	MySqlStatementParser parser=new MySqlStatementParser(sql);
+    	List<SQLStatement> statementList = parser.parseStatementList();
+    	SQLStatement statemen = statementList.get(0);
+    	print(statementList);
+        Assert.assertEquals(1, statementList.size());
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        statemen.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
+        
+        Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertEquals(3, visitor.getColumns().size());
+        Assert.assertEquals(0, visitor.getConditions().size());
+    }
+    
+}


### PR DESCRIPTION
增加MySQL 存储过程中声明CONDITION的语法
例子：declare condition_name CONDITION FOR 1002;
语法定于为
```
DECLARE condition_name CONDITION FOR condition_value
    	condition_value:
    	    SQLSTATE [VALUE] sqlstate_value
    	  | mysql_error_code
```