### PR TITLE
解决Druid多classloader  Mbean注册卸载过程中的问题 

### DIFF
--- a/src/main/java/com/alibaba/druid/stat/DruidDataSourceStatManager.java
+++ b/src/main/java/com/alibaba/druid/stat/DruidDataSourceStatManager.java
@@ -144,7 +144,9 @@ public class DruidDataSourceStatManager implements DruidDataSourceStatManagerMBe
         synchronized (instances) {
             if (instances.size() == 0) {
                 try {
-                    ObjectName objectName = new ObjectName(MBEAN_NAME);
+                    int id = System.identityHashCode(instance.getClass());
+                    ObjectName objectName = new ObjectName(MBEAN_NAME + ",id=" + id);
+                    // ObjectName objectName = new ObjectName(MBEAN_NAME);
                     if (!mbeanServer.isRegistered(objectName)) {
                         mbeanServer.registerMBean(instance, objectName);
                     }
@@ -206,7 +208,9 @@ public class DruidDataSourceStatManager implements DruidDataSourceStatManagerMBe
 
         if (instances.size() == 0) {
             try {
-                mbeanServer.unregisterMBean(new ObjectName(MBEAN_NAME));
+                int id = System.identityHashCode(instance.getClass());
+                ObjectName objName = new ObjectName(MBEAN_NAME + ",id=" + id);
+                mbeanServer.unregisterMBean(objName);
             } catch (Throwable ex) {
                 LOG.error("unregister mbean error", ex);
             }

--- a/src/main/java/com/alibaba/druid/stat/DruidStatService.java
+++ b/src/main/java/com/alibaba/druid/stat/DruidStatService.java
@@ -357,8 +357,9 @@ public final class DruidStatService implements DruidStatServiceMBean {
     public static void registerMBean() {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         try {
-
-            ObjectName objectName = new ObjectName(MBEAN_NAME);
+            int id = System.identityHashCode(instance.getClass());
+            ObjectName objectName = new ObjectName(MBEAN_NAME + ",id=" + id);
+            // ObjectName objectName = new ObjectName(MBEAN_NAME);
             if (!mbeanServer.isRegistered(objectName)) {
                 mbeanServer.registerMBean(instance, objectName);
             }
@@ -369,9 +370,10 @@ public final class DruidStatService implements DruidStatServiceMBean {
 
     public static void unregisterMBean() {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
-
         try {
-            mbeanServer.unregisterMBean(new ObjectName(MBEAN_NAME));
+            int id = System.identityHashCode(instance.getClass());
+            ObjectName objectName = new ObjectName(MBEAN_NAME + ",id=" + id);
+            mbeanServer.unregisterMBean(objectName);
         } catch (JMException ex) {
             LOG.error("unregister mbean error", ex);
         }


### PR DESCRIPTION
  类似于Tomcat的多classloader容器架构中，如果同一个JVM中，多个classloader独自加载druid进行访问数据库，那么在加载和卸载模块的时候，对应Mbean的操作，会因为Druid使用默认的MBean命名进行注册与卸载，导致发生异常。虽然不影响使用，但是日志会出现异常Exception。

  本PR解决上述的问题