### PR TITLE
fix issue https://github.com/alibaba/druid/issues/2859

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/repository/SchemaResolveVisitorFactory.java
+++ b/src/main/java/com/alibaba/druid/sql/repository/SchemaResolveVisitorFactory.java
@@ -2400,7 +2400,7 @@ class SchemaResolveVisitorFactory {
                 checkParameter(visitor, identifierExpr);
 
                 SQLTableSource tableSource = unwrapAlias(visitor.getContext(), null, identifierExpr.nameHashCode64());
-                if (tableSource != null) {
+                if (tableSource != null && (tableSource.getClass() != SQLExprTableSource.class || ((SQLExprTableSource)tableSource).getExpr() != identifierExpr)) {
                     identifierExpr.setResolvedTableSource(tableSource);
                 }
             }

--- a/src/test/java/com/alibaba/druid/mysql/DeleteStackOverflowTest.java
+++ b/src/test/java/com/alibaba/druid/mysql/DeleteStackOverflowTest.java
@@ -1,0 +1,18 @@
+package com.alibaba.druid.mysql;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import junit.framework.TestCase;
+
+public class DeleteStackOverflowTest extends TestCase {
+    public void testOverflow(){
+        String sql = "delete c, cm FROM `wp_88comments` c LEFT JOIN `wp_88commentmeta` cm ON c.comment_ID = cm.comment_id WHERE comment_approved = '0'";
+        SQLStatementParser parser = new MySqlStatementParser(sql);
+        SQLStatement statement = parser.parseStatement();
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        statement.accept(visitor);
+    }
+}
+


### PR DESCRIPTION
The problem is caused by setting IdentifierExpr's ResolvedTableSource to a SQLExprTableSource while SQLExprTableSource's expr is THE IdentifierExpr it self, then if we enter SQLExprTableSource.findTableSourceWithColumn, it'll cause an endless recursion call. This is a simple patch to prevent an IdentifierExpr point an TableSource into itself.