### PR TITLE
PreparedStatement抛出异常后需要在PreparedStatementPool里将其剔除

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
@@ -173,6 +173,12 @@ public class DruidPooledConnection extends PoolableWrapper implements javax.sql.
             stmt.getPreparedStatementHolder().setFetchRowPeak(stmt.getFetchRowPeak());
 
             stmt.setClosed(true); // soft set close
+        } else if (stmt.isPooled() && holder.isPoolPreparedStatements()) {
+            // the PreparedStatement threw an exception
+            stmt.clearResultSet();
+            holder.removeTrace(stmt);
+
+            holder.getStatementPool().remove(stmt.getPreparedStatementHolder());
         } else {
             try {
                 //Connection behind the statement may be in invalid state, which will throw a SQLException.

--- a/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
+++ b/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
@@ -76,7 +76,7 @@ public class PreparedStatementPool {
         if (stmtHolder == null) {
             return;
         }
-        map.remove(stmtHolder.key, stmtHolder);
+        map.remove(stmtHolder.key);
         closeRemovedStatement(stmtHolder);
     }
 

--- a/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
+++ b/src/main/java/com/alibaba/druid/pool/PreparedStatementPool.java
@@ -72,6 +72,14 @@ public class PreparedStatementPool {
         return holder;
     }
 
+    public void remove(PreparedStatementHolder stmtHolder) throws SQLException {
+        if (stmtHolder == null) {
+            return;
+        }
+        map.remove(stmtHolder.key, stmtHolder);
+        closeRemovedStatement(stmtHolder);
+    }
+
     public void put(PreparedStatementHolder stmtHolder) throws SQLException {
         PreparedStatement stmt = stmtHolder.statement;
 

--- a/src/test/java/com/alibaba/druid/pool/ClosePoolableStatementTest.java
+++ b/src/test/java/com/alibaba/druid/pool/ClosePoolableStatementTest.java
@@ -1,0 +1,76 @@
+package com.alibaba.druid.pool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * 测试开启PSCache后关闭DruidPooledPreparedStatement时的情况
+ *
+ * @author DigitalSonic
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:com/alibaba/druid/pool/dataSource.xml")
+public class ClosePoolableStatementTest {
+    @Autowired
+    private DruidDataSource dataSource;
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Before
+    public void setUp() throws Exception {
+        dataSource.setPoolPreparedStatements(true);
+        dataSource.setMaxPoolPreparedStatementPerConnectionSize(5);
+        dataSource.init();
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("create table test (id int, val varchar(32), primary key (id))");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        jdbcTemplate.execute("drop table test");
+    }
+
+    /**
+     * 关注抛出异常后能否正确将PreparedStatement移出缓存，能正常执行后续SQL
+     */
+    @Test
+    public void testClose() throws Exception {
+        insertData(1, "a");
+        try {
+            insertData(1, "a");
+        } catch (Exception e) {
+            assertTrue(e instanceof DuplicateKeyException);
+        }
+        try {
+            insertData(1, "a");
+        } catch (Exception e) {
+            assertTrue(e instanceof DuplicateKeyException);
+            assertEquals(-1, e.getMessage().indexOf("closed"));
+        }
+    }
+
+    private void insertData(final int id, final String val) {
+        jdbcTemplate.update("insert into test (id, val) values (?, ?)", new PreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps) throws SQLException {
+                ps.setInt(1, id);
+                ps.setString(2, val);
+            }
+        });
+    }
+}


### PR DESCRIPTION
为了修复issue #1498 ，closePoolableStatement方法里增加了一个判断stmt.exceptionCount == 0，只有没有出错的stmt才会放入PreparedStatementPool，但是如果这个stmt已经在池里了则不会将其删除，导致后续仍然会取到该PreparedStatement。

在开启了PSCache的情况下，如果发生异常，按照closePoolableStatement的流程会关闭Statement。如果后续仍然取到这个PreparedStatement执行就会报Statement已关闭的错误。
