### PR TITLE
 #2055 change the function to parse the sql in the right of '~'

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -628,7 +628,7 @@ public class SQLExprParser extends SQLParser {
                 break;
             case TILDE:
                 lexer.nextToken();
-                SQLExpr unaryValueExpr = expr();
+                SQLExpr unaryValueExpr = primary();
                 SQLUnaryExpr unary = new SQLUnaryExpr(SQLUnaryOperator.Compl, unaryValueExpr);
                 sqlExpr = unary;
                 break;


### PR DESCRIPTION
Reason:  
  We find is not right to parse the sql ‘ ~ (id = 1)' & ‘ ~ id = 1'
Type :  
  Bug fix
Influences：
  Change the function to parse the sql right behind the '~'