### PR TITLE
解决select无法使用PSCache的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
+++ b/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
@@ -78,15 +78,15 @@ public class PreparedStatementPool {
         if (stmt == null) {
             return;
         }
+        
+        PreparedStatementHolder oldStmtHolder = map.put(stmtHolder.key, stmtHolder);
 
         if (dataSource.isOracle() && dataSource.isUseOracleImplicitCache()) {
-            OracleUtils.enterImplicitCache(stmt);
             stmtHolder.setEnterOracleImplicitCache(true);
+            OracleUtils.enterImplicitCache(stmt);
         } else {
             stmtHolder.setEnterOracleImplicitCache(false);
         }
-
-        PreparedStatementHolder oldStmtHolder = map.put(stmtHolder.key, stmtHolder);
 
         if (oldStmtHolder == stmtHolder) {
             return;


### PR DESCRIPTION
使用Spring的JDBCTemplate执行查询操作后，statement会被close，这种情况原有代码在执行OracleUtils.enterImplicitCache(stmt)时就会抛出异常，而后的put逻辑无法执行，导致select statement无法使用LRUCache缓存PreparedStatementHolder