### PR TITLE
对SQL监控，Session监控页面,添加刷新时间控制

### DIFF
--- a/src/main/resources/support/http/resources/sql.html
+++ b/src/main/resources/support/http/resources/sql.html
@@ -21,12 +21,12 @@
           					<span class="pull-right" style="font-size: 16px; margin-right: 20px;">
           						<label langkey="RefreshPeriod" class="lang" style="display: inline;" for="refreshSecondsSelect">Refresh Period</label>
           						<select id="refreshSecondsSelect" class="refresh-seconds-select btn" style="width:80px;" onchange="javascript:druid.sql.refreshSeconds=parseInt(this.options[this.options.selectedIndex].value);">
-                                    <option value="5"selected="selected">5s</option>
-                                    <option value="10">10s</option>
-                                    <option value="20">20s</option>
-                                    <option value="30">30s</option>
-                                    <option value="60">60s</option>
-                                </select>
+          							<option value="5"selected="selected">5s</option>
+          							<option value="10">10s</option>
+          							<option value="20">20s</option>
+          							<option value="30">30s</option>
+          							<option value="60">60s</option>
+          						</select>
           						<a id="btnSuspendRefresh" langkey="SuspendRefresh" class="btn btn-primary lang" href="javascript:druid.sql.switchSuspendRefresh();">Suspend Refresh</a>
           					</span>
           				</h3>
@@ -100,36 +100,36 @@
 	    				druid.common.ajaxuri = dataSourceId ? 'sql.json?dataSourceId=' + dataSourceId + '&' : 'sql.json?';
 	    				druid.common.handleCallback = druid.sql.handleAjaxResult;
 	    				druid.common.setOrderBy("SQL");
-                        druid.sql.controlRefresh();
+	    				druid.sql.controlRefresh();
 	    			},
-                    controlRefresh : function() {
-                        var FIVE = 5;
-                        if(!druid.sql.refreshSeconds){
-                            druid.sql.refreshSeconds=FIVE;
-                        }
-                        if(!druid.sql.suspendedSeconds){
-                            druid.sql.suspendedSeconds=0;
-                        }
-                        druid.sql.suspendedSeconds += FIVE;
-                        if(!druid.sql.disableAutoRefresh){
-                            if(druid.sql.suspendedSeconds >= druid.sql.refreshSeconds){
-                                druid.sql.suspendedSeconds = 0;
-                                druid.common.ajaxRequestForBasicInfo();
-                            }
-                        }
-                        setTimeout(druid.sql.controlRefresh, FIVE * 1000);
-                    },
-                    switchSuspendRefresh : function() {
-                        druid.sql.disableAutoRefresh = !druid.sql.disableAutoRefresh;
-                        if(druid.sql.disableAutoRefresh){
-                            $("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
-                        } else {
-                            $("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
-                        }
-                    },
-                    disableAutoRefresh : false,
-                    refreshSeconds : 5,
-                    suspendedSeconds : 0,
+	    			controlRefresh : function() {
+	    				var FIVE = 5;
+	    				if(!druid.sql.refreshSeconds){
+	    					druid.sql.refreshSeconds=FIVE;
+	    				}
+	    				if(!druid.sql.suspendedSeconds){
+	    					druid.sql.suspendedSeconds=0;
+	    				}
+	    				druid.sql.suspendedSeconds += FIVE;
+	    				if(!druid.sql.disableAutoRefresh){
+	    					if(druid.sql.suspendedSeconds >= druid.sql.refreshSeconds){
+	    						druid.sql.suspendedSeconds = 0;
+	    						druid.common.ajaxRequestForBasicInfo();
+	    					}
+	    				}
+	    				setTimeout(druid.sql.controlRefresh, FIVE * 1000);
+	    			},
+	    			switchSuspendRefresh : function() {
+	    				druid.sql.disableAutoRefresh = !druid.sql.disableAutoRefresh;
+	    				if(druid.sql.disableAutoRefresh){
+	    					$("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
+	    				} else {
+	    					$("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
+	    				}
+	    			},
+	    			disableAutoRefresh : false,
+	    			refreshSeconds : 5,
+	    			suspendedSeconds : 0,
 	    			
 	    			handleAjaxResult : function(data) {
 	    				var sqlStatList = data.Content;

--- a/src/main/resources/support/http/resources/sql.html
+++ b/src/main/resources/support/http/resources/sql.html
@@ -18,6 +18,17 @@
           				<h3>
           					SQL Stat
           					<a href="sql.json" target="_blank">View JSON API</a>
+          					<span class="pull-right" style="font-size: 16px; margin-right: 20px;">
+          						<label langkey="RefreshPeriod" class="lang" style="display: inline;" for="refreshSecondsSelect">Refresh Period</label>
+          						<select id="refreshSecondsSelect" class="refresh-seconds-select btn" style="width:80px;" onchange="javascript:druid.sql.refreshSeconds=parseInt(this.options[this.options.selectedIndex].value);">
+                                    <option value="5"selected="selected">5s</option>
+                                    <option value="10">10s</option>
+                                    <option value="20">20s</option>
+                                    <option value="30">30s</option>
+                                    <option value="60">60s</option>
+                                </select>
+          						<a id="btnSuspendRefresh" langkey="SuspendRefresh" class="btn btn-primary lang" href="javascript:druid.sql.switchSuspendRefresh();">Suspend Refresh</a>
+          					</span>
           				</h3>
 						<table id="dataTable" class="table table-bordered table-striped responsive-utilities">
 							<thead>
@@ -89,9 +100,36 @@
 	    				druid.common.ajaxuri = dataSourceId ? 'sql.json?dataSourceId=' + dataSourceId + '&' : 'sql.json?';
 	    				druid.common.handleCallback = druid.sql.handleAjaxResult;
 	    				druid.common.setOrderBy("SQL");
-	    				druid.common.ajaxRequestForBasicInfo();
-	    				setInterval("druid.common.ajaxRequestForBasicInfo();",5000);
+                        druid.sql.controlRefresh();
 	    			},
+                    controlRefresh : function() {
+                        var FIVE = 5;
+                        if(!druid.sql.refreshSeconds){
+                            druid.sql.refreshSeconds=FIVE;
+                        }
+                        if(!druid.sql.suspendedSeconds){
+                            druid.sql.suspendedSeconds=0;
+                        }
+                        druid.sql.suspendedSeconds += FIVE;
+                        if(!druid.sql.disableAutoRefresh){
+                            if(druid.sql.suspendedSeconds >= druid.sql.refreshSeconds){
+                                druid.sql.suspendedSeconds = 0;
+                                druid.common.ajaxRequestForBasicInfo();
+                            }
+                        }
+                        setTimeout(druid.sql.controlRefresh, FIVE * 1000);
+                    },
+                    switchSuspendRefresh : function() {
+                        druid.sql.disableAutoRefresh = !druid.sql.disableAutoRefresh;
+                        if(druid.sql.disableAutoRefresh){
+                            $("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
+                        } else {
+                            $("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
+                        }
+                    },
+                    disableAutoRefresh : false,
+                    refreshSeconds : 5,
+                    suspendedSeconds : 0,
 	    			
 	    			handleAjaxResult : function(data) {
 	    				var sqlStatList = data.Content;

--- a/src/main/resources/support/http/resources/websession.html
+++ b/src/main/resources/support/http/resources/websession.html
@@ -17,6 +17,17 @@
           				<h3>
           					Web Session Stat
           					<a href="websession.json" target="_blank">View JSON API</a>
+          					<span class="pull-right" style="font-size: 16px; margin-right: 20px;">
+          						<label langkey="RefreshPeriod" class="lang" style="display: inline;" for="refreshSecondsSelect">Refresh Period</label>
+          						<select id="refreshSecondsSelect" class="refresh-seconds-select btn" style="width:80px;" onchange="javascript:druid.websession.refreshSeconds=parseInt(this.options[this.options.selectedIndex].value);">
+                                    <option value="5"selected="selected">5s</option>
+                                    <option value="10">10s</option>
+                                    <option value="20">20s</option>
+                                    <option value="30">30s</option>
+                                    <option value="60">60s</option>
+                                </select>
+          						<a id="btnSuspendRefresh" langkey="SuspendRefresh" class="btn btn-primary lang" href="javascript:druid.websession.switchSuspendRefresh();">Suspend Refresh</a>
+          					</span>
           				</h3>
 						<table id="dataTable" class="table table-bordered table-striped">
 							<thead>
@@ -55,9 +66,36 @@
     				druid.common.buildHead(6);
     				druid.common.ajaxuri = 'websession.json?';
     				druid.common.handleCallback = druid.websession.handleAjaxResult;
-    				druid.common.ajaxRequestForBasicInfo();
-    				setInterval("druid.common.ajaxRequestForBasicInfo();",5000);
+                    druid.websession.controlRefresh();
     			},
+                controlRefresh : function() {
+                    var FIVE = 5;
+                    if(!druid.websession.refreshSeconds){
+                        druid.websession.refreshSeconds=FIVE;
+                    }
+                    if(!druid.websession.suspendedSeconds){
+                        druid.websession.suspendedSeconds=0;
+                    }
+                    druid.websession.suspendedSeconds += FIVE;
+                    if(!druid.websession.disableAutoRefresh){
+                        if(druid.websession.suspendedSeconds >= druid.websession.refreshSeconds){
+                            druid.websession.suspendedSeconds = 0;
+                            druid.common.ajaxRequestForBasicInfo();
+                        }
+                    }
+                    setTimeout(druid.websession.controlRefresh, FIVE * 1000);
+                },
+                switchSuspendRefresh : function() {
+                    druid.websession.disableAutoRefresh = !druid.websession.disableAutoRefresh;
+                    if(druid.websession.disableAutoRefresh){
+                        $("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
+                    } else {
+                        $("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
+                    }
+                },
+                disableAutoRefresh : false,
+                refreshSeconds : 5,
+                suspendedSeconds : 0,
     			
     			handleAjaxResult : function(data) {
     				var statList = data.Content;

--- a/src/main/resources/support/http/resources/websession.html
+++ b/src/main/resources/support/http/resources/websession.html
@@ -20,12 +20,12 @@
           					<span class="pull-right" style="font-size: 16px; margin-right: 20px;">
           						<label langkey="RefreshPeriod" class="lang" style="display: inline;" for="refreshSecondsSelect">Refresh Period</label>
           						<select id="refreshSecondsSelect" class="refresh-seconds-select btn" style="width:80px;" onchange="javascript:druid.websession.refreshSeconds=parseInt(this.options[this.options.selectedIndex].value);">
-                                    <option value="5"selected="selected">5s</option>
-                                    <option value="10">10s</option>
-                                    <option value="20">20s</option>
-                                    <option value="30">30s</option>
-                                    <option value="60">60s</option>
-                                </select>
+          							<option value="5"selected="selected">5s</option>
+          							<option value="10">10s</option>
+          							<option value="20">20s</option>
+          							<option value="30">30s</option>
+          							<option value="60">60s</option>
+          						</select>
           						<a id="btnSuspendRefresh" langkey="SuspendRefresh" class="btn btn-primary lang" href="javascript:druid.websession.switchSuspendRefresh();">Suspend Refresh</a>
           					</span>
           				</h3>
@@ -66,36 +66,36 @@
     				druid.common.buildHead(6);
     				druid.common.ajaxuri = 'websession.json?';
     				druid.common.handleCallback = druid.websession.handleAjaxResult;
-                    druid.websession.controlRefresh();
+    				druid.websession.controlRefresh();
     			},
-                controlRefresh : function() {
-                    var FIVE = 5;
-                    if(!druid.websession.refreshSeconds){
-                        druid.websession.refreshSeconds=FIVE;
-                    }
-                    if(!druid.websession.suspendedSeconds){
-                        druid.websession.suspendedSeconds=0;
-                    }
-                    druid.websession.suspendedSeconds += FIVE;
-                    if(!druid.websession.disableAutoRefresh){
-                        if(druid.websession.suspendedSeconds >= druid.websession.refreshSeconds){
-                            druid.websession.suspendedSeconds = 0;
-                            druid.common.ajaxRequestForBasicInfo();
-                        }
-                    }
-                    setTimeout(druid.websession.controlRefresh, FIVE * 1000);
-                },
-                switchSuspendRefresh : function() {
-                    druid.websession.disableAutoRefresh = !druid.websession.disableAutoRefresh;
-                    if(druid.websession.disableAutoRefresh){
-                        $("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
-                    } else {
-                        $("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
-                    }
-                },
-                disableAutoRefresh : false,
-                refreshSeconds : 5,
-                suspendedSeconds : 0,
+    			controlRefresh : function() {
+    				var FIVE = 5;
+    				if(!druid.websession.refreshSeconds){
+    					druid.websession.refreshSeconds=FIVE;
+    				}
+    				if(!druid.websession.suspendedSeconds){
+    					druid.websession.suspendedSeconds=0;
+    				}
+    				druid.websession.suspendedSeconds += FIVE;
+    				if(!druid.websession.disableAutoRefresh){
+    					if(druid.websession.suspendedSeconds >= druid.websession.refreshSeconds){
+    						druid.websession.suspendedSeconds = 0;
+    						druid.common.ajaxRequestForBasicInfo();
+    					}
+    				}
+    				setTimeout(druid.websession.controlRefresh, FIVE * 1000);
+    			},
+    			switchSuspendRefresh : function() {
+    				druid.websession.disableAutoRefresh = !druid.websession.disableAutoRefresh;
+    				if(druid.websession.disableAutoRefresh){
+    					$("#btnSuspendRefresh").addClass("btn-warning").removeClass("btn-primary");
+    				} else {
+    					$("#btnSuspendRefresh").addClass("btn-primary").removeClass("btn-warning");
+    				}
+    			},
+    			disableAutoRefresh : false,
+    			refreshSeconds : 5,
+    			suspendedSeconds : 0,
     			
     			handleAjaxResult : function(data) {
     				var statList = data.Content;


### PR DESCRIPTION
参照 #1393 
对SQL监控，Session监控页面,添加刷新时间控制,
防止网络情况较差时无法显示大数据量的问题。
已测试。