### PR TITLE
添加postgresql的begin,commit,set命令解析

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGBeginStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGBeginStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
+
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class PGBeginStatement extends SQLStatementImpl implements PGSQLStatement {
+    public final boolean isBegin;
+
+    public PGBeginStatement(boolean isBegin) {
+        super(JdbcConstants.POSTGRESQL);
+        this.isBegin = isBegin;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof PGASTVisitor) {
+            accept0((PGASTVisitor) visitor);
+        }
+    }
+
+    @Override
+    public void accept0(PGASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGCommitStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGCommitStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
+
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+// 暂时不支持END命令
+public class PGCommitStatement extends SQLStatementImpl implements PGSQLStatement {
+
+    // COMMIT
+    public PGCommitStatement() {
+        super(JdbcConstants.POSTGRESQL);
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof PGASTVisitor) {
+            accept0((PGASTVisitor) visitor);
+        }
+    }
+
+    @Override
+    public void accept0(PGASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
@@ -28,7 +28,7 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.PGWithClause;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
-public class PGSelectQueryBlock extends SQLSelectQueryBlock {
+public class PGSelectQueryBlock extends SQLSelectQueryBlock implements PGSQLObject{
 
     private PGWithClause  with;
     private List<SQLExpr> distinctOn = new ArrayList<SQLExpr>(2);
@@ -56,7 +56,8 @@ public class PGSelectQueryBlock extends SQLSelectQueryBlock {
         accept0((PGASTVisitor) visitor);
     }
 
-    protected void accept0(PGASTVisitor visitor) {
+    @Override
+    public void accept0(PGASTVisitor visitor) {
         if (visitor.visit(this)) {
             acceptChild(visitor, this.with);
             acceptChild(visitor, this.distinctOn);

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSetStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSetStatement.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSetStatement;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.List;
+
+public class PGSetStatement extends SQLSetStatement implements PGSQLStatement {
+    public final String range;
+    public final String param;
+    public final List<SQLExpr> values;
+
+    // SET [ SESSION | LOCAL ] TIME ZONE { timezone | LOCAL | DEFAULT }
+    // SET [ SESSION | LOCAL ] configuration_parameter { TO | = } { value | 'value' | DEFAULT }
+    public PGSetStatement(String range, String param, List<SQLExpr> values) {
+        super(JdbcConstants.POSTGRESQL);
+        this.range = range;
+        this.param = param;
+        this.values = values;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof PGASTVisitor) {
+            accept0((PGASTVisitor) visitor);
+        }
+    }
+
+    @Override
+    public void accept0(PGASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -237,4 +237,24 @@ public class PGExprParser extends SQLExprParser {
 
         return super.primaryRest(expr);
     }
+
+    @Override
+    protected String alias() {
+        String alias = super.alias();
+        if (alias != null) {
+            return alias;
+        }
+        // 某些关键字在alias时,不作为关键字,仍然是作用为别名
+        switch (lexer.token()) {
+        case INTERSECT:
+            // 具体可以参考SQLParser::alias()的方法实现
+            alias = lexer.stringVal();
+            lexer.nextToken();
+            return alias;
+        // TODO other cases
+        default:
+            break;
+        }
+        return alias;
+    }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGLexer.java
@@ -34,6 +34,7 @@ public class PGLexer extends Lexer {
 
         map.putAll(Keywords.DEFAULT_KEYWORDS.getKeywords());
 
+        map.put("BEGIN", Token.BEGIN);
         map.put("CASCADE", Token.CASCADE);
         map.put("CONTINUE", Token.CONTINUE);
         map.put("CURRENT", Token.CURRENT);
@@ -57,7 +58,8 @@ public class PGLexer extends Lexer {
         map.put("ROWS", Token.ROWS);
         map.put("SHARE", Token.SHARE);
         map.put("SHOW", Token.SHOW);
-
+        map.put("START", Token.START);
+        
         map.put("USING", Token.USING);
         map.put("WINDOW", Token.WINDOW);
         

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -281,6 +281,10 @@ public class PGSelectParser extends SQLSelectParser {
 
                 return super.parseTableSourceRest(functionTableSource);
             }
+            if (alias != null) {
+                tableSource.setAlias(alias);
+                return super.parseTableSourceRest(tableSource);
+            }
         }
 
         return super.parseTableSourceRest(tableSource);

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitor.java
@@ -17,25 +17,8 @@ package com.alibaba.druid.sql.dialect.postgresql.visitor;
 
 import com.alibaba.druid.sql.dialect.postgresql.ast.PGWithClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.PGWithQuery;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGBoxExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGCidrExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGCircleExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGExtractExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGInetExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGIntervalExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGLineSegmentsExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGMacAddrExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPointExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPolygonExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGTypeCastExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGDeleteStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGShowStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGValuesQuery;
+import com.alibaba.druid.sql.dialect.postgresql.ast.expr.*;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.*;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public interface PGASTVisitor extends SQLASTVisitor {
@@ -136,4 +119,16 @@ public interface PGASTVisitor extends SQLASTVisitor {
     
     boolean visit(PGShowStatement x);
 
+    void endVisit(PGBeginStatement x);
+    
+    boolean visit(PGBeginStatement x);
+
+    void endVisit(PGCommitStatement x);
+    
+    boolean visit(PGCommitStatement x);
+
+    void endVisit(PGSetStatement x);
+    
+    boolean visit(PGSetStatement x);
+    
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGASTVisitorAdapter.java
@@ -28,17 +28,10 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGMacAddrExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPointExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPolygonExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGTypeCastExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGDeleteStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.*;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.FetchClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.ForClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.WindowClause;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGShowStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGValuesQuery;
 import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
 
 public class PGASTVisitorAdapter extends SQLASTVisitorAdapter implements PGASTVisitor {
@@ -285,6 +278,36 @@ public class PGASTVisitorAdapter extends SQLASTVisitorAdapter implements PGASTVi
     
     @Override
     public boolean visit(PGShowStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(PGBeginStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGBeginStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(PGCommitStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGCommitStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(PGSetStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGSetStatement x) {
         return true;
     }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -33,18 +33,14 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGMacAddrExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPointExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPolygonExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGTypeCastExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGDeleteStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.*;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.FetchClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.ForClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.WindowClause;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGShowStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGValuesQuery;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import com.alibaba.druid.sql.parser.Token;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+import com.alibaba.druid.util.StringUtils;
 
 public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor {
 
@@ -637,7 +633,59 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             print0(ucase ? " OFFSET " : " offset ");
             x.getOffset().accept(this);
         }
+        return false;
+    }
 
+    @Override
+    public void endVisit(PGBeginStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGBeginStatement x) {
+        print0(x.isBegin ? "BEGIN" : "START TRANSACTION");
+        return false;
+    }
+
+    @Override
+    public void endVisit(PGCommitStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGCommitStatement x) {
+        print0(ucase ? "COMMIT" : "commit");
+        return false;
+    }
+
+    @Override
+    public void endVisit(PGSetStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGSetStatement x) {
+        print0(ucase ? "SET " : "set ");
+        if (!StringUtils.isEmpty(x.range)) {
+            print0(x.range);
+            print0(" ");
+        }
+        if (PGSQLStatementParser.TIME_ZONE.equalsIgnoreCase(x.param)) {
+            print0(PGSQLStatementParser.TIME_ZONE);
+            print0(" ");
+            x.values.get(0).accept(this);
+            return false;
+        }
+        print0(x.param);
+        print0(" ");
+        print0(Token.TO.name());
+        print0(" ");
+        for (int i = 0; i < x.values.size(); i++) {
+            if (i != 0) {
+                print0(", ");
+            }
+            x.values.get(i).accept(this);
+        }
         return false;
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGSchemaStatVisitor.java
@@ -34,17 +34,10 @@ import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGMacAddrExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPointExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGPolygonExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGTypeCastExpr;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGDeleteStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.*;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.FetchClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.ForClause;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.WindowClause;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGShowStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
-import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGValuesQuery;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.stat.TableStat;
 import com.alibaba.druid.stat.TableStat.Mode;
@@ -399,6 +392,36 @@ public class PGSchemaStatVisitor extends SchemaStatVisitor implements PGASTVisit
     
     @Override
     public boolean visit(PGShowStatement x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(PGBeginStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGBeginStatement x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(PGCommitStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGCommitStatement x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(PGSetStatement x) {
+        
+    }
+
+    @Override
+    public boolean visit(PGSetStatement x) {
         return false;
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGBeginTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGBeginTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGBeginStatement;
+
+public class PGBeginTest extends PGTest {
+    public void testBegin() throws Exception {
+        String sql = "begin;";
+        String expected = "BEGIN";
+        testParseSql(sql, expected, expected, PGBeginStatement.class);
+
+        sql = "start transaction;";
+        expected = "START TRANSACTION";
+        testParseSql(sql, expected, expected, PGBeginStatement.class);
+    }
+
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGCommitTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGCommitTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGCommitStatement;
+
+public class PGCommitTest extends PGTest {
+    public void testCommit() throws Exception {
+        String sql = "commit;";
+        String expected = "COMMIT";
+        testParseSql(sql, expected, expected, PGCommitStatement.class);
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGFromAsTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGFromAsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
+
+public class PGFromAsTest extends PGTest {
+    public void testFromAs() throws Exception {
+        String sql = "SELECT Count(*) FROM tb_abc AS t1 WHERE ((t1.a_id = 'global_a_id') AND (t1.owner = 'global_bc'));";
+        String expectedSql = "SELECT COUNT(*)\nFROM tb_abc t1\nWHERE t1.a_id = 'global_a_id'\n\tAND t1.owner = 'global_bc'";
+        String expectedPattern = "SELECT COUNT(*)\nFROM tb_abc t1\nWHERE t1.a_id = ?\n\tAND t1.owner = ?";
+        testParseSql(sql, expectedSql, expectedPattern, PGSelectStatement.class);
+    }
+
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGSetTest3.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGSetTest3.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSetStatement;
+
+public class PGSetTest3 extends PGTest {
+    public void testSet() throws Exception {
+        Class<?> type = PGSetStatement.class;
+
+        String sql = "SET TIME ZONE 'Europe/Rome';";
+        String expectedSql = "SET TIME ZONE 'Europe/Rome'";
+        String expectedPattern = "SET TIME ZONE ?";
+        testParseSql(sql, expectedSql, expectedPattern, type);
+
+        sql = "SET configuration_parameter TO DEFAULT;";
+        expectedSql = "SET configuration_parameter TO DEFAULT";
+        testParseSql(sql, expectedSql, expectedSql, type);
+
+        sql = "SET search_path TO my_schema, public;";
+        expectedSql = "SET search_path TO my_schema, public";
+        testParseSql(sql, expectedSql, expectedSql, type);
+
+        sql = "SET search_path =  my_schema, public;";
+        expectedSql = "SET search_path TO my_schema, public";
+        testParseSql(sql, expectedSql, expectedSql, type);
+
+        sql = "SET a=1";
+        expectedSql = "SET a TO 1";
+        testParseSql(sql, expectedSql, expectedSql, type);
+
+        sql = "SET a=1,2";
+        expectedSql = "SET a TO 1, 2";
+        testParseSql(sql, expectedSql, expectedSql, type);
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGShowTest1.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGShowTest1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGShowStatement;
+
+public class PGShowTest1 extends PGTest {
+    public void testShowAll() throws Exception {
+        String sql = "show all;";
+        String expected = "SHOW ALL";
+        testParseSql(sql, expected, expected, PGShowStatement.class);
+
+        sql = "show transaction_read_only;";
+        expected = "SHOW transaction_read_only";
+        testParseSql(sql, expected, expected, PGShowStatement.class);
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/select/PGSelectTest42.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/select/PGSelectTest42.java
@@ -33,13 +33,13 @@ public class PGSelectTest42 extends PGTest {
         List<SQLStatement> statementList = parser.parseStatementList();
         SQLStatement stmt = statementList.get(0);
 
-        Assert.assertEquals("UPDATE sys_account\n" +
+        Assert.assertEquals("UPDATE sys_account a\n" +
                 "SET online = 2\n" +
                 "FROM auto_handler_online o\n" +
                 "WHERE a.id = o.account_id\n" +
                 "\tAND a.online != 2", SQLUtils.toPGString(stmt));
         
-        Assert.assertEquals("update sys_account\n" +
+        Assert.assertEquals("update sys_account a\n" +
                 "set online = 2\n" +
                 "from auto_handler_online o\n" +
                 "where a.id = o.account_id\n" +

--- a/src/test/java/com/alibaba/druid/sql/PGTest.java
+++ b/src/test/java/com/alibaba/druid/sql/PGTest.java
@@ -17,10 +17,12 @@ package com.alibaba.druid.sql;
 
 import java.util.List;
 
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
 import junit.framework.TestCase;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGOutputVisitor;
+import org.junit.Assert;
 
 public class PGTest extends TestCase {
 	protected String output(List<SQLStatement> stmtList) {
@@ -42,4 +44,18 @@ public class PGTest extends TestCase {
 	        }
 	        System.out.println(text);
 	    }
+
+    protected void testParseSql(String sql, String expectedSql, String expectedPattern, Class<?> type) {
+        PGSQLStatementParser parser = new PGSQLStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statement = statementList.get(0);
+
+        Assert.assertEquals(1, statementList.size());
+        Assert.assertTrue(type.isAssignableFrom(statement.getClass()));
+
+        StringBuilder sb = new StringBuilder();
+        PGOutputVisitor visitor = new PGOutputVisitor(sb);
+        statement.accept(visitor);
+        Assert.assertEquals(expectedSql, sb.toString());
+    }
 }


### PR DESCRIPTION
1. 添加postgresql的begin,commit,set命令解析

2. 添加PGStatement的测试代码，修复PGStatement解析bug

3. 修复pg无法识别table别名问题

4. 将PG的关键字移入TOKEN中

5. start transaction的visit优化

相关具体信息将写在review面板上