### PR TITLE
 修改关于 NULL 的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/statement/NullConstraint.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/NullConstraint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.ast.statement;
+
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class NullConstraint extends SQLConstraintImpl implements SQLColumnConstraint {
+
+    public NullConstraint(){
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -65,6 +65,7 @@ import com.alibaba.druid.sql.ast.expr.SQLUnaryExpr;
 import com.alibaba.druid.sql.ast.expr.SQLUnaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
 import com.alibaba.druid.sql.ast.statement.NotNullConstraint;
+import com.alibaba.druid.sql.ast.statement.NullConstraint;
 import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.ast.statement.SQLCharacterDataType;
 import com.alibaba.druid.sql.ast.statement.SQLCheck;
@@ -1688,7 +1689,7 @@ public class SQLExprParser extends SQLParser {
 
         if (lexer.token() == Token.NULL) {
             lexer.nextToken();
-            column.setDefaultExpr(new SQLNullExpr());
+            column.getConstraints().add(new NullConstraint());
             return parseColumnRest(column);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -1192,6 +1192,16 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Printab
         return false;
     }
 
+    public boolean visit(NullConstraint x) {
+    	if (x.getName() != null) {
+    		print0(ucase ? "CONSTRAINT " : "constraint ");
+    		x.getName().accept(this);
+    		print(' ');
+    	}
+    	print0(ucase ? "NULL" : "null");
+    	return false;
+    }
+
     @Override
     public boolean visit(SQLUnionQuery x) {
         x.getLeft().accept(this);

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
@@ -716,4 +716,9 @@ public interface SQLASTVisitor {
     boolean visit(SQLErrorLoggingClause x);
 
     void endVisit(SQLErrorLoggingClause x);
+
+    boolean visit(NullConstraint x);
+
+    void endVisit(NullConstraint x);
+
 }

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitorAdapter.java
@@ -1565,4 +1565,13 @@ public class SQLASTVisitorAdapter implements SQLASTVisitor {
     public void endVisit(SQLErrorLoggingClause x) {
 
     }
+
+    @Override
+    public boolean visit(NullConstraint x) {
+	return true;
+    }
+
+    @Override
+    public void endVisit(NullConstraint x) {
+    }
 }


### PR DESCRIPTION
Oracle 中  原始sql (例句) ：alter table aaa modify bbb null;
转换后成为：  ALTER TABLE  aaa  MODIFY ( bbb DEFAULT NULL );
原始Sql的语义改变了，改变了bbb字段的default值