### PR TITLE
New enhancement for Teradata Insert & Select parser

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/TeradataDateTimeDataType.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/TeradataDateTimeDataType.java
@@ -1,0 +1,39 @@
+package com.alibaba.druid.sql.dialect.teradata.ast;
+
+import com.alibaba.druid.sql.ast.SQLDataTypeImpl;
+import com.alibaba.druid.sql.dialect.teradata.visitor.TeradataASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class TeradataDateTimeDataType extends SQLDataTypeImpl implements TeradataObject {
+	
+	private boolean withTimeZone = false;
+	
+	public TeradataDateTimeDataType() {
+		
+	}
+	
+	public TeradataDateTimeDataType(String type) {
+		super.setName(type);
+	}
+	
+	
+	protected void accept0(SQLASTVisitor visitor) {
+		this.accept0((TeradataASTVisitor) visitor);
+	}
+	
+	public void accept0(TeradataASTVisitor visitor) {
+		if (visitor.visit(this)) {
+            acceptChild(visitor, getArguments());
+        }
+        visitor.endVisit(this);
+	}
+	
+	public boolean isWithTimeZone() {
+		return this.withTimeZone;
+	}
+	
+	public void setWithTimeZone(boolean withTimeZone) {
+		this.withTimeZone = withTimeZone;
+	}
+	
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateExpr.java
@@ -7,10 +7,19 @@ import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class TeradataDateExpr extends SQLExprImpl implements SQLLiteralExpr, TeradataExpr{
 	
-	private String literal;
+	private String           literal;
+	private TeradataDateType type;
 	
 	public TeradataDateExpr() {
 		
+	}
+	
+	public TeradataDateType getType() {
+		return this.type;
+	}
+	
+	public void setType(TeradataDateType type) {
+		this.type = type;
 	}
 	
 	public String getLiteral() {
@@ -51,6 +60,10 @@ public class TeradataDateExpr extends SQLExprImpl implements SQLLiteralExpr, Ter
         } else if (!literal.equals(other.literal)) {
             return false;
         }
+        
+        if (type != other.type) {
+        	return false;
+        }
         return true;
 	}
 
@@ -59,6 +72,7 @@ public class TeradataDateExpr extends SQLExprImpl implements SQLLiteralExpr, Ter
 		final int prime = 31;
         int result = 1;
         result = prime * result + ((literal == null) ? 0 : literal.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
         return result;
 	}
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateExpr.java
@@ -1,0 +1,64 @@
+package com.alibaba.druid.sql.dialect.teradata.ast.expr;
+
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.expr.SQLLiteralExpr;
+import com.alibaba.druid.sql.dialect.teradata.visitor.TeradataASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class TeradataDateExpr extends SQLExprImpl implements SQLLiteralExpr, TeradataExpr{
+	
+	private String literal;
+	
+	public TeradataDateExpr() {
+		
+	}
+	
+	public String getLiteral() {
+		return literal;
+	}
+	
+	public void setLiteral(String literal) {
+		this.literal = literal;
+	}
+	
+	@Override
+	protected void accept0(SQLASTVisitor visitor) {
+		// TODO Auto-generated method stub
+		this.accept0((TeradataASTVisitor) visitor);
+	}
+	
+	public void accept0(TeradataASTVisitor visitor) {
+		visitor.visit(this);
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TeradataDateExpr other = (TeradataDateExpr) obj;
+        if (literal == null) {
+            if (other.literal != null) {
+                return false;
+            }
+        } else if (!literal.equals(other.literal)) {
+            return false;
+        }
+        return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+        int result = 1;
+        result = prime * result + ((literal == null) ? 0 : literal.hashCode());
+        return result;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateTimeUnit.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateTimeUnit.java
@@ -1,0 +1,22 @@
+package com.alibaba.druid.sql.dialect.teradata.ast.expr;
+
+public enum TeradataDateTimeUnit {
+	YEAR, 
+	QUARTER,
+	MONTH,
+	WEEK,
+	DAY,
+	DAY_OF_MONTH,
+	DAY_OF_WEEK,
+	DOW,
+	DAY_OF_YEAR,
+	DOY,
+	YEAR_OF_WEEK,
+	YOW,
+	HOUR,
+	MINUTE,
+	SECOND,
+	TIMEZONE_HOUR,
+	TIMEZONE_MINUTE
+	
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateType.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataDateType.java
@@ -1,0 +1,8 @@
+package com.alibaba.druid.sql.dialect.teradata.ast.expr;
+
+public enum TeradataDateType {
+	DATE,
+	TIME,
+	TIMESTAMP
+
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataExtractExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataExtractExpr.java
@@ -1,0 +1,80 @@
+package com.alibaba.druid.sql.dialect.teradata.ast.expr;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.dialect.teradata.visitor.TeradataASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class TeradataExtractExpr extends SQLExprImpl implements TeradataExpr{
+
+	private TeradataDateTimeUnit unit;
+	private SQLExpr              from;
+	
+	public TeradataExtractExpr() {
+		
+	}
+	
+	public TeradataDateTimeUnit getUnit() {
+		return this.unit;
+	}
+	
+	public void setUnit(TeradataDateTimeUnit unit) {
+		this.unit = unit;
+	}
+	
+	public SQLExpr getFrom() {
+		return this.from;
+	}
+	
+	public void setFrom(SQLExpr from) {
+		this.from = from;
+	}
+	
+	@Override
+	protected void accept0(SQLASTVisitor visitor) {
+		this.accept0((TeradataASTVisitor) visitor);
+	}
+	
+	public void accept0(TeradataASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.from);
+		}
+		
+		visitor.endVisit(this);
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        
+        TeradataExtractExpr other = (TeradataExtractExpr) obj;
+        if (from == null) {
+            if (other.from != null) {
+                return false;
+            }
+        } else if (!from.equals(other.from)) {
+            return false;
+        }
+        if (unit != other.unit) {
+            return false;
+        }
+        return true;        
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((from == null) ? 0 : from.hashCode());
+		result = prime * result + ((unit == null) ? 0 : unit.hashCode());
+		return result;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataFormatExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataFormatExpr.java
@@ -1,0 +1,76 @@
+package com.alibaba.druid.sql.dialect.teradata.ast.expr;
+
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.expr.SQLLiteralExpr;
+import com.alibaba.druid.sql.dialect.teradata.visitor.TeradataASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class TeradataFormatExpr extends SQLExprImpl implements SQLLiteralExpr, SQLName, TeradataExpr{
+
+	private String literal;
+	private String name;
+	
+	public TeradataFormatExpr() {
+		
+	}
+	
+	public String getLiteral() {
+		return literal;
+	}
+	
+	public void setLiteral(String literal) {
+		this.literal = literal;
+	}
+	
+	@Override
+	protected void accept0(SQLASTVisitor visitor) {
+		// TODO Auto-generated method stub
+		this.accept0((TeradataASTVisitor) visitor);
+	}
+	
+	public void accept0(TeradataASTVisitor visitor) {
+		visitor.visit(this);
+		visitor.endVisit(this);
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TeradataFormatExpr other = (TeradataFormatExpr) obj;
+        if (literal == null) {
+            if (other.literal != null) {
+                return false;
+            }
+        } else if (!literal.equals(other.literal)) {
+            return false;
+        }
+        return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+        int result = 1;
+        result = prime * result + ((literal == null) ? 0 : literal.hashCode());
+        return result;
+	}
+
+	@Override
+	public String getSimpleName() {
+		// TODO Auto-generated method stub
+		return name;
+	}
+	
+	public String toString() {
+		return "FORMAT '" + literal +"'"; 
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataIntervalExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/ast/expr/TeradataIntervalExpr.java
@@ -9,6 +9,12 @@ public class TeradataIntervalExpr extends SQLExprImpl implements TeradataExpr {
 	
 	private SQLExpr              value;
 	private TeradataIntervalUnit unit;
+	
+	private TeradataIntervalUnit type;
+	private TeradataIntervalUnit toType;
+	private Integer              precision;
+	private Integer              factionalSecondsPrecision;
+	private Integer              toFactionalSecondsPrecision;
 
 	public TeradataIntervalExpr() {
 		
@@ -30,6 +36,45 @@ public class TeradataIntervalExpr extends SQLExprImpl implements TeradataExpr {
 		this.unit = unit;
 	}
 	
+	public TeradataIntervalUnit getType() {
+		return this.type;
+	}
+	
+	public void setType(TeradataIntervalUnit type) {
+		this.type = type;
+	}
+	
+	public TeradataIntervalUnit getToType() {
+		return this.toType;
+	}
+	
+	public void setToType(TeradataIntervalUnit toType) {
+		this.toType = toType;
+	}
+	
+	public Integer getPrecision() {
+        return this.precision;
+    }
+	
+	public void setPrecision(Integer precision) {
+        this.precision = precision;
+    }
+
+    public Integer getFactionalSecondsPrecision() {
+        return this.factionalSecondsPrecision;
+    }
+
+    public void setFactionalSecondsPrecision(Integer factionalSecondsPrecision) {
+        this.factionalSecondsPrecision = factionalSecondsPrecision;
+    }	
+    
+    public Integer getToFactionalSecondsPrecision() {
+        return this.toFactionalSecondsPrecision;
+    }
+
+    public void setToFactionalSecondsPrecision(Integer toFactionalSecondsPrecision) {
+        this.toFactionalSecondsPrecision = toFactionalSecondsPrecision;
+    }
 	
 	@Override
 	public boolean equals(Object obj) {
@@ -44,6 +89,33 @@ public class TeradataIntervalExpr extends SQLExprImpl implements TeradataExpr {
         }
         TeradataIntervalExpr other = (TeradataIntervalExpr) obj;
         if (unit != other.unit) {
+            return false;
+        }
+        if (factionalSecondsPrecision == null) {
+            if (other.factionalSecondsPrecision != null) {
+                return false;
+            }
+        } else if (!factionalSecondsPrecision.equals(other.factionalSecondsPrecision)) {
+            return false;
+        }
+        if (precision == null) {
+            if (other.precision != null) {
+                return false;
+            }
+        } else if (!precision.equals(other.precision)) {
+            return false;
+        }
+        if (toFactionalSecondsPrecision == null) {
+            if (other.toFactionalSecondsPrecision != null) {
+                return false;
+            }
+        } else if (!toFactionalSecondsPrecision.equals(other.toFactionalSecondsPrecision)) {
+            return false;
+        }
+        if (toType != other.toType) {
+            return false;
+        }
+        if (type != other.type) {
             return false;
         }
         if (value == null) {
@@ -61,17 +133,23 @@ public class TeradataIntervalExpr extends SQLExprImpl implements TeradataExpr {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((unit == null)? 0 : unit.hashCode());
-		result = prime * result + ((value == null)? 0 : value.hashCode());
+		result = prime * result + ((factionalSecondsPrecision == null) ? 0 : factionalSecondsPrecision.hashCode());
+        result = prime * result + ((precision == null) ? 0 : precision.hashCode());
+        result = prime * result + ((toFactionalSecondsPrecision == null) ? 0 : toFactionalSecondsPrecision.hashCode());
+        result = prime * result + ((toType == null) ? 0 : toType.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
 		return result;
 	}
 
 	@Override
 	protected void accept0(SQLASTVisitor visitor) {
-		TeradataASTVisitor tdVisitor = (TeradataASTVisitor) visitor;
-		if (tdVisitor.visit(this)) {
-			acceptChild(visitor, this.value);
-		}
-		tdVisitor.endVisit(this);
+		this.accept0((TeradataASTVisitor) visitor);
+	}
+	
+	public void accept0(TeradataASTVisitor visitor) {
+		visitor.visit(this);
+		visitor.endVisit(this);
 	}
 
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
@@ -50,6 +50,8 @@ public class TeradataLexer extends Lexer {
         
         map.put("MOD", Token.MOD);
         
+        map.put("USING", Token.USING);
+        
         DEFAULT_TD_KEYWORDS = new Keywords(map);
     }
     

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataLexer.java
@@ -44,6 +44,7 @@ public class TeradataLexer extends Lexer {
         map.put("MULTISET", Token.MULTISET);
         
         map.put("FORMAT", Token.FORMAT);
+        map.put("EXTRACT", Token.EXTRACT);
         
         map.put("QUALIFY", Token.QUALIFY);
         

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataSelectParser.java
@@ -66,6 +66,8 @@ public class TeradataSelectParser extends SQLSelectParser{
         
         parserQualify(queryBlock);
         
+        parseWhere(queryBlock);
+        
         queryBlock.setOrderBy(this.exprParser.parseOrderBy());
 
         return queryRest(queryBlock);
@@ -77,17 +79,27 @@ public class TeradataSelectParser extends SQLSelectParser{
 		}
 		
 		lexer.nextToken();
+		
+		if (lexer.token() == Token.LPAREN) {
+			accept(Token.LPAREN);
+		}
 		if (lexer.token() == Token.LITERAL_INT) {
 			lexer.nextToken();
 			// possibly =, >=, <=
 			// ignore this for now
 			lexer.nextToken();
 			
+			if (lexer.token() == Token.LPAREN) {
+				accept(Token.LPAREN);
+			}
 			if (lexer.token() == Token.IDENTIFIER) {
 				SQLExpr expr = new SQLIdentifierExpr(lexer.stringVal());
 				lexer.nextToken();
 				if (lexer.token() != Token.COMMA) {
 					expr = this.exprParser.primaryRest(expr);	
+				}
+				if (lexer.token() == Token.RPAREN) {
+					accept(Token.RPAREN);
 				}
 				// TODO: add qualify clause into queryBlock
 				queryBlock.setQualifyClause(expr);
@@ -100,6 +112,9 @@ public class TeradataSelectParser extends SQLSelectParser{
 			if (lexer.token() != Token.COMMA) {
 				expr = this.exprParser.primaryRest(expr);	
 			}
+			if (lexer.token() == Token.RPAREN) {
+				accept(Token.RPAREN);
+			}
 			lexer.nextToken();
 			lexer.nextToken();
 			// TODO: add qualify clause into queryBlock
@@ -107,6 +122,8 @@ public class TeradataSelectParser extends SQLSelectParser{
 		} else {
 			throw new ParserException("not support token:" + lexer.token());
 		}
+		
+		
 	}
 
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/parser/TeradataSelectParser.java
@@ -62,6 +62,8 @@ public class TeradataSelectParser extends SQLSelectParser{
 
         parseGroupBy(queryBlock);
         
+        parseWhere(queryBlock);
+        
         parserQualify(queryBlock);
         
         queryBlock.setOrderBy(this.exprParser.parseOrderBy());

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
@@ -18,6 +18,7 @@ package com.alibaba.druid.sql.dialect.teradata.visitor;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
+import com.alibaba.druid.sql.dialect.teradata.ast.TeradataDateTimeDataType;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
@@ -57,4 +58,8 @@ public interface TeradataASTVisitor extends SQLASTVisitor {
 	boolean visit(TeradataExtractExpr x);
 
 	void endVisit(TeradataExtractExpr x);
+	
+	boolean visit(TeradataDateTimeDataType x);
+	
+	void endVisit(TeradataDateTimeDataType x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitor.java
@@ -20,6 +20,9 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataExtractExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataFormatExpr;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
@@ -42,4 +45,16 @@ public interface TeradataASTVisitor extends SQLASTVisitor {
 	boolean visit(SQLSubqueryTableSource x);
 	
 	void endVisit(SQLSubqueryTableSource x);
+
+	boolean visit(TeradataDateExpr x);
+
+	void endVisit(TeradataDateExpr x);
+
+	boolean visit(TeradataFormatExpr x);
+
+	void endVisit(TeradataFormatExpr x);
+
+	boolean visit(TeradataExtractExpr x);
+
+	void endVisit(TeradataExtractExpr x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitorAdapter.java
@@ -17,6 +17,9 @@ package com.alibaba.druid.sql.dialect.teradata.visitor;
 
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataExtractExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataFormatExpr;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
 import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
 
@@ -48,6 +51,42 @@ public class TeradataASTVisitorAdapter extends SQLASTVisitorAdapter implements T
 
 	@Override
 	public void endVisit(TeradataIntervalExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataDateExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataDateExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataFormatExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataFormatExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataExtractExpr x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataASTVisitorAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.druid.sql.dialect.teradata.visitor;
 
+import com.alibaba.druid.sql.dialect.teradata.ast.TeradataDateTimeDataType;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
@@ -87,6 +88,18 @@ public class TeradataASTVisitorAdapter extends SQLASTVisitorAdapter implements T
 
 	@Override
 	public void endVisit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataDateTimeDataType x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataDateTimeDataType x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataOutputVisitor.java
@@ -25,6 +25,9 @@ import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataExtractExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataFormatExpr;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
 import com.alibaba.druid.sql.dialect.teradata.ast.stmt.TeradataSelectQueryBlock;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
@@ -202,5 +205,49 @@ public class TeradataOutputVisitor extends SQLASTOutputVisitor implements Terada
             return false;
 		}
 		return super.visit(x);
+	}
+
+	@Override
+	public boolean visit(TeradataDateExpr x) {
+        print0(ucase ? "DATE '" : "date '");
+        print0(x.getLiteral());
+        print('\'');
+        return false;
+	}
+
+	@Override
+	public void endVisit(TeradataDateExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataFormatExpr x) {
+		print0(ucase ? "FORMAT '" : "format '");
+        print0(x.getLiteral());
+        print('\'');
+        return false;
+	}
+
+	@Override
+	public void endVisit(TeradataFormatExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataExtractExpr x) {
+		print0(ucase ? "EXTRACT(" : "extract(");
+        print0(x.getUnit().name());
+        print0(ucase ? " FROM " : " from ");
+        x.getFrom().accept(this);
+        print(')');
+        return false;
+	}
+
+	@Override
+	public void endVisit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataOutputVisitor.java
@@ -20,9 +20,12 @@ import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.SQLOrderBy;
 import com.alibaba.druid.sql.ast.SQLSetQuantifier;
 import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import com.alibaba.druid.sql.ast.expr.SQLLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.teradata.ast.TeradataDateTimeDataType;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
@@ -167,10 +170,38 @@ public class TeradataOutputVisitor extends SQLASTOutputVisitor implements Terada
 
 	@Override
 	public boolean visit(TeradataIntervalExpr x) {
-		print0(ucase ? "INTERVAL " : "interval ");
-		x.getValue().accept(this);
-        print(' ');
-        print0(ucase ? x.getUnit().name() : x.getUnit().name_lcase);
+		if (x.getValue() instanceof SQLLiteralExpr) {
+            print0(ucase ? "INTERVAL " : "interval ");
+            x.getValue().accept(this);
+            print(' ');
+        } else {
+            print('(');
+            x.getValue().accept(this);
+            print0(") ");
+        }
+
+        print0(x.getType().name());
+
+        if (x.getPrecision() != null) {
+            print('(');
+            print(x.getPrecision().intValue());
+            if (x.getFactionalSecondsPrecision() != null) {
+                print0(", ");
+                print(x.getFactionalSecondsPrecision().intValue());
+            }
+            print(')');
+        }
+
+        if (x.getToType() != null) {
+            print0(ucase ? " TO " : " to ");
+            print0(x.getToType().name());
+            if (x.getToFactionalSecondsPrecision() != null) {
+                print('(');
+                print(x.getToFactionalSecondsPrecision().intValue());
+                print(')');
+            }
+        }
+
         return false;
 	}
 
@@ -203,13 +234,39 @@ public class TeradataOutputVisitor extends SQLASTOutputVisitor implements Terada
             }
             print(')');
             return false;
+		} else if ("SUBSTRING".equalsIgnoreCase(x.getMethodName())) {
+			SQLExpr origin_string = (SQLExpr) x.getAttribute("ORIGIN_STRING");
+			
+			print0(x.getMethodName());
+			print('(');
+
+			if (origin_string != null) {
+				origin_string.accept(this);
+			}
+			print0(ucase ? " FROM " : " from ");
+			if(x.getAttribute("FROM_INDEX") instanceof SQLIntegerExpr) {
+				int from_index = ((SQLIntegerExpr) x.getAttribute("FROM_INDEX")).getNumber().intValue();
+				print(from_index);
+			} else {
+				print(x.getAttribute("FROM_INDEX").toString());
+			}
+			
+			if (x.getAttribute("FOR_INDEX") != null) {
+				print0(ucase ? " FOR " : " for ");
+				int for_index = ((SQLIntegerExpr) x.getAttribute("FOR_INDEX")).getNumber().intValue();
+				print(for_index);
+			}
+			
+			print(')');
+			return false;
 		}
 		return super.visit(x);
 	}
 
 	@Override
-	public boolean visit(TeradataDateExpr x) {
-        print0(ucase ? "DATE '" : "date '");
+	public boolean visit(TeradataDateExpr x) {	
+        print0(ucase ? x.getType().toString().toUpperCase() + " '" 
+        		: x.getType().toString().toLowerCase() + " '");
         print0(x.getLiteral());
         print('\'');
         return false;
@@ -248,6 +305,28 @@ public class TeradataOutputVisitor extends SQLASTOutputVisitor implements Terada
 	@Override
 	public void endVisit(TeradataExtractExpr x) {
 		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataDateTimeDataType x) {
+		print0(x.getName()); 
+		
+		if (x.getArguments().size() > 0) {
+			print('(');
+			x.getArguments().get(0).accept(this);
+			print(')');
+		}
+		
+		if (x.isWithTimeZone()) {
+			print0(ucase ? " WITH TIME ZONE" : " with time zone");
+		}
+		
+		return false;
+	}
+
+	@Override
+	public void endVisit(TeradataDateTimeDataType x) {
 		
 	}
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
@@ -27,6 +27,7 @@ import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
 import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
+import com.alibaba.druid.sql.dialect.teradata.ast.TeradataDateTimeDataType;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
@@ -177,6 +178,18 @@ public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements Tera
 
 	@Override
 	public void endVisit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataDateTimeDataType x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataDateTimeDataType x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/teradata/visitor/TeradataSchemaStatVisitor.java
@@ -18,6 +18,7 @@ package com.alibaba.druid.sql.dialect.teradata.visitor;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
@@ -28,6 +29,9 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalytic;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataAnalyticWindowing;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataDateExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataExtractExpr;
+import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataFormatExpr;
 import com.alibaba.druid.sql.dialect.teradata.ast.expr.TeradataIntervalExpr;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.stat.TableStat.Column;
@@ -67,6 +71,14 @@ public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements Tera
 	@Override
 	public void endVisit(TeradataIntervalExpr x) {
 
+	}
+	
+	public boolean visit(SQLMethodInvokeExpr x) {
+		if ("trim".equalsIgnoreCase(x.getMethodName())) {
+			SQLExpr trim_character = (SQLExpr) x.getAttribute("trim_character");
+			accept(trim_character);
+		}
+		return super.visit(x);
 	}
 	
 	@Override
@@ -131,6 +143,42 @@ public class TeradataSchemaStatVisitor extends SchemaStatVisitor implements Tera
 	
 	public Map<String, SQLObject> getAliasQueryMap() {
 		return aliasQueryMap;
+	}
+
+	@Override
+	public boolean visit(TeradataDateExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataDateExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataFormatExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataFormatExpr x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+	@Override
+	public void endVisit(TeradataExtractExpr x) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }


### PR DESCRIPTION
This PR mainly focuses on new features added to Teradata parser:

1. Add support for datetime expression in TD, including `DATE`, `TIME`, `TIMESTAMP`;
1. Add support for functions like `extract()`, `format ...`, `translate...using...`, `substring...from...for`;
1. Enhancement for `interval` clauses;
1. Other minor changes such as chars suffix with `XB` or `XC`;
