### PR TITLE
modify OracleOutputVisitor for insert multiple records

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1148,7 +1148,7 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         if (x.getValues() != null) {
             println();
             print0(ucase ? "VALUES " : "values ");
-            x.getValues().accept(this);
+            printlnAndAccept(x.getValuesList(), ", ");
         } else {
             if (x.getQuery() != null) {
                 println();
@@ -1200,7 +1200,7 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         if (x.getValues() != null) {
             println();
             print0(ucase ? "VALUES " : "values ");
-            x.getValues().accept(this);
+            printlnAndAccept(x.getValuesList(), ", ");
         } else {
             if (x.getQuery() != null) {
                 println();


### PR DESCRIPTION
For example, I have a oracle sql statement, 
**"INSERT INTO user (id, name) VALUES ('1', ?),('2', ?)"**
when use SQLUtils to format it, it output 
**"INSERT INTO user (id, name) VALUES ('1', ?)"**
OracleOutputVisitor will discard second ValuesClause,

I referenced PGOutputVisitor 298 line and modify OracleOutputVisitor
PGOutputVisitor 298 line:
```
if (x.getValues() != null) {
     println();
     print0(ucase ? "VALUES " : "values ");
     printlnAndAccept(x.getValuesList(), ", ");
} else {
    if (x.getQuery() != null) {
        println();
        x.getQuery().accept(this);
    }
}
```
