### PR TITLE
fixd for 参数化解析bug: 两个同名字段的where or条件会被合并成一个

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExpr.java
@@ -29,6 +29,7 @@ import com.alibaba.druid.sql.ast.SQLReplaceable;
 import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
 import com.alibaba.druid.util.Utils;
 
 public class SQLBinaryOpExpr extends SQLExprImpl implements SQLReplaceable, Serializable {
@@ -568,7 +569,7 @@ public class SQLBinaryOpExpr extends SQLExprImpl implements SQLReplaceable, Seri
         }
 
         // ID = ? OR ID = ? => ID = ?
-        if (x.operator == SQLBinaryOperator.BooleanOr) {
+        if (x.operator == SQLBinaryOperator.BooleanOr && !v.isEnabled(VisitorFeature.OutputParameterizedQuesUnMergeOr)) {
             if ((x.left instanceof SQLBinaryOpExpr) && (x.right instanceof SQLBinaryOpExpr)) {
                 SQLBinaryOpExpr leftBinary = (SQLBinaryOpExpr) x.left;
                 SQLBinaryOpExpr rightBinary = (SQLBinaryOpExpr) x.right;

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
@@ -84,6 +84,8 @@ import com.alibaba.druid.sql.ast.statement.*;
 
 public interface SQLASTVisitor {
 
+    boolean isEnabled(VisitorFeature feature);
+
     void endVisit(SQLAllColumnExpr x);
 
     void endVisit(SQLBetweenExpr x);

--- a/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitorTestCase.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/ExportAndParameterizedVisitorTestCase.java
@@ -23,41 +23,47 @@ import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
 import com.alibaba.druid.sql.visitor.ExportParameterVisitorUtils;
 import com.alibaba.druid.sql.visitor.ParameterizedVisitor;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
 import com.alibaba.druid.util.JdbcConstants;
 import com.alibaba.druid.util.JdbcUtils;
+import com.google.common.collect.Lists;
 
 public class ExportAndParameterizedVisitorTestCase extends TestCase {
 
     public void testParameterizedVisitor() {
         // final String sql =
         // "insert  into tab01(a,b,c) values('a1','bXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1',5)";
-        Object[][] sqlAndExpectedCases = { { "insert  into tab01(a,b,c) values('a1','b1',5)", 3, "a1" },
+        Object[][] sqlAndExpectedCases = {
+                {"select * from test_tab1 where name='1' or name='3'",2,"1","true"},
+                {"select * from test_tab1 where name='1' or name='3'",1,Lists.newArrayList("1","3"),"false"},
+                { "insert  into tab01(a,b,c) values('a1','b1',5)", 3, "a1" },
                 { "select * from tab01 where a=1 and b='b1'", 2, 1 }, 
                 { "update tab01 set d='d1' where a=1 and b='b1'", 3, "d1" },
-                { "delete from tab01 where a=1 and b='b1'", 2, 1.0 } };
+                { "delete from tab01 where a=1 and b='b1'", 2, 1 } };
 
         String[] dbTypes = { "mysql", "oracle", "db2" ,JdbcConstants.POSTGRESQL,JdbcUtils.JTDS,"not-found"};
-    // String[]  dbTypes = { JdbcUtils.JTDS};
         for (String dbType : dbTypes) {
-
             System.out.println("dbType:"+dbType);
             for (Object[] arr : sqlAndExpectedCases) {
-
                 final String sql = (String) arr[0];
                 StringBuilder out = new StringBuilder();
 
                 final SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
                 final ParameterizedVisitor pVisitor = (ParameterizedVisitor) ExportParameterVisitorUtils.createExportParameterVisitor(out, dbType);
+               if( arr.length > 3) {
+            	   pVisitor.config(VisitorFeature.OutputParameterizedQuesUnMergeOr,"true".equals(arr[3]));
+               }
                 final SQLStatement parseStatement = parser.parseStatement();
                 parseStatement.accept(pVisitor);
-                // final ExportParameterVisitor vistor2 = new MySqlExportParameterVisitor();
-                // parseStatement.accept(vistor2);
                 final ExportParameterVisitor vistor2 = (ExportParameterVisitor) pVisitor;
                 System.out.println("before:" + sql);
                 System.out.println("after:" + out);
-                System.out.println("size:" + vistor2.getParameters());
-                final int expectedSize = (Integer) arr[1];
+                System.out.println("params:" + vistor2.getParameters());
+                final int expectedSize = arr.length>1 ?  (Integer) arr[1] : 0;
                 Assert.assertEquals(expectedSize, vistor2.getParameters().size());
+                if (arr.length > 2) {
+                	Assert.assertEquals(arr[2],vistor2.getParameters().get(0));
+                }
             }
         }
     }


### PR DESCRIPTION
ref: https://github.com/alibaba/druid/issues/1745
 
为了让sql parser兼容SQL标准，本次修复兼容禁用了“同名参数or条件合并"
需要开启的场景，请如一下设置：`pVisitor.config(VisitorFeature.MergeBooleanOr, true);`

本来此处可做的更兼容，即”默认启用同名参数or条件合并“， 但考虑原实现有违SQL标准又没明确说明，
故强制默认禁用之，以防无意给类库使用者识引入bug -- API在设计上应用尽可避免使用者错误使用！！！
