### PR TITLE
禁用druid-spring-boot-starter中的监控页面及监控数据统计filter

### DIFF
--- a/druid-spring-boot-starter/README.md
+++ b/druid-spring-boot-starter/README.md
@@ -61,7 +61,7 @@ spring.datasource.druid.filters= #配置多个英文逗号分隔
 - 监控配置
 ```
 # WebStatFilter配置，说明请参考Druid Wiki，配置_配置WebStatFilter
-spring.datasource.druid.web-stat-filter.enabled= #是否启用StatFilter默认值true
+spring.datasource.druid.web-stat-filter.enabled= #是否启用StatFilter默认值false
 spring.datasource.druid.web-stat-filter.url-pattern=
 spring.datasource.druid.web-stat-filter.exclusions=
 spring.datasource.druid.web-stat-filter.session-stat-enable=
@@ -71,7 +71,7 @@ spring.datasource.druid.web-stat-filter.principal-cookie-name=
 spring.datasource.druid.web-stat-filter.profile-enable=
 
 # StatViewServlet配置，说明请参考Druid Wiki，配置_StatViewServlet配置
-spring.datasource.druid.stat-view-servlet.enabled= #是否启用StatViewServlet默认值true
+spring.datasource.druid.stat-view-servlet.enabled= #是否启用StatViewServlet默认值false
 spring.datasource.druid.stat-view-servlet.url-pattern=
 spring.datasource.druid.stat-view-servlet.reset-enable=
 spring.datasource.druid.stat-view-servlet.login-username=
@@ -154,7 +154,7 @@ spring.datasource.druid.filter.wall.config.drop-table-allow=false
 - Log4j2Filter
 - CommonsLogFilter
 
-要想使自定义 Filter 配置生效需要将对应 Filter 的 ```enabled``` 设置为 ```true``` ，Druid Spring Boot Starter 默认会启用 StatFilter，你也可以将其 ```enabled``` 设置为 ```false``` 来禁用它。
+要想使自定义 Filter 配置生效需要将对应 Filter 的 ```enabled``` 设置为 ```true``` ，Druid Spring Boot Starter 默认禁用 StatFilter，你也可以将其 ```enabled``` 设置为 ```true``` 来启用它。
 
 ## 如何获取 Druid 的监控数据
 
@@ -165,6 +165,7 @@ Druid 的监控数据可以通过 DruidStatManagerFacade 进行获取，获取�
 public class DruidStatController {
     @GetMapping("/druid/stat")
     public Object druidStat(){
+        // 需要启用StatFilter
         // DruidStatManagerFacade#getDataSourceStatDataList 该方法可以获取所有数据源的监控数据，除此之外 DruidStatManagerFacade 还提供了一些其他方法，你可以按需选择使用。
         return DruidStatManagerFacade.getInstance().getDataSourceStatDataList();
     }

--- a/druid-spring-boot-starter/README_EN.md
+++ b/druid-spring-boot-starter/README_EN.md
@@ -58,7 +58,7 @@ spring.datasource.druid.filters= #Druid filters, default value stat, multiple se
 - Monitor
 ```
 # WebStatFilter properties, detail see Druid Wiki
-spring.datasource.druid.web-stat-filter.enabled= #Enable StatFilter, default value true.
+spring.datasource.druid.web-stat-filter.enabled= #Enable StatFilter, default value false.
 spring.datasource.druid.web-stat-filter.url-pattern=
 spring.datasource.druid.web-stat-filter.exclusions=
 spring.datasource.druid.web-stat-filter.session-stat-enable=
@@ -68,7 +68,7 @@ spring.datasource.druid.web-stat-filter.principal-cookie-name=
 spring.datasource.druid.web-stat-filter.profile-enable=
 
 # StatViewServlet properties, detail see Druid Wiki
-spring.datasource.druid.stat-view-servlet.enabled= #Enable StatViewServlet, default value true.
+spring.datasource.druid.stat-view-servlet.enabled= #Enable StatViewServlet, default value false.
 spring.datasource.druid.stat-view-servlet.url-pattern=
 spring.datasource.druid.stat-view-servlet.reset-enable=
 spring.datasource.druid.stat-view-servlet.login-username=
@@ -148,7 +148,7 @@ Currently, configuration support is provided for the following filters. Please r
 - Log4j2Filter
 - CommonsLogFilter
 
-Druid Spring Boot Starter will enable StatFilter by default, and you can also set its enabled to false.，make the Filter configuration take effect and need to set enabled to true.
+Druid Spring Boot Starter will forbid StatFilter by default, and you can also set its enabled to true.，make the Filter configuration take effect and need to set enabled to true.
 
 ## How to get Druid monitoring(stat) data
 
@@ -158,6 +158,7 @@ Druid's monitoring data can be obtained through DruidStatManagerFacade. After ob
 public class DruidStatController {
     @GetMapping("/druid/stat")
     public Object druidStat(){
+        // Your need enable StatFilter
         // DruidStatManagerFacade#getDataSourceStatDataList 该方法可以获取所有数据源的监控数据，除此之外 DruidStatManagerFacade 还提供了一些其他方法，你可以按需选择使用。
         return DruidStatManagerFacade.getInstance().getDataSourceStatDataList();
     }

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidFilterConfiguration.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidFilterConfiguration.java
@@ -33,7 +33,7 @@ public class DruidFilterConfiguration {
 
     @Bean
     @ConfigurationProperties(FILTER_STAT_PREFIX)
-    @ConditionalOnProperty(prefix = FILTER_STAT_PREFIX, name = "enabled", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = FILTER_STAT_PREFIX, name = "enabled")
     @ConditionalOnMissingBean
     public StatFilter statFilter() {
         return new StatFilter();

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidStatViewServletConfiguration.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidStatViewServletConfiguration.java
@@ -26,8 +26,10 @@ import org.springframework.context.annotation.Bean;
  * @author lihengming [89921218@qq.com]
  */
 @ConditionalOnWebApplication
-@ConditionalOnProperty(name = "spring.datasource.druid.stat-view-servlet.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.datasource.druid.stat-view-servlet.enabled", havingValue = "true")
 public class DruidStatViewServletConfiguration {
+    private static final String DEFAULT_ALLOW_IP = "127.0.0.1";
+
     @Bean
     public ServletRegistrationBean statViewServletRegistrationBean(DruidStatProperties properties) {
         DruidStatProperties.StatViewServlet config = properties.getStatViewServlet();
@@ -36,6 +38,8 @@ public class DruidStatViewServletConfiguration {
         registrationBean.addUrlMappings(config.getUrlPattern() != null ? config.getUrlPattern() : "/druid/*");
         if (config.getAllow() != null) {
             registrationBean.addInitParameter("allow", config.getAllow());
+        } else {
+            registrationBean.addInitParameter("allow", DEFAULT_ALLOW_IP);
         }
         if (config.getDeny() != null) {
             registrationBean.addInitParameter("deny", config.getDeny());

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidWebStatFilterConfiguration.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidWebStatFilterConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Bean;
  * @author lihengming [89921218@qq.com]
  */
 @ConditionalOnWebApplication
-@ConditionalOnProperty(name = "spring.datasource.druid.web-stat-filter.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.datasource.druid.web-stat-filter.enabled", havingValue = "true")
 public class DruidWebStatFilterConfiguration {
     @Bean
     public FilterRegistrationBean webStatFilterRegistrationBean(DruidStatProperties properties) {


### PR DESCRIPTION
[建议默认禁止druid-springboot-starter中的stat-view监控页面，防止DB信息可能泄露](https://github.com/alibaba/druid/issues/3009)