### PR TITLE
优化Oracle、MySQL和PostgreSQL的验证器

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -33,7 +33,8 @@ import com.alibaba.druid.util.Utils;
 
 public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter implements ValidConnectionChecker, Serializable {
 
-    public static final int DEFAULT_VALIDATION_QUERY_TIMEOUT = 1000;
+    public static final int DEFAULT_VALIDATION_QUERY_TIMEOUT = 1;
+    public static final String DEFAULT_VALIDATION_QUERY = "SELECT 1";
 
     private static final long serialVersionUID = 1L;
     private static final Log  LOG              = LogFactory.getLog(MySqlValidConnectionChecker.class);
@@ -105,8 +106,9 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
             }
         }
 
-        if (validateQuery == null || validateQuery.length() == 0) {
-            return true;
+        String query = validateQuery;
+        if (validateQuery == null || validateQuery.isEmpty()) {
+            query = DEFAULT_VALIDATION_QUERY;
         }
 
         Statement stmt = null;
@@ -116,7 +118,7 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
             if (validationQueryTimeout > 0) {
                 stmt.setQueryTimeout(validationQueryTimeout);
             }
-            rs = stmt.executeQuery(validateQuery);
+            rs = stmt.executeQuery(query);
             return true;
         } finally {
             JdbcUtils.close(rs);

--- a/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
+++ b/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
@@ -70,15 +70,17 @@ public class OracleValidConnectionChecker extends ValidConnectionCheckerAdapter 
             conn = ((ConnectionProxy) conn).getRawObject();
         }
 
-        if (validateQuery == null || validateQuery.length() == 0) {
+        if (validateQuery == null || validateQuery.isEmpty()) {
             return true;
         }
+
+        int queryTimeout = validationQueryTimeout < 0 ? timeout : validationQueryTimeout;
 
         Statement stmt = null;
         ResultSet rs = null;
         try {
             stmt = conn.createStatement();
-            stmt.setQueryTimeout(timeout);
+            stmt.setQueryTimeout(queryTimeout);
             rs = stmt.executeQuery(validateQuery);
             return true;
         } finally {

--- a/src/main/java/com/alibaba/druid/pool/vendor/PGValidConnectionChecker.java
+++ b/src/main/java/com/alibaba/druid/pool/vendor/PGValidConnectionChecker.java
@@ -30,6 +30,8 @@ public class PGValidConnectionChecker extends ValidConnectionCheckerAdapter impl
 
     private static final long serialVersionUID     = -2227528634302168877L;
 
+    private int               defaultQueryTimeout  = 1;
+
     private String            defaultValidateQuery = "SELECT 'x'";
 
     public PGValidConnectionChecker(){
@@ -53,10 +55,13 @@ public class PGValidConnectionChecker extends ValidConnectionCheckerAdapter impl
             conn = ((ConnectionProxy) conn).getRawObject();
         }
 
+        int queryTimeout = validationQueryTimeout < 0 ? defaultQueryTimeout : validationQueryTimeout;
+
         Statement stmt = null;
         ResultSet rs = null;
         try {
             stmt = conn.createStatement();
+            stmt.setQueryTimeout(queryTimeout);
             rs = stmt.executeQuery(validateQuery);
             return true;
         } finally {


### PR DESCRIPTION
Oracle：
原先的isValidConnection方法忽略了validationQueryTimeout参数，修改为优先使用validationQueryTimeout，然后才是timeout属性。

MySQL：
1.查询超时单位是秒，默认1000秒太长了，估计当时搞错单位了，修改为1秒。
2.当方法没有传SQL时设定一个默认的SQL，而不是直接返回true。

PostgreSQL：
修正stmt未设置查询超时的问题。