### PR TITLE
fixed for oracle xmltype extract  issue #1481 

### DIFF
--- a/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest60.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest60.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2101 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.oracle.select;
+
+import java.util.List;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.OracleTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleSchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+
+public class OracleSelectTest60 extends OracleTest {
+
+    public void test_0() throws Exception {
+        String sql = "select extract(xmlfld1,'//base').getClobVal() as fld1 from test_table ";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statemen = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        statemen.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("relationships : " + visitor.getRelationships());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("test_table")));
+        Assert.assertEquals(1, visitor.getColumns().size());
+
+    }
+}


### PR DESCRIPTION
support for: extract("xmltype_fld1",'//base').getClobVal()
fixed for  issue #1481 