### PR TITLE
优化ReplicationDriver时连接健康检查的逻辑

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -23,8 +23,6 @@ import com.alibaba.druid.support.logging.Log;
 import com.alibaba.druid.support.logging.LogFactory;
 import com.alibaba.druid.util.JdbcUtils;
 import com.alibaba.druid.util.Utils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
@@ -78,6 +76,24 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
 
     public class NativePingOperation implements PingOperation {
 
+        public class Pair<L, R> {
+            private final L left;
+            private final R right;
+
+            public Pair(L left, R right) {
+                this.left = left;
+                this.right = right;
+            }
+
+            public L getLeft() {
+                return left;
+            }
+
+            public R getRight() {
+                return right;
+            }
+        }
+
         private Pair<Class<?>, Method> defaultConnectionPingMethod = null;
         private Pair<Class<?>, Method> multiHostConnectionPingMethod = null;
 
@@ -92,7 +108,7 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
                 if (connectionClass != null) {
                     Method ping = connectionClass.getMethod("pingInternal", boolean.class, int.class);
                     if (ping != null) {
-                        defaultConnectionPingMethod = new ImmutablePair<Class<?>, Method>(connectionClass, ping);
+                        defaultConnectionPingMethod = new Pair<Class<?>, Method>(connectionClass, ping);
                     }
                 }
             } catch (Exception e) {
@@ -105,7 +121,7 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
                 if (connectionClass != null) {
                     Method ping = connectionClass.getMethod("ping");
                     if (ping != null) {
-                        multiHostConnectionPingMethod = new ImmutablePair<Class<?>, Method>(connectionClass, ping);
+                        multiHostConnectionPingMethod = new Pair<Class<?>, Method>(connectionClass, ping);
                     }
                 }
             }  catch (Exception e) {

--- a/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -47,7 +47,7 @@ public interface JdbcConstants {
     String MYSQL                      = "mysql";
     String MYSQL_DRIVER               = "com.mysql.jdbc.Driver";
     String MYSQL_DRIVER_6             = "com.mysql.cj.jdbc.Driver";
-    String MYSQL_DRIVER_REPLICATE     = "com.mysql.jdbc.";
+    String MYSQL_DRIVER_REPLICATE     = "com.mysql.jdbc.ReplicationDriver";
 
     String MARIADB                    = "mariadb";
     String MARIADB_DRIVER             = "org.mariadb.jdbc.Driver";


### PR DESCRIPTION
修复com.mysql.jdbc.ReplicationDriver名称不正确的问题，此前版本修正过，但是因为某次合并被覆盖回去了，修正它。

修正之后发现连接健康检查的行为事实上只会对其中一个连接生效，正在优化逻辑以保证所有底层连接都被健康检查。

2018-11-16 正在线上小流量测试，目前工作正常

2018-11-26 至目前工作正常
