### PR TITLE
Fix parsing "double precision" of wallfilter in PostgreSQL

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -1508,6 +1508,11 @@ public class SQLExprParser extends SQLParser {
                 ) {
             typeName += (' ' + lexer.stringVal());
             lexer.nextToken();
+        } else if ("double".equalsIgnoreCase(typeName)
+                && JdbcConstants.POSTGRESQL.equals(getDbType()) //
+                ) {
+            typeName += (' ' + lexer.stringVal());
+            lexer.nextToken();
         }
 
         if (isCharType(typeName)) {

--- a/src/test/java/com/alibaba/druid/test/wall/PGWallTest.java
+++ b/src/test/java/com/alibaba/druid/test/wall/PGWallTest.java
@@ -1,0 +1,21 @@
+package com.alibaba.druid.test.wall;
+
+import com.alibaba.druid.wall.WallCheckResult;
+import com.alibaba.druid.wall.WallConfig;
+import com.alibaba.druid.wall.WallProvider;
+import com.alibaba.druid.wall.spi.PGWallProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by fuzhenn on 2016/5/10.
+ */
+public class PGWallTest {
+    @Test
+    public void testDoublePrecision() throws Exception {
+        WallProvider provider = new PGWallProvider(new WallConfig(PGWallProvider.DEFAULT_CONFIG_DIR));
+        String sql = "CREATE TABLE test_pg_wall (col_int INT NOT NULL, col_double_x DOUBLE PRECISION NOT NULL DEFAULT 0, col_varchar VARCHAR(200) NULL)";
+        WallCheckResult result = provider.check(sql);
+        Assert.assertTrue(result.getViolations().size() == 0);
+    }
+}


### PR DESCRIPTION
在PostgreSQL数据库中, WallFilter解析双精度数据类型(Double Precision)时只读取Double而忽略了precision, 会错误的报解析错误.

尝试着解决了一下, 并增加了单元测试, 请指正.