### PR TITLE
lose message

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1496,6 +1496,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
             throw ex;
         } catch (Error ex) {
             createErrorCount.incrementAndGet();
+            setCreateError(ex);
             throw ex;
         } finally {
             long nano = System.nanoTime() - connectStartNanos;


### PR DESCRIPTION
druid报DataSourceNotAvailableException，但是并没有打印出message。如下所示：
Caused by: com.alibaba.druid.pool.DataSourceNotAvailableException: null
	at com.alibaba.druid.pool.DruidDataSource.pollLast(DruidDataSource.java:1553) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.pool.DruidDataSource.getConnectionInternal(DruidDataSource.java:1144) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.pool.DruidDataSource.getConnectionDirect(DruidDataSource.java:1017) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.filter.FilterChainImpl.dataSource_connect(FilterChainImpl.java:4544) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.filter.FilterAdapter.dataSource_getConnection(FilterAdapter.java:2723) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.filter.FilterChainImpl.dataSource_connect(FilterChainImpl.java:4540) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.pool.DruidDataSource.getConnection(DruidDataSource.java:995) ~[druid-1.0.21.jar:1.0.21]
	at com.alibaba.druid.pool.DruidDataSource.getConnection(DruidDataSource.java:987) ~[druid-1.0.21.jar:1.0.21]

跟踪代码之后发现druid进入failFast状态，说明createError没有设置。

`               

               if (failFast && failContinuous.get()) {
                    throw new DataSourceNotAvailableException(createError);
                }

`

搜索设置createError的地方发现是DruidAbstractDataSource.setCreateError, 进一步搜索调用setCreateError的地方发现DruidAbstractDataSource.createPhysicalConnection里面的catch(Error ex)分支并没有设置createError导致消息丢失，如下图代码

` 

        try {
            conn = createPhysicalConnection(url, physicalConnectProperties);
            connectedNanos = System.nanoTime();

            if (conn == null) {
                throw new SQLException("connect error, url " + url + ", driverClass " + this.driverClass);
            }

            initPhysicalConnection(conn);
            initedNanos = System.nanoTime();

            validateConnection(conn);
            validatedNanos = System.nanoTime();
            
            setCreateError(null);
        } catch (SQLException ex) {
            setCreateError(ex);
            throw ex;
        } catch (RuntimeException ex) {
            setCreateError(ex);
            throw ex;
        } catch (Error ex) {
            createErrorCount.incrementAndGet();
            throw ex;
        } finally {
            long nano = System.nanoTime() - connectStartNanos;
            createTimespan += nano;
        }
`