### PR TITLE
删除了sql语句输出时带的换行符，以及放出日志sql格式化语句的两个参数

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
@@ -35,6 +35,7 @@ import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
 import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
 import com.alibaba.druid.proxy.jdbc.StatementProxy;
 import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.SQLUtils.FormatOption;
 import com.alibaba.druid.util.JdbcUtils;
 
 /**
@@ -79,6 +80,9 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
     private boolean           statementLogErrorEnabled             = true;
     private boolean           resultSetLogEnabled                  = true;
     private boolean           resultSetLogErrorEnabled             = true;
+
+    private FormatOption      statementSqlFormatOption             = SQLUtils.DEFAULT_LCASE_FORMAT_OPTION;
+    private boolean           statementLogSqlPrettyFormat          = false;
 
     protected DataSourceProxy dataSource;
 
@@ -334,6 +338,22 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
         this.statementParameterClearLogEnable = statementParameterClearLogEnable;
     }
 
+    public FormatOption getStatementSqlFormatOption() {
+        return this.statementSqlFormatOption;
+    }
+
+    public void setStatementSqlFormatOption(FormatOption formatOption) {
+        this.statementSqlFormatOption = formatOption;
+    }
+
+    public boolean isStatementSqlPrettyFormat() {
+        return this.statementLogSqlPrettyFormat;
+    }
+
+    public void setStatementSqlPrettyFormat(boolean statementSqlPrettyFormat) {
+        this.statementLogSqlPrettyFormat = statementSqlPrettyFormat;
+    }
+
     protected abstract void connectionLog(String message);
 
     protected abstract void statementLog(String message);
@@ -545,7 +565,8 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
         }
 
         String dbType = statement.getConnectionProxy().getDirectDataSource().getDbType();
-        String formattedSql = SQLUtils.format(sql, dbType, parameters);
+        String formattedSql = SQLUtils.format(sql, dbType, parameters, this.statementSqlFormatOption,
+                                              this.statementLogSqlPrettyFormat);
         statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. "
                      + formattedSql);
     }

--- a/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
@@ -450,7 +450,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
             double millis = nanos / (1000 * 1000);
 
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. "
-                         + millis + " millis. \n" + sql);
+                         + millis + " millis. " + sql);
         }
     }
 
@@ -476,7 +476,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
             double millis = nanos / (1000 * 1000);
 
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement)
-                         + "} batch executed. " + millis + " millis. \n" + sql);
+                         + "} batch executed. " + millis + " millis. " + sql);
         }
     }
 
@@ -498,7 +498,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
             double millis = nanos / (1000 * 1000);
 
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + ", rs-"
-                         + resultSet.getId() + "} query executed. " + millis + " millis. \n" + sql);
+                         + resultSet.getId() + "} query executed. " + millis + " millis. " + sql);
         }
     }
 
@@ -520,7 +520,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
             double millis = nanos / (1000 * 1000);
 
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement)
-                         + "} update executed. effort " + updateCount + ". " + millis + " millis. \n" + sql);
+                         + "} update executed. effort " + updateCount + ". " + millis + " millis. " + sql);
         }
     }
 
@@ -531,7 +531,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
 
         int parametersSize = statement.getParametersSize();
         if (parametersSize == 0) {
-            statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. \n"
+            statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. "
                          + sql);
             return;
         }
@@ -546,7 +546,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
 
         String dbType = statement.getConnectionProxy().getDirectDataSource().getDbType();
         String formattedSql = SQLUtils.format(sql, dbType, parameters);
-        statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. \n"
+        statementLog("{conn-" + statement.getConnectionProxy().getId() + ", " + stmtId(statement) + "} executed. "
                      + formattedSql);
     }
 
@@ -715,14 +715,14 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
     protected void statementPrepareAfter(PreparedStatementProxy statement) {
         if (statementPrepareAfterLogEnable && isStatementLogEnabled()) {
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", pstmt-" + statement.getId()
-                         + "} created. \n" + statement.getSql());
+                         + "} created. " + statement.getSql());
         }
     }
 
     protected void statementPrepareCallAfter(CallableStatementProxy statement) {
         if (statementPrepareCallAfterLogEnable && isStatementLogEnabled()) {
             statementLog("{conn-" + statement.getConnectionProxy().getId() + ", cstmt-" + statement.getId()
-                         + "} created. \n" + statement.getSql());
+                         + "} created. " + statement.getSql());
         }
     }
 

--- a/src/main/java/com/alibaba/druid/filter/logging/LogFilterMBean.java
+++ b/src/main/java/com/alibaba/druid/filter/logging/LogFilterMBean.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.druid.filter.logging;
 
+import com.alibaba.druid.sql.SQLUtils.FormatOption;
+
 /**
  * @author wenshao [szujobs@hotmail.com]
  */
@@ -133,4 +135,13 @@ public interface LogFilterMBean {
     boolean isResultSetCloseAfterLogEnabled();
 
     void setResultSetCloseAfterLogEnabled(boolean resultSetCloseAfterLogEnable);
+
+    FormatOption getStatementSqlFormatOption();
+
+    void setStatementSqlFormatOption(FormatOption formatOption);
+
+    boolean isStatementSqlPrettyFormat();
+
+    void setStatementSqlPrettyFormat(boolean statementSqlPrettyFormat);
+
 }

--- a/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -144,7 +144,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         try {
             sql = ParameterizedOutputVisitorUtils.parameterize(sql, dbType);
         } catch (Exception e) {
-            LOG.error("merge sql error, dbType " + dbType + ", sql : \n" + sql, e);
+            LOG.error("merge sql error, dbType " + dbType + ", sql : " + sql, e);
         }
 
         return sql;
@@ -462,8 +462,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
                 sqlStat.setLastSlowParameters(slowParameters);
 
                 if (logSlowSql) {
-                    LOG.error("slow sql " + millis + " millis. \n" + statement.getLastExecuteSql() + "\n"
-                              + slowParameters);
+                    LOG.error("slow sql " + millis + " millis. " + statement.getLastExecuteSql() + "" + slowParameters);
                 }
             }
         }

--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -63,10 +63,10 @@ public class SQLUtils {
     private final static Log LOG = LogFactory.getLog(SQLUtils.class);
 
     public static String toSQLString(SQLObject sqlObject, String dbType) {
-        return toSQLString(sqlObject, dbType, null);
+        return toSQLString(sqlObject, dbType, null, false);
     }
     
-    public static String toSQLString(SQLObject sqlObject, String dbType, FormatOption option) {
+    public static String toSQLString(SQLObject sqlObject, String dbType, FormatOption option, boolean prettyFormat) {
         StringBuilder out = new StringBuilder();
         SQLASTOutputVisitor visitor = createOutputVisitor(out, dbType);
         
@@ -74,6 +74,7 @@ public class SQLUtils {
             option = DEFAULT_FORMAT_OPTION;
         }
         visitor.setUppCase(option.isUppCase());
+        visitor.setPrettyFormat(prettyFormat);
         
         sqlObject.accept(visitor);
 
@@ -90,19 +91,19 @@ public class SQLUtils {
     }
 
     public static String toOdpsString(SQLObject sqlObject) {
-        return toOdpsString(sqlObject, null);
+        return toOdpsString(sqlObject, null, false);
     }
     
-    public static String toOdpsString(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.ODPS, option);
+    public static String toOdpsString(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.ODPS, option, prettyFormat);
     }
     
     public static String toMySqlString(SQLObject sqlObject) {
-        return toMySqlString(sqlObject, null);
+        return toMySqlString(sqlObject, null, false);
     }
 
-    public static String toMySqlString(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.MYSQL, option);
+    public static String toMySqlString(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.MYSQL, option, prettyFormat);
     }
 
     public static SQLExpr toMySqlExpr(String sql) {
@@ -138,35 +139,35 @@ public class SQLUtils {
     }
 
     public static String toOracleString(SQLObject sqlObject) {
-        return toOracleString(sqlObject, null);
+        return toOracleString(sqlObject, null, false);
     }
     
-    public static String toOracleString(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.ORACLE, option);
+    public static String toOracleString(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.ORACLE, option, prettyFormat);
     }
     
     public static String toPGString(SQLObject sqlObject) {
-        return toPGString(sqlObject, null);
+        return toPGString(sqlObject, null, false);
     }
 
-    public static String toPGString(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.POSTGRESQL, option);
+    public static String toPGString(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.POSTGRESQL, option, prettyFormat);
     }
 
     public static String toDB2String(SQLObject sqlObject) {
-        return toDB2String(sqlObject, null);
+        return toDB2String(sqlObject, null, false);
     }
     
-    public static String toDB2String(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.DB2, option);
+    public static String toDB2String(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.DB2, option, prettyFormat);
     }
 
     public static String toSQLServerString(SQLObject sqlObject) {
-        return toSQLServerString(sqlObject, null);
+        return toSQLServerString(sqlObject, null, false);
     }
     
-    public static String toSQLServerString(SQLObject sqlObject, FormatOption option) {
-        return toSQLString(sqlObject, JdbcConstants.SQL_SERVER, option);
+    public static String toSQLServerString(SQLObject sqlObject, FormatOption option, boolean prettyFormat) {
+        return toSQLString(sqlObject, JdbcConstants.SQL_SERVER, option, prettyFormat);
     }
     
     public static String formatPGSql(String sql, FormatOption option) {
@@ -227,25 +228,25 @@ public class SQLUtils {
     }
 
     public static String format(String sql, String dbType) {
-        return format(sql, dbType, null, null);
+        return format(sql, dbType, null, null, false);
     }
     
     public static String format(String sql, String dbType, FormatOption option) {
-        return format(sql, dbType, null, option);
+        return format(sql, dbType, null, option, false);
     }
     
     public static String format(String sql, String dbType, List<Object> parameters) {
-        return format(sql, dbType, parameters, null);
+        return format(sql, dbType, parameters, null, false);
     }
 
-    public static String format(String sql, String dbType, List<Object> parameters, FormatOption option) {
+    public static String format(String sql, String dbType, List<Object> parameters, FormatOption option, boolean prettyFormat) {
         try {
             SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
             parser.setKeepComments(true);
             
             List<SQLStatement> statementList = parser.parseStatementList();
 
-            return toSQLString(statementList, dbType, parameters, option);
+            return toSQLString(statementList, dbType, parameters, option, null, prettyFormat);
         } catch (ParserException ex) {
             LOG.warn("format error", ex);
             return sql;
@@ -261,28 +262,30 @@ public class SQLUtils {
     }
     
     public static String toSQLString(List<SQLStatement> statementList, String dbType, List<Object> parameters) {
-        return toSQLString(statementList, dbType, parameters, null, null);
+        return toSQLString(statementList, dbType, parameters, DEFAULT_LCASE_FORMAT_OPTION, null, false);
     }
 
     public static String toSQLString(List<SQLStatement> statementList, String dbType, List<Object> parameters, FormatOption option) {
-        return toSQLString(statementList, dbType, parameters, option, null);
+        return toSQLString(statementList, dbType, parameters, option, null, false);
     }
 
     public static String toSQLString(List<SQLStatement> statementList
             , String dbType
             , List<Object> parameters
             , FormatOption option
-            , Map<String, String> tableMapping) {
+            , Map<String, String> tableMapping
+            , boolean prettyFormat) {
         StringBuilder out = new StringBuilder();
         SQLASTOutputVisitor visitor = createFormatOutputVisitor(out, statementList, dbType);
         if (parameters != null) {
             visitor.setParameters(parameters);
         }
-        
+    
         if (option == null) {
             option = DEFAULT_FORMAT_OPTION;
         }
         visitor.setUppCase(option.isUppCase());
+        visitor.setPrettyFormat(prettyFormat);
 
         if (tableMapping != null) {
             visitor.setTableMapping(tableMapping);
@@ -658,7 +661,7 @@ public class SQLUtils {
 
     public static String refactor(String sql, String dbType, Map<String, String> tableMapping) {
         List<SQLStatement> stmtList = parseStatements(sql, dbType);
-        return SQLUtils.toSQLString(stmtList, dbType, null, null, tableMapping);
+        return SQLUtils.toSQLString(stmtList, dbType, null, DEFAULT_LCASE_FORMAT_OPTION, tableMapping, false);
     }
 
     public static boolean containsIndexDDL(String sql, String dbType) {


### PR DESCRIPTION
sql语句输出时带有的换行符（\n）导致日志分析困难，我删除了。
PrettyFormat格式化sql语句增加了换行符，因此我在LogFilter中增加了此属性的设置，默认关闭。
Sql语句格式化时有大小写控制，但没有设置的属性，我在LogFilter中增加了此属性的设置，默认小写。

logFilter.setStatementSqlPrettyFormat(false); //关闭sql语句换行输出。默认
						logFilter.setStatementSqlFormatOption(SQLUtils.DEFAULT_LCASE_FORMAT_OPTION);//sql语句小写输出。默认