### PR TITLE
修正DruidDataSource#recycle 因Thread被interrupted时无法close的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -36,7 +36,6 @@ import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -1422,7 +1421,15 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
 
             boolean result;
             final long lastActiveTimeMillis = System.currentTimeMillis();
-            lock.lockInterruptibly();
+            lock.lock();
+//            ====== begin =======
+//            lockInterruptibly的实现有如下问题:
+//            会导致当前线程被Interrupt时,holder无法正常被回收
+//            因此改成 lock.lock();
+//            comment by wubiliang(未立)
+//            原来的代码是
+//            lock.lockInterruptibly();
+//          ====== end =======
             try {
                 activeCount--;
                 closeCount++;


### PR DESCRIPTION
当应用程序调用conn.close 的时候
假如当前线程被 interrupted
则 druid 无法正确回收 conn

根本原因是recycle  原来的 lock.lockInterruptibly() 写法
应该改成lock.lock();
