### PR TITLE
Oracle驱动问题优化

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1134,7 +1134,8 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         }
 
         if (JdbcConstants.ORACLE_DRIVER2.equalsIgnoreCase(driverClass)) {
-            LOG.error("oracle.jdbc.driver.OracleDriver is deprecated.");
+            driverClass = "oracle.jdbc.OracleDriver";
+            LOG.warn("oracle.jdbc.driver.OracleDriver is deprecated.Having use oracle.jdbc.OracleDriver.");
         }
 
         if (inited) {


### PR DESCRIPTION
如果是oracle.jdbc.driver.OracleDriver驱动，替换为oracle.jdbc.OracleDriver，并wran，使用error容易让人误解。
原来是如果使用了过时的驱动，然后提示error,并继续使用过时的驱动，
现修改为如果使用了过时的驱动，提示warn,说明已改为新版的驱动。