### PR TITLE
Update LogFactory.java

### DIFF
--- a/src/main/java/com/alibaba/druid/support/logging/LogFactory.java
+++ b/src/main/java/com/alibaba/druid/support/logging/LogFactory.java
@@ -38,13 +38,8 @@ public class LogFactory {
                 tryImplementation("java.util.logging.Logger", "com.alibaba.druid.support.logging.Jdk14LoggingImpl");
             }
         }
-        // 优先选择log4j,而非Apache Common Logging. 因为后者无法设置真实Log调用者的信息
-        tryImplementation("org.apache.log4j.Logger", "com.alibaba.druid.support.logging.Log4jImpl");
-        tryImplementation("org.apache.logging.log4j.Logger", "com.alibaba.druid.support.logging.Log4j2Impl");
+        // 选择slf4j,接口编程，使用方更加灵活。
         tryImplementation("org.slf4j.Logger", "com.alibaba.druid.support.logging.SLF4JImpl");
-        tryImplementation("org.apache.commons.logging.LogFactory",
-                          "com.alibaba.druid.support.logging.JakartaCommonsLoggingImpl");
-        tryImplementation("java.util.logging.Logger", "com.alibaba.druid.support.logging.Jdk14LoggingImpl");
 
         if (logConstructor == null) {
             try {


### PR DESCRIPTION
项目中如果不指定druid.logType属性，那么原有的逻辑会使用log4j打印日志。但是如果这时候使用方用的不是log4j，那么就会报以下警告：
参考：https://github.com/alibaba/druid/issues/1422
这里直接使用slf4j,具体实现交给用户。