### PR TITLE
work out the parse of create table that contains 'algorithm=2' in partiton or subpartition

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlPartitionByKey.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlPartitionByKey.java
@@ -26,7 +26,16 @@ import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class MySqlPartitionByKey extends SQLPartitionBy implements MySqlObject {
+    private short algorithm = 2;
 
+    public short getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(short algorithm) {
+        this.algorithm = algorithm;
+    }
+    
     @Override
     protected void accept0(SQLASTVisitor visitor) {
         if (visitor instanceof MySqlASTVisitor) {
@@ -54,6 +63,7 @@ public class MySqlPartitionByKey extends SQLPartitionBy implements MySqlObject {
             c2.setParent(x);
             x.columns.add(c2);
         }
+	x.setAlgorithm(algorithm);
     }
 
     public MySqlPartitionByKey clone() {

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlSubPartitionByKey.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlSubPartitionByKey.java
@@ -27,6 +27,15 @@ import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 public class MySqlSubPartitionByKey extends SQLSubPartitionBy implements MySqlObject {
 
     private List<SQLName> columns = new ArrayList<SQLName>();
+    private short algorithm = 2;
+
+    public short getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(short algorithm) {
+        this.algorithm = algorithm;
+    }
 
     @Override
     protected void accept0(SQLASTVisitor visitor) {
@@ -64,6 +73,7 @@ public class MySqlSubPartitionByKey extends SQLSubPartitionBy implements MySqlOb
             c2.setParent(x);
             x.columns.add(c2);
         }
+	x.setAlgorithm(algorithm);
     }
 
     public MySqlSubPartitionByKey clone() {

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -454,6 +454,13 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                         clause.setLinear(true);
                     }
 
+                    if (lexer.token() == Token.ALGORITHM) {
+                        lexer.nextToken();
+                        accept(Token.EQ);
+                        clause.setAlgorithm(lexer.integerValue().shortValue());
+                        lexer.nextToken();
+                    }
+
                     accept(Token.LPAREN);
                     if (lexer.token() != Token.RPAREN) {
                         for (;;) {
@@ -633,6 +640,13 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
 
                 if (linear) {
                     clause.setLinear(true);
+                }
+
+                if (lexer.token() == Token.ALGORITHM) {
+                    lexer.nextToken();
+                    accept(Token.EQ);
+                    subPartitionKey.setAlgorithm(lexer.integerValue().shortValue());
+                    lexer.nextToken();
                 }
 
                 accept(Token.LPAREN);

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
@@ -35,6 +35,7 @@ public class MySqlLexer extends Lexer {
 
         map.putAll(Keywords.DEFAULT_KEYWORDS.getKeywords());
 
+	map.put("ALGORITHM", Token.ALGORITHM);
         map.put("DUAL", Token.DUAL);
         map.put("FALSE", Token.FALSE);
         map.put("IDENTIFIED", Token.IDENTIFIED);

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -125,6 +125,7 @@ public enum Token {
     KILL("KILL"),
     IDENTIFIED("IDENTIFIED"),
     PASSWORD("PASSWORD"),
+    ALGORITHM("ALGORITHM"),
     DUAL("DUAL"),
     BINARY("BINARY"),
     SHOW("SHOW"),

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest91.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest91.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.mysql.createTable;
+
+import java.util.List;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.stat.TableStat.Column;
+
+public class MySqlCreateTableTest91 extends MysqlTest {
+
+    public void test_0() throws Exception {
+        String sql = "CREATE TABLE tbl_name(id int, sid int, name varchar(8)) " + //
+	    "PARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) PARTITIONS 4 (PARTITION p0, PARTITION p1, PARTITION p2, PARTITION p3)";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statemen = statementList.get(0);
+
+        Assert.assertEquals(1, statementList.size());
+    }
+
+    public void test_1() throws Exception {
+        String sql = "CREATE TABLE tbl_name(id int, sid int, name varchar(8)) " + //
+	    "PARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) PARTITIONS 4 " + //
+	    "SUBPARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) SUBPARTITIONS 2 " + //
+	    "(PARTITION p0 (SUBPARTITION s0, SUBPARTITION s1), " + //
+	    "PARTITION p1 (SUBPARTITION s0, SUBPARTITION s1), " + //
+	    "PARTITION p2 (SUBPARTITION s0, SUBPARTITION s1), " + //
+	    "PARTITION p3 (SUBPARTITION s0, SUBPARTITION s1))";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statemen = statementList.get(0);
+
+        Assert.assertEquals(1, statementList.size());
+    }
+}


### PR DESCRIPTION
At the moment, druid can't parse the statments as follows:

CREATE TABLE tbl_name(id int, sid int, name varchar(8))  
PARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) 
PARTITIONS 4
 (PARTITION p0, PARTITION p1, PARTITION p2, PARTITION p3)

CREATE TABLE tbl_name(id int, sid int, name varchar(8)) 
PARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) 
PARTITIONS 4 
SUBPARTITION BY LINEAR KEY ALGORITHM=2 (id, sid) 
SUBPARTITIONS 2 
(PARTITION p0 (SUBPARTITION s0, SUBPARTITION s1), 
PARTITION p1 (SUBPARTITION s0, SUBPARTITION s1), 
PARTITION p2 (SUBPARTITION s0, SUBPARTITION s1), 
PARTITION p3 (SUBPARTITION s0, SUBPARTITION s1))

This is due to the "ALGORITHM=2" part. We can skip it,  and don't interfere with anything else.