### PR TITLE
add kylin support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.kylin</groupId>
+			<artifactId>kylin-jdbc</artifactId>
+			<version>2.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
 			<version>2.2.2</version>

--- a/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -93,6 +93,10 @@ public interface JdbcConstants {
     public static final String ENTERPRISEDB        = "edb";
     public static final String ENTERPRISEDB_DRIVER = "com.edb.Driver";
 
+    public static final String KYLIN               = "kylin";
+    public static final String KYLIN_DRIVER        = "org.apache.kylin.jdbc.Driver";
+
+
     public static final String SQLITE              = "sqlite";
     public static final String SQLITE_DRIVER       = "org.sqlite.JDBC";
 }

--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -448,6 +448,8 @@ public final class JdbcUtils implements JdbcConstants {
             return "org.apache.phoenix.queryserver.client.Driver";
         } else if (rawUrl.startsWith("jdbc:phoenix://")) {
             return JdbcConstants.PHOENIX_DRIVER;
+        } else if (rawUrl.startsWith("jdbc:kylin:")) {
+            return JdbcConstants.KYLIN_DRIVER;
         } else {
             throw new SQLException("unkow jdbc driver : " + rawUrl);
         }

--- a/src/test/java/com/alibaba/druid/kylin/KylinDriverSupportTest.java
+++ b/src/test/java/com/alibaba/druid/kylin/KylinDriverSupportTest.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.kylin;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.util.JdbcConstants;
+import com.alibaba.druid.util.JdbcUtils;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author yinheli
+ */
+public class KylinDriverSupportTest {
+
+    // test config
+    private static final String URL = "jdbc:kylin://172.168.1.111:7070/jlkBigData";
+    private static final String USER_NAME = "ADMIN";
+    private static final String PASSWORD = "KYLIN";
+    private static final String VALIDATION_QUERY = "select 1";
+
+    @Test
+    public void testDriverClassName() throws SQLException {
+        String driverClass = JdbcUtils.getDriverClassName(URL);
+        Assert.assertThat("check get driverClassName", driverClass, Is.is(JdbcConstants.KYLIN_DRIVER));
+    }
+
+    @Test
+    public void testQuery() throws SQLException {
+        DruidDataSource dataSource = new DruidDataSource();
+        try {
+            dataSource = new DruidDataSource();
+            dataSource.setUrl(URL);
+            dataSource.setUsername(USER_NAME);
+            dataSource.setPassword(PASSWORD);
+            dataSource.setValidationQuery(VALIDATION_QUERY);
+
+            Connection conn = dataSource.getConnection();
+            PreparedStatement state = conn.prepareStatement(VALIDATION_QUERY);
+            ResultSet resultSet = state.executeQuery();
+            Assert.assertThat("check result", resultSet, IsNull.notNullValue());
+        } finally {
+            dataSource.close();
+        }
+
+    }
+
+}


### PR DESCRIPTION
添加对 Kylin JDBC 驱动的支持。

单元测试依赖 kylin 环境，这里我将测试日志贴一下：

```
2017-05-27 11:26:51,978 [INFO ] DruidDataSource:812 - {dataSource-1} inited
2017-05-27 11:26:52,326 [DEBUG] KylinConnection:62 - Kylin base url 172.168.1.111:7070, project name jlkBigData
2017-05-27 11:26:53,081 [DEBUG] BasicClientConnectionManager:159 - Get connection for route {}->http://172.168.1.111:7070
2017-05-27 11:26:53,095 [DEBUG] DefaultClientConnectionOperator:177 - Connecting to 172.168.1.111:7070
2017-05-27 11:26:53,116 [DEBUG] RequestAddCookies:132 - CookieSpec selected: best-match
2017-05-27 11:26:53,130 [DEBUG] RequestAuthCache:78 - Auth cache not set in the context
2017-05-27 11:26:53,131 [DEBUG] RequestProxyAuthentication:87 - Proxy auth state: UNCHALLENGED
2017-05-27 11:26:53,131 [DEBUG] DefaultHttpClient:713 - Attempt 1 to execute request
2017-05-27 11:26:53,132 [DEBUG] DefaultClientConnection:269 - Sending request: POST /kylin/api/user/authentication HTTP/1.1
2017-05-27 11:26:53,134 [DEBUG] wire:63 - >> "POST /kylin/api/user/authentication HTTP/1.1[\r][\n]"
2017-05-27 11:26:53,136 [DEBUG] wire:63 - >> "Accept: application/json, text/plain, */*[\r][\n]"
2017-05-27 11:26:53,136 [DEBUG] wire:63 - >> "Content-Type: application/json[\r][\n]"
2017-05-27 11:26:53,136 [DEBUG] wire:63 - >> "Authorization: Basic QURNSU46S1lMSU4=[\r][\n]"
2017-05-27 11:26:53,136 [DEBUG] wire:63 - >> "Content-Length: 2[\r][\n]"
2017-05-27 11:26:53,136 [DEBUG] wire:63 - >> "Host: 172.168.1.111:7070[\r][\n]"
2017-05-27 11:26:53,137 [DEBUG] wire:63 - >> "Connection: Keep-Alive[\r][\n]"
2017-05-27 11:26:53,138 [DEBUG] wire:63 - >> "User-Agent: Apache-HttpClient/4.2.5 (java 1.5)[\r][\n]"
2017-05-27 11:26:53,138 [DEBUG] wire:63 - >> "[\r][\n]"
2017-05-27 11:26:53,138 [DEBUG] headers:273 - >> POST /kylin/api/user/authentication HTTP/1.1
2017-05-27 11:26:53,138 [DEBUG] headers:276 - >> Accept: application/json, text/plain, */*
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> Content-Type: application/json
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> Authorization: Basic QURNSU46S1lMSU4=
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> Content-Length: 2
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> Host: 172.168.1.111:7070
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> Connection: Keep-Alive
2017-05-27 11:26:53,139 [DEBUG] headers:276 - >> User-Agent: Apache-HttpClient/4.2.5 (java 1.5)
2017-05-27 11:26:53,140 [DEBUG] wire:77 - >> "{}"
2017-05-27 11:26:53,379 [DEBUG] wire:63 - << "HTTP/1.1 200 OK[\r][\n]"
2017-05-27 11:26:53,380 [DEBUG] wire:63 - << "Server: Apache-Coyote/1.1[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Set-Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5; Path=/kylin/; HttpOnly[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Pragma: no-cache[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Cache-Control: no-cache, no-store, max-age=0[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Expires: Thu, 01 Jan 1970 00:00:00 GMT[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Content-Type: application/json;charset=UTF-8[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Content-Language: zh-CN[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Content-Length: 246[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "Date: Sat, 27 May 2017 03:26:08 GMT[\r][\n]"
2017-05-27 11:26:53,381 [DEBUG] wire:63 - << "[\r][\n]"
2017-05-27 11:26:53,382 [DEBUG] DefaultClientConnection:254 - Receiving response: HTTP/1.1 200 OK
2017-05-27 11:26:53,382 [DEBUG] headers:257 - << HTTP/1.1 200 OK
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Server: Apache-Coyote/1.1
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Set-Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5; Path=/kylin/; HttpOnly
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Pragma: no-cache
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Cache-Control: no-cache, no-store, max-age=0
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Expires: Thu, 01 Jan 1970 00:00:00 GMT
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Content-Type: application/json;charset=UTF-8
2017-05-27 11:26:53,382 [DEBUG] headers:260 - << Content-Language: zh-CN
2017-05-27 11:26:53,383 [DEBUG] headers:260 - << Content-Length: 246
2017-05-27 11:26:53,383 [DEBUG] headers:260 - << Date: Sat, 27 May 2017 03:26:08 GMT
2017-05-27 11:26:53,389 [DEBUG] ResponseProcessCookies:122 - Cookie accepted: "[version: 0][name: JSESSIONID][value: BAF3610449277DA68C4008D43F41F5C5][domain: 172.168.1.111][path: /kylin/][expiry: null]". 
2017-05-27 11:26:53,390 [DEBUG] DefaultHttpClient:543 - Connection can be kept alive indefinitely
2017-05-27 11:26:53,392 [DEBUG] DefaultClientConnection:154 - Connection 0.0.0.0:33843<->172.168.1.111:7070 shut down
2017-05-27 11:26:53,392 [DEBUG] BasicClientConnectionManager:201 - Releasing connection org.apache.kylin.jdbc.shaded.org.apache.http.impl.conn.ManagedClientConnectionImpl@584b7291
2017-05-27 11:26:53,457 [DEBUG] KylinClient:369 - Post body:
 {"sql":"select 1","project":"jlkBigData","acceptPartial":false,"backdoorToggles":{"ATTR_STATEMENT_MAX_ROWS":"0"}}
2017-05-27 11:26:53,458 [DEBUG] BasicClientConnectionManager:159 - Get connection for route {}->http://172.168.1.111:7070
2017-05-27 11:26:53,458 [DEBUG] DefaultClientConnectionOperator:177 - Connecting to 172.168.1.111:7070
2017-05-27 11:26:53,462 [DEBUG] RequestAddCookies:132 - CookieSpec selected: best-match
2017-05-27 11:26:53,462 [DEBUG] RequestAddCookies:184 - Cookie [version: 0][name: JSESSIONID][value: BAF3610449277DA68C4008D43F41F5C5][domain: 172.168.1.111][path: /kylin/][expiry: null] match [172.168.1.111:7070/kylin/api/query]
2017-05-27 11:26:53,463 [DEBUG] RequestAuthCache:78 - Auth cache not set in the context
2017-05-27 11:26:53,463 [DEBUG] RequestProxyAuthentication:87 - Proxy auth state: UNCHALLENGED
2017-05-27 11:26:53,463 [DEBUG] DefaultHttpClient:713 - Attempt 1 to execute request
2017-05-27 11:26:53,463 [DEBUG] DefaultClientConnection:269 - Sending request: POST /kylin/api/query HTTP/1.1
2017-05-27 11:26:53,463 [DEBUG] wire:63 - >> "POST /kylin/api/query HTTP/1.1[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Accept: application/json, text/plain, */*[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Content-Type: application/json[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Authorization: Basic QURNSU46S1lMSU4=[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Content-Length: 113[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Host: 172.168.1.111:7070[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Connection: Keep-Alive[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "User-Agent: Apache-HttpClient/4.2.5 (java 1.5)[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "Cookie2: $Version=1[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] wire:63 - >> "[\r][\n]"
2017-05-27 11:26:53,464 [DEBUG] headers:273 - >> POST /kylin/api/query HTTP/1.1
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Accept: application/json, text/plain, */*
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Content-Type: application/json
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Authorization: Basic QURNSU46S1lMSU4=
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Content-Length: 113
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Host: 172.168.1.111:7070
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Connection: Keep-Alive
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> User-Agent: Apache-HttpClient/4.2.5 (java 1.5)
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5
2017-05-27 11:26:53,465 [DEBUG] headers:276 - >> Cookie2: $Version=1
2017-05-27 11:26:53,465 [DEBUG] wire:77 - >> "{"sql":"select 1","project":"jlkBigData","acceptPartial":false,"backdoorToggles":{"ATTR_STATEMENT_MAX_ROWS":"0"}}"
2017-05-27 11:26:53,497 [DEBUG] wire:63 - << "HTTP/1.1 200 OK[\r][\n]"
2017-05-27 11:26:53,497 [DEBUG] wire:63 - << "Server: Apache-Coyote/1.1[\r][\n]"
2017-05-27 11:26:53,498 [DEBUG] wire:63 - << "Content-Type: application/json;charset=UTF-8[\r][\n]"
2017-05-27 11:26:53,498 [DEBUG] wire:63 - << "Content-Length: 570[\r][\n]"
2017-05-27 11:26:53,498 [DEBUG] wire:63 - << "Date: Sat, 27 May 2017 03:26:08 GMT[\r][\n]"
2017-05-27 11:26:53,498 [DEBUG] wire:63 - << "[\r][\n]"
2017-05-27 11:26:53,498 [DEBUG] DefaultClientConnection:254 - Receiving response: HTTP/1.1 200 OK
2017-05-27 11:26:53,498 [DEBUG] headers:257 - << HTTP/1.1 200 OK
2017-05-27 11:26:53,499 [DEBUG] headers:260 - << Server: Apache-Coyote/1.1
2017-05-27 11:26:53,499 [DEBUG] headers:260 - << Content-Type: application/json;charset=UTF-8
2017-05-27 11:26:53,499 [DEBUG] headers:260 - << Content-Length: 570
2017-05-27 11:26:53,499 [DEBUG] headers:260 - << Date: Sat, 27 May 2017 03:26:08 GMT
2017-05-27 11:26:53,499 [DEBUG] DefaultHttpClient:543 - Connection can be kept alive indefinitely
2017-05-27 11:26:53,505 [DEBUG] wire:77 - << "{"columnMetas":[{"isNullable":0,"displaySize":10,"label":"EXPR$0","name":"EXPR$0","schemaName":null,"catelogName":null,"tableName":null,"precision":10,"scale":0,"columnType":4,"columnTypeName":"INTEGER","writable":false,"autoIncrement":false,"caseSensitive":true,"currency":false,"definitelyWritable":false,"searchable":false,"signed":true,"readOnly":true}],"results":[["1"]],"cube":"","affectedRowCount":0,"isException":false,"exceptionMessage":null,"duration":25,"totalScanCount":0,"totalScanBytes":0,"hitExceptionCache":false,"storageCacheUsed":false,"partial":false}"
2017-05-27 11:26:53,543 [DEBUG] BasicClientConnectionManager:201 - Releasing connection org.apache.kylin.jdbc.shaded.org.apache.http.impl.conn.ManagedClientConnectionImpl@3f156935
2017-05-27 11:26:53,543 [DEBUG] BasicClientConnectionManager:228 - Connection can be kept alive indefinitely
2017-05-27 11:26:53,563 [DEBUG] KylinClient:369 - Post body:
 {"sql":"select 1","project":"jlkBigData","acceptPartial":false,"backdoorToggles":{"ATTR_STATEMENT_MAX_ROWS":"0"}}
2017-05-27 11:26:53,563 [DEBUG] BasicClientConnectionManager:159 - Get connection for route {}->http://172.168.1.111:7070
2017-05-27 11:26:53,564 [DEBUG] DefaultHttpClient:465 - Stale connection check
2017-05-27 11:26:53,565 [DEBUG] RequestAddCookies:132 - CookieSpec selected: best-match
2017-05-27 11:26:53,565 [DEBUG] RequestAddCookies:184 - Cookie [version: 0][name: JSESSIONID][value: BAF3610449277DA68C4008D43F41F5C5][domain: 172.168.1.111][path: /kylin/][expiry: null] match [172.168.1.111:7070/kylin/api/query]
2017-05-27 11:26:53,565 [DEBUG] RequestAuthCache:78 - Auth cache not set in the context
2017-05-27 11:26:53,566 [DEBUG] RequestProxyAuthentication:87 - Proxy auth state: UNCHALLENGED
2017-05-27 11:26:53,566 [DEBUG] DefaultHttpClient:713 - Attempt 1 to execute request
2017-05-27 11:26:53,566 [DEBUG] DefaultClientConnection:269 - Sending request: POST /kylin/api/query HTTP/1.1
2017-05-27 11:26:53,566 [DEBUG] wire:63 - >> "POST /kylin/api/query HTTP/1.1[\r][\n]"
2017-05-27 11:26:53,567 [DEBUG] wire:63 - >> "Accept: application/json, text/plain, */*[\r][\n]"
2017-05-27 11:26:53,567 [DEBUG] wire:63 - >> "Content-Type: application/json[\r][\n]"
2017-05-27 11:26:53,567 [DEBUG] wire:63 - >> "Authorization: Basic QURNSU46S1lMSU4=[\r][\n]"
2017-05-27 11:26:53,567 [DEBUG] wire:63 - >> "Content-Length: 113[\r][\n]"
2017-05-27 11:26:53,568 [DEBUG] wire:63 - >> "Host: 172.168.1.111:7070[\r][\n]"
2017-05-27 11:26:53,568 [DEBUG] wire:63 - >> "Connection: Keep-Alive[\r][\n]"
2017-05-27 11:26:53,569 [DEBUG] wire:63 - >> "User-Agent: Apache-HttpClient/4.2.5 (java 1.5)[\r][\n]"
2017-05-27 11:26:53,569 [DEBUG] wire:63 - >> "Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5[\r][\n]"
2017-05-27 11:26:53,569 [DEBUG] wire:63 - >> "Cookie2: $Version=1[\r][\n]"
2017-05-27 11:26:53,569 [DEBUG] wire:63 - >> "[\r][\n]"
2017-05-27 11:26:53,569 [DEBUG] headers:273 - >> POST /kylin/api/query HTTP/1.1
2017-05-27 11:26:53,569 [DEBUG] headers:276 - >> Accept: application/json, text/plain, */*
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Content-Type: application/json
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Authorization: Basic QURNSU46S1lMSU4=
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Content-Length: 113
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Host: 172.168.1.111:7070
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Connection: Keep-Alive
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> User-Agent: Apache-HttpClient/4.2.5 (java 1.5)
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Cookie: JSESSIONID=BAF3610449277DA68C4008D43F41F5C5
2017-05-27 11:26:53,570 [DEBUG] headers:276 - >> Cookie2: $Version=1
2017-05-27 11:26:53,570 [DEBUG] wire:77 - >> "{"sql":"select 1","project":"jlkBigData","acceptPartial":false,"backdoorToggles":{"ATTR_STATEMENT_MAX_ROWS":"0"}}"
2017-05-27 11:26:53,580 [DEBUG] wire:63 - << "HTTP/1.1 200 OK[\r][\n]"
2017-05-27 11:26:53,581 [DEBUG] wire:63 - << "Server: Apache-Coyote/1.1[\r][\n]"
2017-05-27 11:26:53,581 [DEBUG] wire:63 - << "Content-Type: application/json;charset=UTF-8[\r][\n]"
2017-05-27 11:26:53,581 [DEBUG] wire:63 - << "Content-Length: 569[\r][\n]"
2017-05-27 11:26:53,582 [DEBUG] wire:63 - << "Date: Sat, 27 May 2017 03:26:08 GMT[\r][\n]"
2017-05-27 11:26:53,582 [DEBUG] wire:63 - << "[\r][\n]"
2017-05-27 11:26:53,582 [DEBUG] DefaultClientConnection:254 - Receiving response: HTTP/1.1 200 OK
2017-05-27 11:26:53,582 [DEBUG] headers:257 - << HTTP/1.1 200 OK
2017-05-27 11:26:53,582 [DEBUG] headers:260 - << Server: Apache-Coyote/1.1
2017-05-27 11:26:53,583 [DEBUG] headers:260 - << Content-Type: application/json;charset=UTF-8
2017-05-27 11:26:53,583 [DEBUG] headers:260 - << Content-Length: 569
2017-05-27 11:26:53,583 [DEBUG] headers:260 - << Date: Sat, 27 May 2017 03:26:08 GMT
2017-05-27 11:26:53,583 [DEBUG] DefaultHttpClient:543 - Connection can be kept alive indefinitely
2017-05-27 11:26:53,584 [DEBUG] wire:77 - << "{"columnMetas":[{"isNullable":0,"displaySize":10,"label":"EXPR$0","name":"EXPR$0","schemaName":null,"catelogName":null,"tableName":null,"precision":10,"scale":0,"columnType":4,"columnTypeName":"INTEGER","writable":false,"autoIncrement":false,"caseSensitive":true,"currency":false,"definitelyWritable":false,"searchable":false,"signed":true,"readOnly":true}],"results":[["1"]],"cube":"","affectedRowCount":0,"isException":false,"exceptionMessage":null,"duration":2,"totalScanCount":0,"totalScanBytes":0,"hitExceptionCache":false,"storageCacheUsed":false,"partial":false}"
2017-05-27 11:26:53,584 [DEBUG] BasicClientConnectionManager:201 - Releasing connection org.apache.kylin.jdbc.shaded.org.apache.http.impl.conn.ManagedClientConnectionImpl@6adede5
2017-05-27 11:26:53,584 [DEBUG] BasicClientConnectionManager:228 - Connection can be kept alive indefinitely
2017-05-27 11:26:53,591 [INFO ] DruidDataSource:1561 - {dataSource-1} closed
```