### PR TITLE
SQLBinaryExpr计算值有误

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryExpr.java
@@ -18,7 +18,7 @@ package com.alibaba.druid.sql.ast.expr;
 import com.alibaba.druid.sql.ast.SQLExprImpl;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
-public class SQLBinaryExpr extends SQLExprImpl implements SQLLiteralExpr, SQLValuableExpr {
+public class SQLBinaryExpr extends SQLExprImpl implements SQLLiteralExpr {
 
     private String value;
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -584,11 +584,11 @@ public class SQLEvalVisitorUtils {
         String text = x.getValue();
 
         long[] words = new long[text.length() / 64 + 1];
-        for (int i = 0; i < text.length(); ++i) {
+        for (int i = text.length()-1; i >= 0 ; --i) {
             char ch = text.charAt(i);
             if (ch == '1') {
                 int wordIndex = i >> 6;
-                words[wordIndex] |= (1L << i);
+                words[wordIndex] |= (1L << (text.length() - 1 - i));
             }
         }
 
@@ -600,7 +600,7 @@ public class SQLEvalVisitorUtils {
             byte[] bytes = new byte[words.length * 8];
 
             for (int i = 0; i < words.length; ++i) {
-                Utils.putLong(bytes, i * 8, words[i]);
+                Utils.putLong(bytes, (words.length-1-i) * 8, words[i]);
             }
 
             val = new BigInteger(bytes);

--- a/src/test/java/com/alibaba/druid/bvt/sql/eval/SQLEvalVisitorUtilsTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/eval/SQLEvalVisitorUtilsTest.java
@@ -1,14 +1,15 @@
 package com.alibaba.druid.bvt.sql.eval;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Arrays;
-
-import org.junit.Assert;
-import junit.framework.TestCase;
-
+import com.alibaba.druid.sql.ast.expr.SQLBinaryExpr;
 import com.alibaba.druid.sql.visitor.SQLEvalVisitorUtils;
 import com.alibaba.druid.util.JdbcUtils;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class SQLEvalVisitorUtilsTest extends TestCase {
 
@@ -167,5 +168,13 @@ public class SQLEvalVisitorUtilsTest extends TestCase {
                             SQLEvalVisitorUtils.evalExpr(JdbcUtils.MYSQL, "? >= ?", Arrays.<Object> asList(2, 3)));
         Assert.assertEquals(true, SQLEvalVisitorUtils.evalExpr(JdbcUtils.MYSQL, "? >= ?", Arrays.<Object> asList(3, 3)));
         Assert.assertEquals(true, SQLEvalVisitorUtils.evalExpr(JdbcUtils.MYSQL, "? >= ?", Arrays.<Object> asList(4, 3)));
+    }
+
+    public void test_binary() throws Exception {
+        Assert.assertEquals(1L, SQLEvalVisitorUtils.eval(JdbcUtils.MYSQL, new SQLBinaryExpr("01"), new ArrayList<Object>()));
+        Assert.assertEquals(2L, SQLEvalVisitorUtils.eval(JdbcUtils.MYSQL, new SQLBinaryExpr("10"), new ArrayList<Object>()));
+        Assert.assertEquals(3L, SQLEvalVisitorUtils.eval(JdbcUtils.MYSQL, new SQLBinaryExpr("11"), new ArrayList<Object>()));
+        Assert.assertEquals(4L, SQLEvalVisitorUtils.eval(JdbcUtils.MYSQL, new SQLBinaryExpr("100"), new ArrayList<Object>()));
+        Assert.assertEquals(new BigInteger("36893488147419103231"), SQLEvalVisitorUtils.eval(JdbcUtils.MYSQL, new SQLBinaryExpr("11111111111111111111111111111111111111111111111111111111111111111"), new ArrayList<Object>()));
     }
 }


### PR DESCRIPTION
SQLBinaryExpr的eval计算值有误 
master分支中b'01'  计算结果为string类型的 01
之前分支中b'01' 计算结果为long类型 的2 