### PR TITLE
修正OracleExportParameterVisitor无法解析带小数点的数字类型的参数值

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleParameterizedOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleParameterizedOutputVisitor.java
@@ -22,6 +22,8 @@ import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
 import com.alibaba.druid.sql.ast.expr.SQLNCharExpr;
 import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
 import com.alibaba.druid.sql.ast.expr.SQLNumberExpr;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 import com.alibaba.druid.sql.visitor.ParameterizedOutputVisitorUtils;
 import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
 
@@ -39,6 +41,7 @@ public class OracleParameterizedOutputVisitor extends OracleOutputVisitor implem
 
     public OracleParameterizedOutputVisitor(Appendable appender, boolean printPostSemi){
         super(appender, printPostSemi);
+        this.parameterized = true;
     }
 
     public boolean visit(SQLBinaryOpExpr x) {
@@ -54,6 +57,10 @@ public class OracleParameterizedOutputVisitor extends OracleOutputVisitor implem
 
         print('?');
         incrementReplaceCunt();
+        
+        if(this instanceof ExportParameterVisitor || this.parameters != null){
+            ExportParameterVisitorUtils.exportParameter((this).getParameters(), x);
+        }
         return false;
     }
 

--- a/src/test/java/com/alibaba/druid/bvt/sql/oracle/visitor/ExportParameterDotNumberTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/oracle/visitor/ExportParameterDotNumberTest.java
@@ -1,0 +1,46 @@
+package com.alibaba.druid.bvt.sql.oracle.visitor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleExportParameterVisitor;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import junit.framework.TestCase;
+
+public class ExportParameterDotNumberTest extends TestCase {
+	/**
+	* Logger for this class
+	*/
+	private static final Logger LOG = LoggerFactory.getLogger(ExportParameterDotNumberTest.class);
+
+	String dbType = JdbcConstants.MYSQL;
+
+	public void test_exportParameter() throws Exception {
+		String[] sqls = { "INSERT INTO test_tab1 (name) VALUES ( 2.0  )",
+				 "INSERT INTO test_tab1 (name) VALUES ( 2  )",
+		};
+		for(String sql : sqls){
+			final StringBuilder out = new StringBuilder();
+			final ExportParameterVisitor visitor = new OracleExportParameterVisitor(out);
+			SQLStatementParser parser = new OracleStatementParser(sql);
+			final SQLStatement parseStatement = parser.parseStatement();
+			parseStatement.accept(visitor);
+			final List<Object> plist = visitor.getParameters();
+			LOG.info("from_sql:{}",sql);
+			sql = out.toString();
+		
+			LOG.info("to_sql:{} ==> plist:{}",sql,plist);
+			
+			Assert.assertTrue(plist.size()>0);
+		}
+	}
+
+}


### PR DESCRIPTION
eg:
```
	String  sql = "INSERT INTO test_tab1 (name) VALUES ( 2.0 )";
	final StringBuilder out = new StringBuilder();
        final ExportParameterVisitor visitor = new OracleExportParameterVisitor(out);
        SQLStatementParser parser = new OracleStatementParser(sql);
        final SQLStatement parseStatement = parser.parseStatement();
        parseStatement.accept(visitor);
        final List<Object> plist = visitor.getParameters();
       LOG.debug("sql:{}",sql);
        sql = out.toString();
        LOG.debug("sql:{} params:{} \n size:{}",sql,plist,plist.size());
      //error : plist.size() ==0

```