### PR TITLE
add signed datatype keyword support for SQLExprParser

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -2521,7 +2521,8 @@ public class SQLExprParser extends SQLParser {
             lexer.nextToken();
         }
 
-        if (typeNameHashCode == FnvHash.Constants.UNSIGNED) {
+        if (typeNameHashCode == FnvHash.Constants.UNSIGNED
+                || typeNameHashCode == FnvHash.Constants.SIGNED) {
             if (lexer.token == Token.IDENTIFIER) {
                 typeName += (' ' + lexer.stringVal());
                 lexer.nextToken();

--- a/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -485,6 +485,7 @@ public final class FnvHash {
         long STORAGE = fnv1a_64_lower("STORAGE");
         long STORED = fnv1a_64_lower("STORED");
         long VIRTUAL = fnv1a_64_lower("VIRTUAL");
+        long SIGNED = fnv1a_64_lower("SIGNED");
         long UNSIGNED = fnv1a_64_lower("UNSIGNED");
         long ZEROFILL = fnv1a_64_lower("ZEROFILL");
         long GLOBAL = fnv1a_64_lower("GLOBAL");

--- a/src/test/java/com/alibaba/druid/sql/SQLExprParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/SQLExprParserTest.java
@@ -18,6 +18,7 @@ package com.alibaba.druid.sql;
 import org.junit.Assert;
 import junit.framework.TestCase;
 
+import com.alibaba.druid.sql.ast.SQLDataType;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
@@ -37,5 +38,14 @@ public class SQLExprParserTest extends TestCase {
         
         Assert.assertEquals("AGE", left.getName());
         Assert.assertEquals(5, right.getNumber().intValue());
+    }
+    public void test_signed_data_type() throws Exception {
+        SQLExprParser exprParser_1 = new SQLExprParser("unsigned tinyint");
+        SQLDataType dataType_1 = exprParser_1.parseDataType();
+        Assert.assertEquals("unsigned tinyint", dataType_1.getName());
+
+        SQLExprParser exprParser_2 = new SQLExprParser("signed tinyint");
+        SQLDataType dataType_2 = exprParser_2.parseDataType();
+        Assert.assertEquals("signed tinyint", dataType_2.getName());
     }
 }


### PR DESCRIPTION
1. 按 #2947  的描述增加了对SIGNED关键词的解析
2. 增加了测试用例 signed tinyint