### PR TITLE
bug修复及设计增强：相应ExportParameterVisitor实现类扩展相应的ParameterizedOutputVisitor…

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2ExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2ExportParameterVisitor.java
@@ -28,58 +28,94 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 
-public class DB2ExportParameterVisitor extends DB2ASTVisitorAdapter implements ExportParameterVisitor {
+public class DB2ExportParameterVisitor extends DB2ParameterizedOutputVisitor implements ExportParameterVisitor {
 
-    private final List<Object> parameters;
 
-    public DB2ExportParameterVisitor(){
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public DB2ExportParameterVisitor(final List<Object> parameters,final Appendable appender,final boolean wantParameterizedOutput){
+        super(appender);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
+
+    public DB2ExportParameterVisitor() {
         this(new ArrayList<Object>());
     }
 
-    public DB2ExportParameterVisitor(List<Object> parameters){
-        this.parameters = parameters;
+    public DB2ExportParameterVisitor(final List<Object> parameters){
+        this(parameters,new StringBuilder(),false);
     }
 
+    public DB2ExportParameterVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
+    }
+
+    
     public List<Object> getParameters() {
         return parameters;
     }
 
     @Override
     public boolean visit(SQLSelectItem x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLOrderBy x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLSelectGroupByClause x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLMethodInvokeExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getParameters());
-
         return true;
     }
 
     @Override
     public boolean visit(SQLInListExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
+        
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getTargetList());
-
         return true;
     }
 
     @Override
     public boolean visit(SQLBetweenExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
+
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlExportParameterVisitor.java
@@ -29,51 +29,83 @@ import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock.L
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 
-public class MySqlExportParameterVisitor extends MySqlASTVisitorAdapter implements ExportParameterVisitor {
+public class MySqlExportParameterVisitor extends MySqlParameterizedOutputVisitor implements ExportParameterVisitor {
 
-    private final List<Object> parameters;
-    
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public MySqlExportParameterVisitor(final List<Object> parameters,final Appendable appender,final boolean wantParameterizedOutput){
+        super(appender);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
+
     public MySqlExportParameterVisitor() {
         this(new ArrayList<Object>());
     }
 
-    public MySqlExportParameterVisitor(List<Object> parameters){
-        this.parameters = parameters;
+    public MySqlExportParameterVisitor(final List<Object> parameters){
+        this(parameters,new StringBuilder(),false);
+    }
+
+    public MySqlExportParameterVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
     }
 
     public List<Object> getParameters() {
         return parameters;
     }
+    
 
     @Override
-    public boolean visit(SQLSelectItem x) {
+    public boolean visit(final SQLSelectItem x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(Limit x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLOrderBy x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLSelectGroupByClause x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLMethodInvokeExpr x) {
+        if(requireParameterizedOutput){
+           return super.visit(x);
+        }
+        
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getParameters());
-
         return true;
     }
 
     @Override
     public boolean visit(SQLInListExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+         }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getTargetList());
 
         return true;
@@ -81,13 +113,18 @@ public class MySqlExportParameterVisitor extends MySqlASTVisitorAdapter implemen
 
     @Override
     public boolean visit(SQLBetweenExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+         }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+         }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
-
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleExportParameterVisitor.java
@@ -28,16 +28,29 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 
-public class OracleExportParameterVisitor extends OracleASTVisitorAdapter implements ExportParameterVisitor {
+public class OracleExportParameterVisitor extends OracleParameterizedOutputVisitor implements ExportParameterVisitor {
 
-    private final List<Object> parameters;
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public OracleExportParameterVisitor(List<Object> parameters,Appendable appender,final boolean wantParameterizedOutput){
+        super(appender,false);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
 
     public OracleExportParameterVisitor() {
         this(new ArrayList<Object>());
     }
 
     public OracleExportParameterVisitor(List<Object> parameters){
-        this.parameters = parameters;
+        this(parameters,new StringBuilder(),true);
+    }
+
+    public OracleExportParameterVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
     }
 
     public List<Object> getParameters() {
@@ -46,40 +59,60 @@ public class OracleExportParameterVisitor extends OracleASTVisitorAdapter implem
 
     @Override
     public boolean visit(SQLSelectItem x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLOrderBy x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLSelectGroupByClause x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLMethodInvokeExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
+        
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getParameters());
-
         return true;
     }
 
     @Override
     public boolean visit(SQLInListExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getTargetList());
-
         return true;
     }
 
     @Override
     public boolean visit(SQLBetweenExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleExportParameterVisitor.java
@@ -46,7 +46,7 @@ public class OracleExportParameterVisitor extends OracleParameterizedOutputVisit
     }
 
     public OracleExportParameterVisitor(List<Object> parameters){
-        this(parameters,new StringBuilder(),true);
+        this(parameters,new StringBuilder(),false);
     }
 
     public OracleExportParameterVisitor(final Appendable appender) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
@@ -28,39 +28,64 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 
-public class PGExportParameterVisitor extends PGASTVisitorAdapter implements ExportParameterVisitor {
+public class PGExportParameterVisitor extends PGParameterizedOutputVisitor implements ExportParameterVisitor {
 
-    private final List<Object> parameters;
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public PGExportParameterVisitor(final List<Object> parameters,final Appendable appender,final boolean wantParameterizedOutput){
+        super(appender);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
 
     public PGExportParameterVisitor() {
         this(new ArrayList<Object>());
     }
 
-    public PGExportParameterVisitor(List<Object> parameters){
-        this.parameters = parameters;
+    public PGExportParameterVisitor(final List<Object> parameters){
+        this(parameters,new StringBuilder(),false);
     }
 
+    public PGExportParameterVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
+    }
+    
     public List<Object> getParameters() {
         return parameters;
     }
 
     @Override
     public boolean visit(SQLSelectItem x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLOrderBy x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLSelectGroupByClause x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLMethodInvokeExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getParameters());
 
         return true;
@@ -68,6 +93,9 @@ public class PGExportParameterVisitor extends PGASTVisitorAdapter implements Exp
 
     @Override
     public boolean visit(SQLInListExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getTargetList());
 
         return true;
@@ -75,11 +103,17 @@ public class PGExportParameterVisitor extends PGASTVisitorAdapter implements Exp
 
     @Override
     public boolean visit(SQLBetweenExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
@@ -46,7 +46,7 @@ public class PGExportParameterVisitor extends PGParameterizedOutputVisitor imple
     }
 
     public PGExportParameterVisitor(final List<Object> parameters){
-        this(parameters,new StringBuilder(),true);
+        this(parameters,new StringBuilder(),false);
     }
 
     public PGExportParameterVisitor(final Appendable appender) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGExportParameterVisitor.java
@@ -46,7 +46,7 @@ public class PGExportParameterVisitor extends PGParameterizedOutputVisitor imple
     }
 
     public PGExportParameterVisitor(final List<Object> parameters){
-        this(parameters,new StringBuilder(),false);
+        this(parameters,new StringBuilder(),true);
     }
 
     public PGExportParameterVisitor(final Appendable appender) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
@@ -28,39 +28,65 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 
-public class MSSQLServerExportParameterVisitor extends SQLServerASTVisitorAdapter implements ExportParameterVisitor {
+public class MSSQLServerExportParameterVisitor extends SQLServerParameterizedOutputVisitor implements ExportParameterVisitor {
 
-    private final List<Object> parameters;
-    
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public MSSQLServerExportParameterVisitor(final List<Object> parameters,final Appendable appender,final boolean wantParameterizedOutput){
+        super(appender);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
+
     public MSSQLServerExportParameterVisitor() {
         this(new ArrayList<Object>());
     }
 
-    public MSSQLServerExportParameterVisitor(List<Object> parameters){
-        this.parameters = parameters;
+    public MSSQLServerExportParameterVisitor(final List<Object> parameters){
+        this(parameters,new StringBuilder(),false);
     }
 
+    public MSSQLServerExportParameterVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
+    }
+    
     public List<Object> getParameters() {
         return parameters;
     }
 
     @Override
     public boolean visit(SQLSelectItem x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLOrderBy x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLSelectGroupByClause x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         return false;
     }
 
     @Override
     public boolean visit(SQLMethodInvokeExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
+        
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getParameters());
 
         return true;
@@ -68,6 +94,9 @@ public class MSSQLServerExportParameterVisitor extends SQLServerASTVisitorAdapte
 
     @Override
     public boolean visit(SQLInListExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParamterAndAccept(this.parameters, x.getTargetList());
 
         return true;
@@ -75,11 +104,17 @@ public class MSSQLServerExportParameterVisitor extends SQLServerASTVisitorAdapte
 
     @Override
     public boolean visit(SQLBetweenExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
+        if(requireParameterizedOutput){
+            return super.visit(x);
+        }
         ExportParameterVisitorUtils.exportParameter(this.parameters, x);
         return true;
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
@@ -46,7 +46,7 @@ public class MSSQLServerExportParameterVisitor extends SQLServerParameterizedOut
     }
 
     public MSSQLServerExportParameterVisitor(final List<Object> parameters){
-        this(parameters,new StringBuilder(),true);
+        this(parameters,new StringBuilder(),false);
     }
 
     public MSSQLServerExportParameterVisitor(final Appendable appender) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/MSSQLServerExportParameterVisitor.java
@@ -46,7 +46,7 @@ public class MSSQLServerExportParameterVisitor extends SQLServerParameterizedOut
     }
 
     public MSSQLServerExportParameterVisitor(final List<Object> parameters){
-        this(parameters,new StringBuilder(),false);
+        this(parameters,new StringBuilder(),true);
     }
 
     public MSSQLServerExportParameterVisitor(final Appendable appender) {

--- a/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterVisitorUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterVisitorUtils.java
@@ -25,8 +25,49 @@ import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
 import com.alibaba.druid.sql.ast.expr.SQLLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLNumericLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
+import com.alibaba.druid.sql.dialect.db2.visitor.DB2ExportParameterVisitor;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlExportParameterVisitor;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleExportParameterVisitor;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGExportParameterVisitor;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.MSSQLServerExportParameterVisitor;
+import com.alibaba.druid.util.JdbcUtils;
 
-public class ExportParameterVisitorUtils {
+public final class ExportParameterVisitorUtils {
+    
+    //private for util class not need new instance
+    private ExportParameterVisitorUtils() {
+        super();
+    }
+
+    public static ExportParameterVisitor createExportParameterVisitor(final  Appendable out ,final String dbType) {
+        
+        if (JdbcUtils.MYSQL.equals(dbType)) {
+            return new MySqlExportParameterVisitor(out);
+        }
+        if (JdbcUtils.ORACLE.equals(dbType) || JdbcUtils.ALI_ORACLE.equals(dbType)) {
+            return new OracleExportParameterVisitor(out);
+        }
+        if (JdbcUtils.DB2.equals(dbType)) {
+            return new DB2ExportParameterVisitor(out);
+        }
+        
+        if (JdbcUtils.MARIADB.equals(dbType)) {
+            return new MySqlExportParameterVisitor(out);
+        }
+        
+        if (JdbcUtils.H2.equals(dbType)) {
+            return new MySqlExportParameterVisitor(out);
+        }
+        if (JdbcUtils.POSTGRESQL.equals(dbType)) {
+            return new PGExportParameterVisitor(out);
+        }
+        if (JdbcUtils.SQL_SERVER.equals(dbType) || JdbcUtils.JTDS.equals(dbType)) {
+            return new MSSQLServerExportParameterVisitor(out);
+        }
+       return new ExportParameterizedOutputVisitor(out);
+    }
+
+    
 
     public static boolean exportParamterAndAccept(final List<Object> parameters, List<SQLExpr> list) {
         for (int i = 0, size = list.size(); i < size; ++i) {

--- a/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterizedOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterizedOutputVisitor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.visitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExportParameterizedOutputVisitor extends ParameterizedOutputVisitor implements ExportParameterVisitor {
+
+    /**
+     * true= if require parameterized sql output
+     */
+    private final boolean requireParameterizedOutput;
+
+    public ExportParameterizedOutputVisitor(final List<Object> parameters,final Appendable appender,final boolean wantParameterizedOutput){
+        super(appender);
+        this.parameters = parameters;
+        this.requireParameterizedOutput = wantParameterizedOutput;
+    }
+
+    public ExportParameterizedOutputVisitor() {
+        this(new ArrayList<Object>());
+    }
+
+    public ExportParameterizedOutputVisitor(final List<Object> parameters){
+        this(parameters,new StringBuilder(),false);
+    }
+
+    public ExportParameterizedOutputVisitor(final Appendable appender) {
+        this(new ArrayList<Object>(),appender,true);
+    }
+
+    
+    public List<Object> getParameters() {
+        return parameters;
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
@@ -123,6 +123,9 @@ public class ParameterizedOutputVisitorUtils {
 
         if (changed) {
             v.incrementReplaceCunt();
+            if( v instanceof ExportParameterVisitor){
+                ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+            }
         }
 
         return false;
@@ -135,6 +138,10 @@ public class ParameterizedOutputVisitorUtils {
 
         v.print('?');
         v.incrementReplaceCunt();
+        
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 
@@ -145,15 +152,22 @@ public class ParameterizedOutputVisitorUtils {
 
         v.print('?');
         v.incrementReplaceCunt();
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 
     public static boolean visit(ParameterizedVisitor v, SQLCharExpr x) {
         v.print('?');
         v.incrementReplaceCunt();
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 
+   
     public static boolean checkParameterize(SQLObject x) {
         if (Boolean.TRUE.equals(x.getAttribute(ParameterizedOutputVisitorUtils.ATTR_PARAMS_SKIP))) {
             return false;
@@ -176,6 +190,10 @@ public class ParameterizedOutputVisitorUtils {
     public static boolean visit(ParameterizedVisitor v, SQLNCharExpr x) {
         v.print('?');
         v.incrementReplaceCunt();
+        
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 
@@ -192,18 +210,30 @@ public class ParameterizedOutputVisitorUtils {
 
         v.print('?');
         v.incrementReplaceCunt();
+        
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 
     public static boolean visit(ParameterizedVisitor v, SQLVariantRefExpr x) {
         v.print('?');
         v.incrementReplaceCunt();
+        
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
     
     public static boolean visit(ParameterizedVisitor v, SQLHexExpr x) {
         v.print('?');
         v.incrementReplaceCunt();
+        
+        if( v instanceof ExportParameterVisitor){
+            ExportParameterVisitorUtils.exportParameter(((ExportParameterVisitor)v).getParameters(), x);
+        }
         return false;
     }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -845,7 +845,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Printab
     public boolean visit(SQLVariantRefExpr x) {
         int index = x.getIndex();
 
-        if (parameters == null || index >= parameters.size()) {
+        if (index < 0 || parameters == null || index >= parameters.size()) {
             print0(x.getName());
             return false;
         }

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -100,7 +100,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Printab
 
     protected boolean          groupItemSingleLine    = false;
 
-    private List<Object>       parameters;
+    protected List<Object>       parameters;
 
     protected String           dbType;
 

--- a/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitorTestCase.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitorTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.parser;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
+import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import com.alibaba.druid.util.JdbcUtils;
+
+public class ExportAndParameterizedVisitorTestCase extends TestCase {
+
+    public void testParameterizedVisitor() {
+        // final String sql =
+        // "insert  into tab01(a,b,c) values('a1','bXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1',5)";
+        Object[][] sqlAndExpectedCases = { { "insert  into tab01(a,b,c) values('a1','b1',5)", 3, "a1" },
+                { "select * from tab01 where a=1 and b='b1'", 2, 1 }, 
+                { "update tab01 set d='d1' where a=1 and b='b1'", 3, "d1" },
+                { "delete from tab01 where a=1 and b='b1'", 2, 1.0 } };
+
+        String[] dbTypes = { "mysql", "oracle", "db2" ,JdbcConstants.POSTGRESQL,JdbcUtils.JTDS,"not-found"};
+    // String[]  dbTypes = { JdbcUtils.JTDS};
+        for (String dbType : dbTypes) {
+
+            System.out.println("dbType:"+dbType);
+            for (Object[] arr : sqlAndExpectedCases) {
+
+                final String sql = (String) arr[0];
+                StringBuilder out = new StringBuilder();
+
+                final SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                final ParameterizedVisitor pVisitor = (ParameterizedVisitor) ExportParameterVisitorUtils.createExportParameterVisitor(out, dbType);
+                final SQLStatement parseStatement = parser.parseStatement();
+                parseStatement.accept(pVisitor);
+                // final ExportParameterVisitor vistor2 = new MySqlExportParameterVisitor();
+                // parseStatement.accept(vistor2);
+                final ExportParameterVisitor vistor2 = (ExportParameterVisitor) pVisitor;
+                System.out.println("before:" + sql);
+                System.out.println("after:" + out);
+                System.out.println("size:" + vistor2.getParameters());
+                final int expectedSize = (Integer) arr[1];
+                Assert.assertEquals(expectedSize, vistor2.getParameters().size());
+            }
+        }
+    }
+}


### PR DESCRIPTION
bug修复及设计增强：相应ExportParameterVisitor实现类扩展相应的ParameterizedOutputVisitor实现类，以修正ExportParameterVisitor现有实现的功能bug并减少重复代码

相应的测试代码在：
https://github.com/qxo/druid/blob/ExportParameterVisitorRefactoring/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitorTestCase.java

之前： 
ExportParameterVisitor实现对只针select sql有效
且如想同时获取PreparedStatement  sql和参数值得运行两次
另外如不采用继续机制，所有大部在逻辑代码得写两次

重复的事还是让程序去重做吧，程序员该去做更有价值的事:)

 welcome to  review my commit :)
