### PR TITLE
C3P0配置项 'checkoutTimeout' 单位为毫秒，无需转换

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSourceC3P0Adapter.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSourceC3P0Adapter.java
@@ -145,11 +145,11 @@ public class DruidDataSourceC3P0Adapter implements DataSource, DruidDataSourceC3
     }
 
     public int getCheckoutTimeout() {
-        return (int) dataSource.getMaxWait() / 1000;
+        return (int) dataSource.getMaxWait();
     }
 
     public void setCheckoutTimeout(int checkoutTimeout) {
-        dataSource.setMaxWait(checkoutTimeout * 1000);
+        dataSource.setMaxWait(checkoutTimeout);
     }
 
     public boolean isAutoCommitOnClose() {


### PR DESCRIPTION
http://www.mchange.com/projects/c3p0/index.html#checkoutTimeout 这个配置项在C3P0中单位已经是毫秒，无需在转换成maxWait时做转换。