### PR TITLE
fix com.alibaba.druid.sql.parser.CommentTest.test2() failed

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -1090,7 +1090,7 @@ public class Lexer {
         
         scanChar();
         scanChar();
-        mark = pos - 1;
+        mark = pos;
         bufPos = 0;
 
         for (;;) {


### PR DESCRIPTION
In the `com.alibaba.druid.sql.parser.Lexer.scanSingleLineComment()` method, `mark` should be assigned as `pos` instead of `pos - 1` to avoid including the second `'/'` character in `stringVal` of comment, which leads to test `com.alibaba.druid.sql.parser.CommentTest.test2()` failed.