### PR TITLE
modify sessionStatMap is full bug

### DIFF
--- a/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
+++ b/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
@@ -337,6 +337,7 @@ public class WebAppStat {
 
                     if (fullCount == 0) {
                         LOG.error("sessionStatMap is full");
+                        reset();
                     }
                 }
 


### PR DESCRIPTION
 WebSessionStat uriStat = sessionStatMap.get(sessionId);

            if (uriStat == null) {
                if (sessionStatMap.size() >= this.getMaxStatSessionCount()) {
                    long fullCount = uriSessionMapFullCount.getAndIncrement();

                    if (fullCount == 0) {
                        LOG.error("sessionStatMap is full");
                    }
                }

                WebSessionStat newStat = new WebSessionStat(sessionId);

                sessionStatMap.put(sessionId, newStat);

                return newStat;
            }



this sessionStatMap not clear ,add the clear method