### PR TITLE
fix bug:LOCK TABLES table_name write 在mysql防火墙校验的时候会过不了校验

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -597,10 +597,12 @@ public class MySqlStatementParser extends SQLStatementParser {
                     stmt.setLockType(LockType.READ);
                 }
             } else if (lexer.identifierEquals(WRITE)) {
+                lexer.nextToken();
                 stmt.setLockType(LockType.WRITE);
             } else if (lexer.identifierEquals(FnvHash.Constants.LOW_PRIORITY)) {
                 lexer.nextToken();
                 acceptIdentifier(WRITE);
+                lexer.nextToken();
                 stmt.setLockType(LockType.LOW_PRIORITY_WRITE);
             } else {
                 throw new ParserException("syntax error, expect READ or WRITE, actual " + lexer.token() + ", " + lexer.info());

--- a/src/test/java/com/alibaba/druid/test/wall/MySqlResourceWallTest.java
+++ b/src/test/java/com/alibaba/druid/test/wall/MySqlResourceWallTest.java
@@ -104,6 +104,24 @@ public class MySqlResourceWallTest extends TestCase {
         Assert.assertTrue(provider.checkValid(sql));
 
 
+        sql = "lock table dsdfsdf read";
+        result = provider.check(sql);
+        if (result.getViolations().size() > 0) {
+            Violation violation = result.getViolations().get(0);
+            System.out.println("error () : " + violation.getMessage());
+        }
+        Assert.assertTrue(provider.checkValid(sql));
+
+
+        sql = "lock table dsdfsdf read local";
+        result = provider.check(sql);
+        if (result.getViolations().size() > 0) {
+            Violation violation = result.getViolations().get(0);
+            System.out.println("error () : " + violation.getMessage());
+        }
+        Assert.assertTrue(provider.checkValid(sql));
+
+
     }
 
 }

--- a/src/test/java/com/alibaba/druid/test/wall/MySqlResourceWallTest.java
+++ b/src/test/java/com/alibaba/druid/test/wall/MySqlResourceWallTest.java
@@ -25,25 +25,19 @@ import com.alibaba.druid.wall.Violation;
 import com.alibaba.druid.wall.WallCheckResult;
 import com.alibaba.druid.wall.WallProvider;
 import com.alibaba.druid.wall.spi.MySqlWallProvider;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class MySqlResourceWallTest extends TestCase {
 
     private String[] items;
 
-    protected void setUp() throws Exception {
-//        File file = new File("/home/wenshao/error_sql");
-        File file = new File("/home/wenshao/scan_result");
-        FileInputStream is = new FileInputStream(file);
-        String text = Utils.read(is);
-        is.close();
-        items = text.split("\\|\\n\\|");
-    }
 
     public void test_false() throws Exception {
         WallProvider provider = new MySqlWallProvider();
-        
+
         provider.getConfig().setConditionDoubleConstAllow(true);
-        
+
         provider.getConfig().setUseAllow(true);
         provider.getConfig().setStrictSyntaxCheck(false);
         provider.getConfig().setMultiStatementAllow(true);
@@ -74,6 +68,42 @@ public class MySqlResourceWallTest extends TestCase {
 //        String sql = "SELECT name, '******' password, createTime from user where name like 'admin' AND (CASE WHEN (7885=7885) THEN 1 ELSE 0 END)";
 
 //        Assert.assertFalse(provider.checkValid(sql));
+    }
+
+
+
+    @Test
+    public void test_lock_table() throws Exception {
+        WallProvider provider = new MySqlWallProvider();
+        provider.getConfig().setNoneBaseStatementAllow(true);
+
+        String sql = "lock tables etstsun write";
+        WallCheckResult result = provider.check(sql);
+        if (result.getViolations().size() > 0) {
+            Violation violation = result.getViolations().get(0);
+            System.out.println("error () : " + violation.getMessage());
+        }
+        Assert.assertTrue(provider.checkValid(sql));
+
+
+        sql = "lock tables etstsun LOW_PRIORITY write";
+        result = provider.check(sql);
+        if (result.getViolations().size() > 0) {
+            Violation violation = result.getViolations().get(0);
+            System.out.println("error () : " + violation.getMessage());
+        }
+        Assert.assertTrue(provider.checkValid(sql));
+
+
+        sql = "UNLOCK TABLES";
+        result = provider.check(sql);
+        if (result.getViolations().size() > 0) {
+            Violation violation = result.getViolations().get(0);
+            System.out.println("error () : " + violation.getMessage());
+        }
+        Assert.assertTrue(provider.checkValid(sql));
+
+
     }
 
 }


### PR DESCRIPTION
详情见https://github.com/alibaba/druid/issues/2000   
在druid进行防火墙校验SQL的时候LOCK TABLES table_name write 无法正常通过验证