### PR TITLE
optimizer fail-fast

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -247,6 +248,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     private boolean                                    asyncCloseConnectionEnable                = false;
     protected int                                      maxCreateTaskCount                        = 3;
     protected boolean                                  failFast                                  = false;
+    protected AtomicBoolean                            failContinuous                            = new AtomicBoolean(false);
     protected ScheduledExecutorService                 destroyScheduler;
     protected ScheduledExecutorService                 createScheduler;
 
@@ -1515,6 +1517,10 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         } finally {
             lock.unlock();
         }
+    }
+    
+    protected void setFailContinuous(boolean fail) {
+        failContinuous.set(fail);
     }
 
     public void initPhysicalConnection(Connection conn) throws SQLException {

--- a/src/test/java/com/alibaba/druid/bvt/pool/profile/FailFastTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/profile/FailFastTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 
+import com.alibaba.druid.pool.DataSourceNotAvailableException;
 import com.alibaba.druid.pool.DruidDataSource;
 
 import junit.framework.TestCase;
@@ -70,8 +71,9 @@ public class FailFastTest extends TestCase {
         connectStartLatch.await();
         
         latch.countDown();
-        
         connectEndLatch.await(3, TimeUnit.SECONDS);
+        SQLException ex = errorHolder.get();
+        Assert.assertTrue(ex instanceof DataSourceNotAvailableException);
     }
 
 }


### PR DESCRIPTION
优化下druid fail-fast的判断机制. 
优化前:
1.  createPhysicalConnection只要有任何一次链接创建失败的异常,就会进入fail-fast模式. 正常的一些网络抖动会频繁触发fail-fast,影响略大

优化后:
1. 结合connectionErrorRetryAttempts和timeBetweenConnectErrorMillis的失败控制，超过一定失败次数后才进入fail-fast模式，规避掉一些偶发性的网络抖动引起大面积失败. 

补充了一下测试用例