### PR TITLE
解决问题#2809，com.alibaba.druid.spring.boot.autoconfigure.DruidDataSourceWrapper类无public修饰

### DIFF
--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
@@ -34,7 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author lihengming [89921218@qq.com]
  */
 @ConfigurationProperties("spring.datasource.druid")
-class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean {
+public class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean {
     @Autowired
     private DataSourceProperties basicProperties;
 


### PR DESCRIPTION
…SourceWrapper： a non-visible class，not public class

org.springframework.aop.framework.AopConfigException: Could not generate CGLIB subclass of class [class com.alibaba.druid.spring.boot.autoconfigure.DruidDataSourceWrapper]: Common causes of this problem include using a final class or a non-visible class; nested exception is org.springframework.cglib.core.CodeGenerationException: java.lang.reflect.InvocationTargetException-->null