### PR TITLE
add druid sql parser support  for XMLSERIALIZE  on oracle and db2

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLMethodInvokeExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLMethodInvokeExpr.java
@@ -126,6 +126,11 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
 
         buf.append(this.name);
         buf.append("(");
+        
+        if(  this.content != null ){
+        	this.content.output(buf);
+        	buf.append(' ');
+        }
         for (int i = 0, size = this.parameters.size(); i < size; ++i) {
             if (i != 0) {
                 buf.append(", ");
@@ -133,17 +138,23 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
 
             this.parameters.get(i).output(buf);
         }
+        if( this.as != null){
+        	buf.append(' ');
+        	this.as.output(buf);
+        }
         buf.append(")");
     }
 
     @Override
     protected void accept0(SQLASTVisitor visitor) {
         if (visitor.visit(this)) {
+        	acceptChild(visitor, this.content);
             acceptChild(visitor, this.owner);
             acceptChild(visitor, this.parameters);
             acceptChild(visitor, this.from);
             acceptChild(visitor, this.using);
             acceptChild(visitor, this._for);
+            acceptChild(visitor, this.as);
         }
 
         visitor.endVisit(this);
@@ -162,11 +173,13 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
 
     protected void accept0(OracleASTVisitor visitor) {
         if (visitor.visit(this)) {
+            acceptChild(visitor, this.content);
             acceptChild(visitor, this.owner);
             acceptChild(visitor, this.parameters);
             acceptChild(visitor, this.from);
             acceptChild(visitor, this.using);
             acceptChild(visitor, this._for);
+            acceptChild(visitor, this.as);
         }
 
         visitor.endVisit(this);
@@ -181,7 +194,10 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
 
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
+        if (content != null ? !content.equals(that.content) : that.content != null) return false;
         if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
+        if (as != null ? !as.equals(that.as) : that.as != null) return false;
+        
         return from != null ? from.equals(that.from) : that.from == null;
 
     }
@@ -190,8 +206,10 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (owner != null ? owner.hashCode() : 0);
+        result = 31 * result + (content != null ? content.hashCode() : 0);
         result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
         result = 31 * result + (from != null ? from.hashCode() : 0);
+        result = 31 * result + (as != null ? as.hashCode() : 0);
         return result;
     }
 
@@ -203,7 +221,10 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
         if (owner != null) {
             x.setOwner(owner.clone());
         }
-
+        
+        if( content != null ){
+        	x.setContent(content);
+        }
         for (SQLExpr param : parameters) {
             x.addParameter(param.clone());
         }
@@ -215,7 +236,9 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
         if (using != null) {
             x.setUsing(using.clone());
         }
-
+        if (as  != null) {
+        	x.setAs(as);
+        }
         return x;
     }
 
@@ -329,4 +352,29 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
     public void setTrimOption(String trimOption) {
         this.trimOption = trimOption;
     }
+    
+    private SQLExpr             as;
+    private SQLExpr     content;
+    
+	public SQLExpr getAs() {
+		return as;
+	}
+
+	public void setAs(SQLExpr x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+        this.as = x;
+     }
+
+	public SQLExpr getContent() {
+		return content;
+	}
+
+	public void setContent(SQLExpr x) {
+	    if (x != null) {
+            x.setParent(this);
+        }
+        this.content = x;
+	}
 }

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -1062,6 +1062,10 @@ public class SQLExprParser extends SQLParser {
         }
 
         Token token = lexer.token;
+        if( "XMLSERIALIZE".equals(methodName) && lexer.identifierEquals("CONTENT")) {
+        	  SQLExpr contentExpr = expr();
+        	  methodInvokeExpr.setContent(contentExpr);
+        }
         if (token != Token.RPAREN && token != Token.FROM) {
             exprList(methodInvokeExpr.getParameters(), methodInvokeExpr);
         }
@@ -1098,6 +1102,12 @@ public class SQLExprParser extends SQLParser {
             }
             methodInvokeExpr.setUsing(using);
         }
+         if (lexer.token == Token.AS || lexer.identifierEquals(FnvHash.Constants.AS)) {
+        	lexer.nextToken();
+            SQLExpr as;
+             as = this.primary();
+            methodInvokeExpr.setAs(as);
+         }
 
         SQLAggregateExpr aggregateExpr = null;
         if (lexer.token == Token.ORDER) {

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -278,6 +278,9 @@ public class SQLStatementParser extends SQLParser {
                     continue;
                 }
                 case COMMENT: {
+                    if(JdbcConstants.MYSQL.equals(this.dbType)){//mysql 关键字 comment 没有这个语法，oracle才有
+                        return;
+                    }
                     SQLStatement stmt = parseComment();
                     stmt.setParent(parent);
                     statementList.add(stmt);

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -1425,6 +1425,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             }
         }
 
+        final SQLExpr contentExpr = x.getContent();
+        if( contentExpr != null ){
+        	print(contentExpr.toString());
+        	print(' ');
+        }
 
         for (int i = 0, size = parameters.size(); i < size; ++i) {
             if (i != 0) {
@@ -1482,6 +1487,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             printExpr(using);
         }
 
+        final SQLExpr asExpr = x.getAs();
+        if(  asExpr != null ){
+        	print(" as ");
+        	print(asExpr.toString());
+        }
         print(')');
         return false;
     }

--- a/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitor4OracleTestCase.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitor4OracleTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.parser;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
+import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
+
+import junit.framework.TestCase;
+
+public class ExportAndParameterizedVisitor4OracleTestCase extends TestCase {
+
+    public void testParameterizedVisitor() {
+         Object[][] sqlAndExpectedCases = {
+        		{ "SELECT XMLSERIALIZE(CONTENT XMLTYPE('<Owner>Grandco</Owner>') as varchar(200) ) AS xmlserialize_doc   FROM DUAL",1},
+             };
+
+        String[] dbTypes = {  "oracle"};
+       for (String dbType : dbTypes) {
+
+            System.out.println("dbType:"+dbType);
+            for (Object[] arr : sqlAndExpectedCases) {
+
+                final String sql = (String) arr[0];
+                StringBuilder out = new StringBuilder();
+
+                final SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                final ParameterizedVisitor pVisitor = (ParameterizedVisitor) ExportParameterVisitorUtils.createExportParameterVisitor(out, dbType);
+                final SQLStatement parseStatement = parser.parseStatement();
+                parseStatement.accept(pVisitor);
+                // final ExportParameterVisitor vistor2 = new MySqlExportParameterVisitor();
+                // parseStatement.accept(vistor2);
+                final ExportParameterVisitor vistor2 = (ExportParameterVisitor) pVisitor;
+                System.out.println("before:" + sql);
+                System.out.println("after:" + out);
+                System.out.println("size:" + vistor2.getParameters());
+                final int expectedSize = arr.length > 1 ?  (Integer) arr[1] : 0 ;
+                Assert.assertEquals(expectedSize, vistor2.getParameters().size());
+            }
+        }
+    }
+}

--- a/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitor4db2TestCase.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitor4db2TestCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.parser;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
+import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import com.alibaba.druid.util.JdbcUtils;
+
+public class ExportAndParameterizedVisitor4db2TestCase extends TestCase {
+
+    public void testParameterizedVisitor() {
+       
+    	Object[][] sqlAndExpectedCases = {
+        		{ "select  XMLSERIALIZE(content fld1 as varchar(2000) )  fld1 from test_tab1 where name='1'  ",1},
+        		{ "select  XMLSERIALIZE(fld1 as varchar(2000) )  fld1 from test_tab1 where name='1'  ",1},
+        		{ "select  fld as b from test_tab1 where name='1'  ",1},
+             };
+        String[] dbTypes = {  "db2"};
+       for (String dbType : dbTypes) {
+
+            System.out.println("dbType:"+dbType);
+            for (Object[] arr : sqlAndExpectedCases) {
+
+                final String sql = (String) arr[0];
+                StringBuilder out = new StringBuilder();
+
+                final SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                final ParameterizedVisitor pVisitor = (ParameterizedVisitor) ExportParameterVisitorUtils.createExportParameterVisitor(out, dbType);
+                final SQLStatement parseStatement = parser.parseStatement();
+                parseStatement.accept(pVisitor);
+                final ExportParameterVisitor vistor2 = (ExportParameterVisitor) pVisitor;
+                System.out.println("before:" + sql);
+                System.out.println("after:" + out);
+                System.out.println("size:" + vistor2.getParameters());
+                final int expectedSize = arr.length>1 ?  (Integer) arr[1] : 0;
+                Assert.assertEquals(expectedSize, vistor2.getParameters().size());
+            }
+        }
+    }
+}


### PR DESCRIPTION
增加对XMLSERIALIZE 语法的支持
目前仅测试了oracle和db2,对我们自己来说已经够用，但语法可能没完全支持

ref:
* https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/XMLSERIALIZE.html#GUID-F2D5ECE7-3838-4DD5-BE8F-2AEE7890AA1C
* https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/sqlref/src/tpc/db2z_bif_xmlserialize.html