### PR TITLE
Druid连接池初始化时支持对驱动类遍历处理，避免ExceptionSorter空的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1175,28 +1175,37 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
             return;
         }
 
-        String realDriverClassName = driver.getClass().getName();
-        if (realDriverClassName.equals(JdbcConstants.MYSQL_DRIVER) //
-            || realDriverClassName.equals(JdbcConstants.MYSQL_DRIVER_6)) {
-            this.exceptionSorter = new MySqlExceptionSorter();
-        } else if (realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER)
-                || realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER2)) {
-            this.exceptionSorter = new OracleExceptionSorter();
-        } else if (realDriverClassName.equals("com.informix.jdbc.IfxDriver")) {
-            this.exceptionSorter = new InformixExceptionSorter();
+        Class driverTemp = driver.getClass();
+        do {
+            String realDriverClassName = driverTemp.getName();
+            if (realDriverClassName.equals(JdbcConstants.MYSQL_DRIVER) //
+                    || realDriverClassName.equals(JdbcConstants.MYSQL_DRIVER_6)) {
+                this.exceptionSorter = new MySqlExceptionSorter();
+            } else if (realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER)
+                    || realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER2)) {
+                this.exceptionSorter = new OracleExceptionSorter();
+            } else if (realDriverClassName.equals("com.informix.jdbc.IfxDriver")) {
+                this.exceptionSorter = new InformixExceptionSorter();
 
-        } else if (realDriverClassName.equals("com.sybase.jdbc2.jdbc.SybDriver")) {
-            this.exceptionSorter = new SybaseExceptionSorter();
+            } else if (realDriverClassName.equals("com.sybase.jdbc2.jdbc.SybDriver")) {
+                this.exceptionSorter = new SybaseExceptionSorter();
 
-        } else if (realDriverClassName.equals(JdbcConstants.POSTGRESQL_DRIVER)
-                || realDriverClassName.equals(JdbcConstants.ENTERPRISEDB_DRIVER)) {
-            this.exceptionSorter = new PGExceptionSorter();
+            } else if (realDriverClassName.equals(JdbcConstants.POSTGRESQL_DRIVER)
+                    || realDriverClassName.equals(JdbcConstants.ENTERPRISEDB_DRIVER)) {
+                this.exceptionSorter = new PGExceptionSorter();
 
-        } else if (realDriverClassName.equals("com.alibaba.druid.mock.MockDriver")) {
-            this.exceptionSorter = new MockExceptionSorter();
-        } else if (realDriverClassName.contains("DB2")) {
-            this.exceptionSorter = new DB2ExceptionSorter();
-        }
+            } else if (realDriverClassName.equals("com.alibaba.druid.mock.MockDriver")) {
+                this.exceptionSorter = new MockExceptionSorter();
+            } else if (realDriverClassName.contains("DB2")) {
+                this.exceptionSorter = new DB2ExceptionSorter();
+            } else if (realDriverClassName.equals("com.taobao.tddl.driver")) {
+                this.exceptionSorter = new MySqlExceptionSorter();
+            }
+            if (this.exceptionSorter != null) {
+                break;
+            }
+        } while ( (driverTemp = driverTemp.getSuperclass() ) != Object.class);
+
     }
 
     @Override

--- a/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest_exceptionSorter_extend.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest_exceptionSorter_extend.java
@@ -1,0 +1,101 @@
+package com.alibaba.druid.bvt.pool;
+
+import com.alibaba.druid.mock.MockDriver;
+import com.alibaba.druid.mock.MockStatementBase;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.ExceptionSorter;
+import com.alibaba.druid.pool.vendor.MySqlExceptionSorter;
+import com.mysql.jdbc.Driver;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * 这个场景测试exceptionSorter_extend
+ * 
+ * @author xiaoying [caohongxi001@gmail.com]
+ */
+public class DruidDataSourceTest_exceptionSorter_extend extends TestCase {
+
+    public static class SubDriver extends com.mysql.jdbc.Driver{
+
+        /**
+         * Construct a new driver and register it with DriverManager
+         *
+         * @throws SQLException if a database error occurs.
+         */
+        public SubDriver() throws SQLException {
+        }
+    }
+    public static class SubDriver1 implements java.sql.Driver{
+
+        /**
+         * Construct a new driver and register it with DriverManager
+         *
+         * @throws SQLException if a database error occurs.
+         */
+        public SubDriver1() throws SQLException {
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) throws SQLException {
+            return false;
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 0;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return null;
+        }
+    }
+
+    /**
+     * 测试继承自com.mysql.jdbc.Driver的子类可以设置sorter
+     * @throws Exception
+     */
+    public void testExceptionSorter() throws Exception {
+        DruidDataSource dataSource1 = new DruidDataSource();
+        dataSource1.setDriverClassName(SubDriver.class.getName());
+        dataSource1.init();
+        Assert.assertNotNull(dataSource1.getExceptionSorter());
+        Assert.assertEquals(MySqlExceptionSorter.class.getName(), dataSource1.getExceptionSorter().getClass().getName());
+    }
+
+    /**
+     * 测试实现自java.sql.Driver的类未设置sorter
+     * @throws Exception
+     */
+    public void testExceptionSorterNull() throws Exception {
+        DruidDataSource dataSource1 = new DruidDataSource();
+        dataSource1.setDriverClassName(SubDriver1.class.getName());
+        dataSource1.init();
+        Assert.assertEquals("sorter is not null",null,dataSource1.getExceptionSorter());
+    }
+}


### PR DESCRIPTION
1. 问题说明：
  - 当Driver类如果是用户自定义实现时，由于内部equals判断导致exceptionSorter为空
  - 此问题会导致错误的连接被返回到连接池，从而引不期望的错误
2. 问题Fixed：
   - 遍历驱动类，与期望驱动类比较，通过此方式来设置exceptionSorter
3. request代码
  - 类路径：
     - 修改类： com.alibaba.druid.pool.DruidDataSource
     - 测试类： com.alibaba.druid.bvt.pool.DruidDataSourceTest_exceptionSorter_extend