### PR TITLE
明确了keyFactory的provider和cipher的padding算法，解决密钥解密冲突

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -94,7 +94,7 @@ public class ConfigTools {
 			X509EncodedKeySpec x509KeySpec = new X509EncodedKeySpec(
 					publicKeyBytes);
 
-			KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+			KeyFactory keyFactory = KeyFactory.getInstance("RSA", "SunRsaSign");
 			return keyFactory.generatePublic(x509KeySpec);
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Failed to get public key", e);
@@ -129,7 +129,7 @@ public class ConfigTools {
 
 	public static String decrypt(PublicKey publicKey, String cipherText)
 			throws Exception {
-		Cipher cipher = Cipher.getInstance("RSA");
+		Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
 		try {
 			cipher.init(Cipher.DECRYPT_MODE, publicKey);
 		} catch (InvalidKeyException e) {


### PR DESCRIPTION
修复了当系统中存在多个密钥处理逻辑和算法时，如果不明确填写provider和cipher机制，造成与已有的程序冲突（实际测试出现第一个jndi的datasource正确通过解密，第二个datasource解密错误）