### PR TITLE
#2053 add support of 'show tables in db_name ....'

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -1626,7 +1626,7 @@ public class MySqlStatementParser extends SQLStatementParser {
     private SQLShowTablesStatement parseShowTabless() {
         SQLShowTablesStatement stmt = new SQLShowTablesStatement();
 
-        if (lexer.token() == Token.FROM) {
+        if (lexer.token() == Token.FROM || lexer.token() == Token.IN) {
             lexer.nextToken();
             SQLName database = exprParser.name();
             if (lexer.token() == Token.SUB && database instanceof SQLIdentifierExpr) {


### PR DESCRIPTION
 SHOW TABLES Syntax:  
SHOW [FULL] TABLES
  [{FROM | IN} db_name]
  [LIKE 'pattern' | WHERE expr]  
In lastest version  'show tables in db_name ....' not supported