### PR TITLE
enhance mysql sql fields size

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlSchemaStatVisitor.java
@@ -925,7 +925,7 @@ public class MySqlSchemaStatVisitor extends SchemaStatVisitor implements MySqlAS
 
         SQLName column = x.getColumnName();
         String columnName = column.toString();
-        addColumn(tableName, columnName);
+        addColumn(tableName, columnName, x.getNewColumnDefinition().getDataType());
         return false;
     }
 


### PR DESCRIPTION
sql 解析的时候，没有返回sql中字段的类型长度，比如 varchar(225) 返回225。对create 和 alter进行了支持