### PR TITLE
从spring上下文中寻找全部Filter并注入，以期让自定义Filter或借助spring管理的Filter更易融入druid

### DIFF
--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
@@ -15,20 +15,15 @@
  */
 package com.alibaba.druid.spring.boot.autoconfigure;
 
-import com.alibaba.druid.filter.config.ConfigFilter;
-import com.alibaba.druid.filter.encoding.EncodingConvertFilter;
-import com.alibaba.druid.filter.logging.CommonsLogFilter;
-import com.alibaba.druid.filter.logging.Log4j2Filter;
-import com.alibaba.druid.filter.logging.Log4jFilter;
-import com.alibaba.druid.filter.logging.Slf4jLogFilter;
-import com.alibaba.druid.filter.stat.StatFilter;
+import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.wall.WallFilter;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
 
 /**
  * @author lihengming [89921218@qq.com]
@@ -56,43 +51,8 @@ class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean
     }
 
     @Autowired(required = false)
-    public void addStatFilter(StatFilter statFilter) {
-        super.filters.add(statFilter);
-    }
-
-    @Autowired(required = false)
-    public void addConfigFilter(ConfigFilter configFilter) {
-        super.filters.add(configFilter);
-    }
-
-    @Autowired(required = false)
-    public void addEncodingConvertFilter(EncodingConvertFilter encodingConvertFilter) {
-        super.filters.add(encodingConvertFilter);
-    }
-
-    @Autowired(required = false)
-    public void addSlf4jLogFilter(Slf4jLogFilter slf4jLogFilter) {
-        super.filters.add(slf4jLogFilter);
-    }
-
-    @Autowired(required = false)
-    public void addLog4jFilter(Log4jFilter log4jFilter) {
-        super.filters.add(log4jFilter);
-    }
-
-    @Autowired(required = false)
-    public void addLog4j2Filter(Log4j2Filter log4j2Filter) {
-        super.filters.add(log4j2Filter);
-    }
-
-    @Autowired(required = false)
-    public void addCommonsLogFilter(CommonsLogFilter commonsLogFilter) {
-        super.filters.add(commonsLogFilter);
-    }
-
-    @Autowired(required = false)
-    public void addWallFilter(WallFilter wallFilter) {
-        super.filters.add(wallFilter);
+    public void autoAddFilters(List<Filter> filtes){
+        super.filters.addAll(filtes);
     }
 
     /**

--- a/druid-spring-boot-starter/src/test/java/com/alibaba/druid/spring/boot/testcase/DruidFilterTestCase.java
+++ b/druid-spring-boot-starter/src/test/java/com/alibaba/druid/spring/boot/testcase/DruidFilterTestCase.java
@@ -5,12 +5,19 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import com.alibaba.druid.filter.Filter;
+import com.alibaba.druid.filter.FilterAdapter;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
 import com.alibaba.druid.spring.boot.demo.DemoApplication;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -20,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author lihengming [89921218@qq.com]
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = DemoApplication.class)
+@SpringBootTest(classes = {DemoApplication.class, DruidFilterTestCase.Config.class})
 @ActiveProfiles("filter")
 public class DruidFilterTestCase {
     @Resource
@@ -29,6 +36,34 @@ public class DruidFilterTestCase {
     @Test
     public void test() {
         List<Filter> filters = dataSource.getProxyFilters();
-        assertThat(filters.size()).isEqualTo(3);
+        //配置文件中3个，自定义1个，共4个
+        assertThat(filters.size()).isEqualTo(4);
+    }
+
+    /**
+     * @author dk
+     * 用于此测试的一个配置，仅加入了一个自定义的Filter，此Filter打印出数据库连接url
+     */
+    @Configuration
+    @ComponentScan
+    public static class Config{
+
+        /**
+         * @author dk
+         */
+        @Component
+        public static class SomeCustomFilter extends FilterAdapter {
+
+            private static Logger logger = LoggerFactory.getLogger(SomeCustomFilter.class);
+
+            @Override
+            public void init(DataSourceProxy dataSourceProxy){
+                if (!(dataSourceProxy instanceof DruidDataSource)) {
+                    logger.error("ConfigLoader only support DruidDataSource");
+                }
+                DruidDataSource dataSource = (DruidDataSource) dataSourceProxy;
+                logger.info("db configuration: url="+ dataSource.getUrl());
+            }
+        }
     }
 }


### PR DESCRIPTION
原有自定义且通过spring管理的filter通过proxyFilters设置，换用druid-spring-boot-starter后意识到不便通过配置文件使用proxyFilters。
通过阅读DruidDataSourceWrapper得到启发，建议@Autowired一个Filter类型的List，实现从spring上下文中寻找全部Filter并注入，让自定义Filter或借助spring管理的Filter更易融入druid。
测试复用DruidFilterTestCase