### PR TITLE
SQL语法解析器优化

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveClusterBy.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveClusterBy.java
@@ -1,0 +1,92 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveClusterBy extends SQLObjectImpl {
+	
+	protected final List<HiveClusterByItem> items = new ArrayList<HiveClusterByItem>();
+
+	public HiveClusterBy() {
+
+	}
+
+	public HiveClusterBy(SQLExpr expr) {
+		HiveClusterByItem item = new HiveClusterByItem(expr);
+		addItem(item);
+	}
+
+	public void addItem(HiveClusterByItem item) {
+		if (item != null) {
+			item.setParent(this);
+		}
+		this.items.add(item);
+	}
+
+	public List<HiveClusterByItem> getItems() {
+		return this.items;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.items);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((items == null) ? 0 : items.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveSortBy other = (HiveSortBy) obj;
+		if (items == null) {
+			if (other.items != null)
+				return false;
+		} else if (!items.equals(other.items))
+			return false;
+		return true;
+	}
+
+	public void addItem(SQLExpr expr) {
+		HiveClusterByItem item = createItem();
+		item.setExpr(expr);
+		addItem(item);
+	}
+
+	protected HiveClusterByItem createItem() {
+		return new HiveClusterByItem();
+	}
+
+	public HiveClusterBy clone() {
+		HiveClusterBy x = new HiveClusterBy();
+		for (HiveClusterByItem item : items) {
+			HiveClusterByItem item1 = item.clone();
+			item1.setParent(x);
+			x.items.add(item1);
+		}
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveClusterByItem.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveClusterByItem.java
@@ -1,0 +1,85 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.ast.SQLReplaceable;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveClusterByItem extends SQLObjectImpl implements SQLReplaceable {
+	protected SQLExpr expr;
+
+	public HiveClusterByItem() {
+
+	}
+
+	public HiveClusterByItem(SQLExpr expr) {
+		this.setExpr(expr);
+	}
+
+	public SQLExpr getExpr() {
+		return this.expr;
+	}
+
+	public void setExpr(SQLExpr expr) {
+		if (expr != null) {
+			expr.setParent(this);
+		}
+		this.expr = expr;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.expr);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((expr == null) ? 0 : expr.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveClusterByItem other = (HiveClusterByItem) obj;
+		if (expr == null) {
+			if (other.expr != null)
+				return false;
+		} else if (!expr.equals(other.expr))
+			return false;
+		return true;
+	}
+
+	@Override
+	public boolean replace(SQLExpr expr, SQLExpr target) {
+		if (this.expr == expr) {
+			this.setExpr(target);
+			return true;
+		}
+		return false;
+	}
+
+	public HiveClusterByItem clone() {
+		HiveClusterByItem x = new HiveClusterByItem();
+		if (expr != null) {
+			x.setExpr(expr.clone());
+		}
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveDistributeBy.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveDistributeBy.java
@@ -1,0 +1,92 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveDistributeBy extends SQLObjectImpl {
+
+	protected final List<HiveDistributeByItem> items = new ArrayList<HiveDistributeByItem>();
+
+	public HiveDistributeBy() {
+
+	}
+
+	public HiveDistributeBy(SQLExpr expr) {
+		HiveDistributeByItem item = new HiveDistributeByItem(expr);
+		addItem(item);
+	}
+
+	public void addItem(HiveDistributeByItem item) {
+		if (item != null) {
+			item.setParent(this);
+		}
+		this.items.add(item);
+	}
+
+	public List<HiveDistributeByItem> getItems() {
+		return this.items;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.items);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((items == null) ? 0 : items.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveSortBy other = (HiveSortBy) obj;
+		if (items == null) {
+			if (other.items != null)
+				return false;
+		} else if (!items.equals(other.items))
+			return false;
+		return true;
+	}
+
+	public void addItem(SQLExpr expr) {
+		HiveDistributeByItem item = createItem();
+		item.setExpr(expr);
+		addItem(item);
+	}
+
+	protected HiveDistributeByItem createItem() {
+		return new HiveDistributeByItem();
+	}
+
+	public HiveDistributeBy clone() {
+		HiveDistributeBy x = new HiveDistributeBy();
+		for (HiveDistributeByItem item : items) {
+			HiveDistributeByItem item1 = item.clone();
+			item1.setParent(x);
+			x.items.add(item1);
+		}
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveDistributeByItem.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveDistributeByItem.java
@@ -1,0 +1,85 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.ast.SQLReplaceable;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveDistributeByItem extends SQLObjectImpl implements SQLReplaceable {
+	protected SQLExpr expr;
+
+	public HiveDistributeByItem() {
+
+	}
+
+	public HiveDistributeByItem(SQLExpr expr) {
+		this.setExpr(expr);
+	}
+
+	public SQLExpr getExpr() {
+		return this.expr;
+	}
+
+	public void setExpr(SQLExpr expr) {
+		if (expr != null) {
+			expr.setParent(this);
+		}
+		this.expr = expr;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.expr);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((expr == null) ? 0 : expr.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveDistributeByItem other = (HiveDistributeByItem) obj;
+		if (expr == null) {
+			if (other.expr != null)
+				return false;
+		} else if (!expr.equals(other.expr))
+			return false;
+		return true;
+	}
+
+	@Override
+	public boolean replace(SQLExpr expr, SQLExpr target) {
+		if (this.expr == expr) {
+			this.setExpr(target);
+			return true;
+		}
+		return false;
+	}
+
+	public HiveDistributeByItem clone() {
+		HiveDistributeByItem x = new HiveDistributeByItem();
+		if (expr != null) {
+			x.setExpr(expr.clone());
+		}
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveSelectSortByItem.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveSelectSortByItem.java
@@ -1,0 +1,100 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
+import com.alibaba.druid.sql.ast.SQLReplaceable;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveSelectSortByItem extends SQLObjectImpl implements SQLReplaceable {
+
+	protected SQLExpr expr;
+	protected SQLOrderingSpecification type;
+
+	public HiveSelectSortByItem() {
+
+	}
+
+	public HiveSelectSortByItem(SQLExpr expr) {
+		this.setExpr(expr);
+	}
+
+	public SQLExpr getExpr() {
+		return this.expr;
+	}
+
+	public void setExpr(SQLExpr expr) {
+		if (expr != null) {
+			expr.setParent(this);
+		}
+		this.expr = expr;
+	}
+
+	public SQLOrderingSpecification getType() {
+		return this.type;
+	}
+
+	public void setType(SQLOrderingSpecification type) {
+		this.type = type;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.expr);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((expr == null) ? 0 : expr.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveSelectSortByItem other = (HiveSelectSortByItem) obj;
+		if (expr == null) {
+			if (other.expr != null)
+				return false;
+		} else if (!expr.equals(other.expr))
+			return false;
+		if (type != other.type)
+			return false;
+		return true;
+	}
+
+	@Override
+	public boolean replace(SQLExpr expr, SQLExpr target) {
+		if (this.expr == expr) {
+			this.setExpr(target);
+			return true;
+		}
+		return false;
+	}
+
+	public HiveSelectSortByItem clone() {
+		HiveSelectSortByItem x = new HiveSelectSortByItem();
+		if (expr != null) {
+			x.setExpr(expr.clone());
+		}
+		x.type = type;
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveShowDatabasesStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveShowDatabasesStatement.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class HiveShowDatabasesStatement extends SQLStatementImpl {
+
+	protected SQLExpr like;
+
+	public HiveShowDatabasesStatement() {
+		dbType = JdbcConstants.HIVE;
+	}
+
+	public SQLExpr getLike() {
+		return like;
+	}
+
+	public void setLike(SQLExpr like) {
+		this.like = like;
+	}
+
+	@Override
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		} else {
+			acceptChild(visitor, like);
+		}
+	}
+
+	public void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, like);
+		}
+		visitor.endVisit(this);
+	}
+
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveShowTablesStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveShowTablesStatement.java
@@ -1,0 +1,51 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class HiveShowTablesStatement extends SQLStatementImpl {
+
+	protected SQLExpr database;
+	protected SQLExpr like;
+
+	public HiveShowTablesStatement() {
+		dbType = JdbcConstants.HIVE;
+	}
+
+	public SQLExpr getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(SQLExpr database) {
+		this.database = database;
+	}
+
+	public SQLExpr getLike() {
+		return like;
+	}
+
+	public void setLike(SQLExpr like) {
+		this.like = like;
+	}
+
+	@Override
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		} else {
+			acceptChild(visitor, database);
+			acceptChild(visitor, like);
+		}
+	}
+
+	public void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, database);
+			acceptChild(visitor, like);
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveSortBy.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/ast/HiveSortBy.java
@@ -1,0 +1,94 @@
+package com.alibaba.druid.sql.dialect.hive.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
+import com.alibaba.druid.sql.dialect.hive.visitor.HiveASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class HiveSortBy extends SQLObjectImpl {
+	
+	protected final List<HiveSelectSortByItem> items = new ArrayList<HiveSelectSortByItem>();
+
+	public HiveSortBy() {
+
+	}
+
+	public HiveSortBy(SQLExpr expr) {
+		HiveSelectSortByItem item = new HiveSelectSortByItem(expr);
+		addItem(item);
+	}
+
+	public void addItem(HiveSelectSortByItem item) {
+		if (item != null) {
+			item.setParent(this);
+		}
+		this.items.add(item);
+	}
+
+	public List<HiveSelectSortByItem> getItems() {
+		return this.items;
+	}
+
+	protected void accept0(SQLASTVisitor visitor) {
+		if (visitor instanceof HiveASTVisitor) {
+			accept0((HiveASTVisitor) visitor);
+		}
+	}
+
+	protected void accept0(HiveASTVisitor visitor) {
+		if (visitor.visit(this)) {
+			acceptChild(visitor, this.items);
+		}
+		visitor.endVisit(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((items == null) ? 0 : items.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HiveSortBy other = (HiveSortBy) obj;
+		if (items == null) {
+			if (other.items != null)
+				return false;
+		} else if (!items.equals(other.items))
+			return false;
+		return true;
+	}
+
+	public void addItem(SQLExpr expr, SQLOrderingSpecification type) {
+		HiveSelectSortByItem item = createItem();
+		item.setExpr(expr);
+		item.setType(type);
+		addItem(item);
+	}
+
+	protected HiveSelectSortByItem createItem() {
+		return new HiveSelectSortByItem();
+	}
+
+	public HiveSortBy clone() {
+		HiveSortBy x = new HiveSortBy();
+		for (HiveSelectSortByItem item : items) {
+			HiveSelectSortByItem item1 = item.clone();
+			item1.setParent(x);
+			x.items.add(item1);
+		}
+		return x;
+	}
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
@@ -257,4 +257,8 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
     protected HiveCreateTableStatement newCreateStatement() {
         return new HiveCreateTableStatement();
     }
+    
+    public HiveSelectParser createSQLSelectParser() {
+        return new HiveSelectParser(this.exprParser, selectListCache);
+    }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveExprParser.java
@@ -16,10 +16,19 @@
 package com.alibaba.druid.sql.dialect.hive.parser;
 
 import java.util.Arrays;
+import java.util.List;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
 import com.alibaba.druid.sql.ast.expr.SQLArrayExpr;
 import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.parser.Lexer;
 import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.SQLParserFeature;
@@ -75,4 +84,98 @@ public class HiveExprParser extends SQLExprParser {
         }
         return super.primaryRest(expr);
     }
+    
+	public HiveSortBy parseHiveSortBy() {
+		if (lexer.token() == Token.SORT) {
+			HiveSortBy hiveSortBy = new HiveSortBy();
+			lexer.nextToken();
+			accept(Token.BY);
+			sortBy(hiveSortBy.getItems(), hiveSortBy);
+			return hiveSortBy;
+		}
+		return null;
+	}
+
+	public void sortBy(List<HiveSelectSortByItem> items, SQLObject parent) {
+		HiveSelectSortByItem item = parseSelectSortByItem();
+		item.setParent(parent);
+		items.add(item);
+		while (lexer.token() == Token.COMMA) {
+			lexer.nextToken();
+			item = parseSelectSortByItem();
+			item.setParent(parent);
+			items.add(item);
+		}
+	}
+
+	public HiveSelectSortByItem parseSelectSortByItem() {
+		HiveSelectSortByItem item = new HiveSelectSortByItem();
+		item.setExpr(expr());
+		if (lexer.token() == Token.ASC) {
+			lexer.nextToken();
+			item.setType(SQLOrderingSpecification.ASC);
+		} else if (lexer.token() == Token.DESC) {
+			lexer.nextToken();
+			item.setType(SQLOrderingSpecification.DESC);
+		}
+		return item;
+	}
+	
+	public HiveDistributeBy parseHiveDistributeBy() {
+		if (lexer.token() == Token.DISTRIBUTE) {
+			HiveDistributeBy hiveDistributeBy = new HiveDistributeBy();
+			lexer.nextToken();
+			accept(Token.BY);
+			distributeBy(hiveDistributeBy.getItems(), hiveDistributeBy);
+			return hiveDistributeBy;
+		}
+		return null;
+	}
+	
+	public void distributeBy(List<HiveDistributeByItem> items, SQLObject parent) {
+		HiveDistributeByItem item = parseHiveDistributeByItem();
+		item.setParent(parent);
+		items.add(item);
+		while (lexer.token() == Token.COMMA) {
+			lexer.nextToken();
+			item = parseHiveDistributeByItem();
+			item.setParent(parent);
+			items.add(item);
+		}
+	}
+	
+	public HiveDistributeByItem parseHiveDistributeByItem() {
+		HiveDistributeByItem item = new HiveDistributeByItem();
+		item.setExpr(expr());
+		return item;
+	}
+	
+	public HiveClusterBy parseHiveClusterBy() {
+		if (lexer.token() == Token.CLUSTER) {
+			HiveClusterBy hiveClusterBy = new HiveClusterBy();
+			lexer.nextToken();
+			accept(Token.BY);
+			clusterBy(hiveClusterBy.getItems(), hiveClusterBy);
+			return hiveClusterBy;
+		}
+		return null;
+	}
+	
+	public void clusterBy(List<HiveClusterByItem> items, SQLObject parent) {
+		HiveClusterByItem item = parseHiveClusterByItem();
+		item.setParent(parent);
+		items.add(item);
+		while (lexer.token() == Token.COMMA) {
+			lexer.nextToken();
+			item = parseHiveClusterByItem();
+			item.setParent(parent);
+			items.add(item);
+		}
+	}
+	
+	public HiveClusterByItem parseHiveClusterByItem() {
+		HiveClusterByItem item = new HiveClusterByItem();
+		item.setExpr(expr());
+		return item;
+	}
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
@@ -48,6 +48,9 @@ public class HiveLexer extends Lexer {
         map.put("TRUE", Token.TRUE);
         map.put("FALSE", Token.FALSE);
         map.put("RLIKE", Token.RLIKE);
+        
+        map.put("DISTRIBUTE", Token.DISTRIBUTE);
+        map.put("CLUSTER", Token.CLUSTER);
 
         DEFAULT_HIVE_KEYWORDS = new Keywords(map);
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
@@ -51,6 +51,8 @@ public class HiveLexer extends Lexer {
         
         map.put("DISTRIBUTE", Token.DISTRIBUTE);
         map.put("CLUSTER", Token.CLUSTER);
+        
+        map.put("SHOW", Token.SHOW);
 
         DEFAULT_HIVE_KEYWORDS = new Keywords(map);
     }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveSelectParser.java
@@ -16,9 +16,19 @@
 package com.alibaba.druid.sql.dialect.hive.parser;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLOrderBy;
 import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
+import com.alibaba.druid.sql.ast.SQLSetQuantifier;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
+import com.alibaba.druid.sql.dialect.hive.stmt.HiveSelectQueryBlock;
 import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.SQLSelectListCache;
 import com.alibaba.druid.sql.parser.SQLSelectParser;
@@ -26,48 +36,165 @@ import com.alibaba.druid.sql.parser.Token;
 
 public class HiveSelectParser extends SQLSelectParser {
 
-    public HiveSelectParser(SQLExprParser exprParser){
-        super(exprParser);
-    }
+	public HiveSelectParser(SQLExprParser exprParser) {
+		super(exprParser);
+	}
 
-    public HiveSelectParser(SQLExprParser exprParser, SQLSelectListCache selectListCache){
-        super(exprParser, selectListCache);
-    }
+	public HiveSelectParser(SQLExprParser exprParser, SQLSelectListCache selectListCache) {
+		super(exprParser, selectListCache);
+	}
 
-    public HiveSelectParser(String sql){
-        this(new HiveExprParser(sql));
-    }
+	public HiveSelectParser(String sql) {
+		this(new HiveExprParser(sql));
+	}
 
-    protected SQLExprParser createExprParser() {
-        return new HiveExprParser(lexer);
-    }
+	protected SQLExprParser createExprParser() {
+		return new HiveExprParser(lexer);
+	}
 
-    protected void parseSortBy(SQLSelectQueryBlock queryBlock) {
-        if (lexer.token() == Token.SORT) {
-            lexer.nextToken();
-            accept(Token.BY);
-            for (;;) {
-                SQLExpr expr = this.expr();
+	protected void parseSortBy(SQLSelectQueryBlock queryBlock) {
+		if (lexer.token() == Token.SORT) {
+			lexer.nextToken();
+			accept(Token.BY);
+			for (;;) {
+				SQLExpr expr = this.expr();
 
-                SQLSelectOrderByItem sortByItem = new SQLSelectOrderByItem(expr);
+				SQLSelectOrderByItem sortByItem = new SQLSelectOrderByItem(expr);
 
-                if (lexer.token() == Token.ASC) {
-                    sortByItem.setType(SQLOrderingSpecification.ASC);
-                    lexer.nextToken();
-                } else if (lexer.token() == Token.DESC) {
-                    sortByItem.setType(SQLOrderingSpecification.DESC);
-                    lexer.nextToken();
-                }
+				if (lexer.token() == Token.ASC) {
+					sortByItem.setType(SQLOrderingSpecification.ASC);
+					lexer.nextToken();
+				} else if (lexer.token() == Token.DESC) {
+					sortByItem.setType(SQLOrderingSpecification.DESC);
+					lexer.nextToken();
+				}
 
-                queryBlock.addSortBy(sortByItem);
+				queryBlock.addSortBy(sortByItem);
 
-                if (lexer.token() == Token.COMMA) {
-                    lexer.nextToken();
-                } else {
-                    break;
-                }
-            }
-        }
-    }
+				if (lexer.token() == Token.COMMA) {
+					lexer.nextToken();
+				} else {
+					break;
+				}
+			}
+		}
+	}
 
+	public SQLSelect select() {
+		SQLSelect select = new SQLSelect();
+
+		if (lexer.token() == Token.WITH) {
+			SQLWithSubqueryClause with = this.parseWith();
+			select.setWithSubQuery(with);
+		}
+
+		SQLSelectQuery query = query();
+		select.setQuery(query);
+
+		SQLOrderBy orderBy = this.parseOrderBy();
+
+		if (query instanceof SQLSelectQueryBlock) {
+			SQLSelectQueryBlock queryBlock = (SQLSelectQueryBlock) query;
+
+			if (queryBlock.getOrderBy() == null) {
+				queryBlock.setOrderBy(orderBy);
+			} else {
+				select.setOrderBy(orderBy);
+			}
+
+			if (orderBy != null) {
+				parseFetchClause(queryBlock);
+			}
+		} else {
+			select.setOrderBy(orderBy);
+		}
+
+		while (lexer.token() == Token.HINT) {
+			this.exprParser.parseHints(select.getHints());
+		}
+
+		return select;
+	}
+
+	public SQLSelectQuery query(SQLObject parent, boolean acceptUnion) {
+		if (lexer.token() == Token.LPAREN) {
+			lexer.nextToken();
+			SQLSelectQuery select = query();
+			accept(Token.RPAREN);
+			return queryRest(select, acceptUnion);
+		}
+
+		HiveSelectQueryBlock queryBlock = new HiveSelectQueryBlock();
+
+		if (lexer.hasComment() && lexer.isKeepComments()) {
+			queryBlock.addBeforeComment(lexer.readAndResetComments());
+		}
+
+		accept(Token.SELECT);
+
+		if (lexer.token() == Token.HINT) {
+			this.exprParser.parseHints(queryBlock.getHints());
+		}
+
+		if (lexer.token() == Token.COMMENT) {
+			lexer.nextToken();
+		}
+
+		if (lexer.token() == Token.DISTINCT) {
+			queryBlock.setDistionOption(SQLSetQuantifier.DISTINCT);
+			lexer.nextToken();
+		} else if (lexer.token() == Token.ALL) {
+			queryBlock.setDistionOption(SQLSetQuantifier.ALL);
+			lexer.nextToken();
+		}
+
+		parseSelectList(queryBlock);
+
+		parseFrom(queryBlock);
+
+		parseWhere(queryBlock);
+
+		parseGroupBy(queryBlock);
+		
+		parseHiveClusterBy(queryBlock);
+		
+		parseHiveDistributeBy(queryBlock);
+
+		parseHiveSortBy(queryBlock);
+
+		parseFetchClause(queryBlock);
+
+		return queryRest(queryBlock, acceptUnion);
+	}
+
+
+	protected void parseHiveSortBy(HiveSelectQueryBlock queryBlock) {
+		if (this.exprParser instanceof HiveExprParser) {
+			HiveExprParser hiveExprParser = (HiveExprParser) this.exprParser;
+			HiveSortBy hiveSortBy = hiveExprParser.parseHiveSortBy();
+			if (queryBlock != null) {
+				queryBlock.setHiveSortBy(hiveSortBy);
+			}
+		}
+	}
+
+	protected void parseHiveDistributeBy(HiveSelectQueryBlock queryBlock) {
+		if (this.exprParser instanceof HiveExprParser) {
+			HiveExprParser hiveExprParser = (HiveExprParser) this.exprParser;
+			HiveDistributeBy hiveDistributeBy = hiveExprParser.parseHiveDistributeBy();
+			if (queryBlock != null) {
+				queryBlock.setHiveDistributeBy(hiveDistributeBy);
+			}
+		}
+	}
+	
+	protected void parseHiveClusterBy(HiveSelectQueryBlock queryBlock) {
+		if (this.exprParser instanceof HiveExprParser) {
+			HiveExprParser hiveExprParser = (HiveExprParser) this.exprParser;
+			HiveClusterBy hiveClusterBy = hiveExprParser.parseHiveClusterBy();
+			if (queryBlock != null) {
+				queryBlock.setHiveClusterBy(hiveClusterBy);
+			}
+		}
+	}
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveSelectParser.java
@@ -16,6 +16,7 @@
 package com.alibaba.druid.sql.dialect.hive.parser;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.SQLOrderBy;
 import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
@@ -24,6 +25,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
 import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
@@ -197,4 +199,18 @@ public class HiveSelectParser extends SQLSelectParser {
 			}
 		}
 	}
+	
+    public SQLUnionQuery unionRest(SQLUnionQuery union) {
+        if (lexer.token() == Token.ORDER) {
+            SQLOrderBy orderBy = this.exprParser.parseOrderBy();
+            union.setOrderBy(orderBy);
+            return unionRest(union);
+        }
+        if (lexer.token() == Token.LIMIT) {
+        	SQLLimit limit = this.exprParser.parseLimit();
+        	union.setLimit(limit);
+            return unionRest(union);
+        }
+        return union;
+    }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
@@ -23,6 +23,7 @@ import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLReplaceStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
@@ -143,4 +144,11 @@ public class HiveStatementParser extends SQLStatementParser {
 
         return false;
     }
+    
+	public SQLStatement parseSelect() {
+		SQLSelectParser selectParser = createSQLSelectParser();
+		SQLSelect select = selectParser.select();
+		return new SQLSelectStatement(select, JdbcConstants.HIVE);
+	}
+	
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/stmt/HiveSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/stmt/HiveSelectQueryBlock.java
@@ -1,0 +1,49 @@
+package com.alibaba.druid.sql.dialect.hive.stmt;
+
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
+
+public class HiveSelectQueryBlock extends SQLSelectQueryBlock {
+
+	protected HiveSortBy hiveSortBy;
+
+	protected HiveDistributeBy hiveDistributeBy;
+	
+	protected HiveClusterBy hiveClusterBy;
+
+	public HiveSortBy getHiveSortBy() {
+		return hiveSortBy;
+	}
+
+	public void setHiveSortBy(HiveSortBy hiveSortBy) {
+		if (hiveSortBy != null) {
+			hiveSortBy.setParent(this);
+		}
+		this.hiveSortBy = hiveSortBy;
+	}
+
+	public HiveDistributeBy getHiveDistributeBy() {
+		return hiveDistributeBy;
+	}
+
+	public void setHiveDistributeBy(HiveDistributeBy hiveDistributeBy) {
+		if (hiveDistributeBy != null) {
+			hiveDistributeBy.setParent(this);
+		}
+		this.hiveDistributeBy = hiveDistributeBy;
+	}
+
+	public HiveClusterBy getHiveClusterBy() {
+		return hiveClusterBy;
+	}
+
+	public void setHiveClusterBy(HiveClusterBy hiveClusterBy) {
+		if (hiveClusterBy != null) {
+			hiveClusterBy.setParent(this);
+		}
+		this.hiveClusterBy = hiveClusterBy;
+	}
+
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitor.java
@@ -15,9 +15,15 @@
  */
 package com.alibaba.druid.sql.dialect.hive.visitor;
 
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeByItem;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
@@ -33,4 +39,25 @@ public interface HiveASTVisitor extends SQLASTVisitor {
 
     boolean visit(HiveInsert x);
     void endVisit(HiveInsert x);
+    
+    // sort by
+    boolean visit(HiveSortBy x);
+    void endVisit(HiveSortBy x);
+    
+    boolean visit(HiveSelectSortByItem x);
+    void endVisit(HiveSelectSortByItem x);
+    
+    // distribute by
+    boolean visit(HiveDistributeBy x);
+    void endVisit(HiveDistributeBy x);
+    
+    boolean visit(HiveDistributeByItem x);
+    void endVisit(HiveDistributeByItem x);
+    
+    // cluster by
+    boolean visit(HiveClusterBy x);
+    void endVisit(HiveClusterBy x);
+    
+    boolean visit(HiveClusterByItem x);
+    void endVisit(HiveClusterByItem x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitor.java
@@ -23,6 +23,8 @@ import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowDatabasesStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowTablesStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
@@ -60,4 +62,13 @@ public interface HiveASTVisitor extends SQLASTVisitor {
     
     boolean visit(HiveClusterByItem x);
     void endVisit(HiveClusterByItem x);
+    
+    // show databases
+    boolean visit(HiveShowDatabasesStatement x);
+    void endVisit(HiveShowDatabasesStatement x);
+    
+    // show tables
+    boolean visit(HiveShowTablesStatement x);
+    void endVisit(HiveShowTablesStatement x);
+    
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitorAdapter.java
@@ -15,9 +15,15 @@
  */
 package com.alibaba.druid.sql.dialect.hive.visitor;
 
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeByItem;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
 
@@ -61,4 +67,66 @@ public class HiveASTVisitorAdapter extends SQLASTVisitorAdapter implements HiveA
     public void endVisit(HiveInsert x) {
 
     }
+
+	@Override
+	public boolean visit(HiveSelectSortByItem x) {		
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveSelectSortByItem x) {		
+		
+	}
+
+	@Override
+	public boolean visit(HiveSortBy x) {		
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveSortBy x) {		
+		
+	}
+
+	@Override
+	public boolean visit(HiveDistributeBy x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeBy x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveDistributeByItem x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeByItem x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterBy x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveClusterBy x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterByItem x) {
+		return true;
+	}
+
+	@Override
+	public void endVisit(HiveClusterByItem x) {
+		
+	}
+    
+    
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveASTVisitorAdapter.java
@@ -23,6 +23,8 @@ import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowDatabasesStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowTablesStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
@@ -125,6 +127,26 @@ public class HiveASTVisitorAdapter extends SQLASTVisitorAdapter implements HiveA
 
 	@Override
 	public void endVisit(HiveClusterByItem x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveShowDatabasesStatement x) {
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowDatabasesStatement x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveShowTablesStatement x) {
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowTablesStatement x) {
 		
 	}
     

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
@@ -19,8 +19,13 @@ import java.util.List;
 import java.util.Map;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLOrderBy;
+import com.alibaba.druid.sql.ast.SQLOrderingSpecification;
+import com.alibaba.druid.sql.ast.SQLSetQuantifier;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
 import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
@@ -28,13 +33,23 @@ import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLExternalRecordFormat;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
 import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeByItem;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
+import com.alibaba.druid.sql.dialect.hive.stmt.HiveSelectQueryBlock;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 
 public class HiveOutputVisitor extends SQLASTOutputVisitor implements HiveASTVisitor {
@@ -336,4 +351,218 @@ public class HiveOutputVisitor extends SQLASTOutputVisitor implements HiveASTVis
     public void endVisit(HiveInsert x) {
 
     }
+
+	@Override
+	public boolean visit(HiveSelectSortByItem x) {
+		SQLExpr expr = x.getExpr();
+
+		if (expr instanceof SQLIntegerExpr) {
+			print(((SQLIntegerExpr) expr).getNumber().longValue());
+		} else {
+			printExpr(expr);
+		}
+
+		SQLOrderingSpecification type = x.getType();
+		if (type != null) {
+			print(' ');
+			print0(ucase ? type.name : type.name_lcase);
+		}
+
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveSelectSortByItem x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveSortBy x) {
+		List<HiveSelectSortByItem> items = x.getItems();
+		if (items.size() > 0) {
+			print0(ucase ? "SORT BY " : "sort by ");
+			for (int i = 0, size = items.size(); i < size; ++i) {
+				if (i != 0) {
+					print0(", ");
+				}
+				HiveSelectSortByItem item = items.get(i);
+				visit(item);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveSortBy x) {
+		
+	}
+    
+	protected void printQuery(SQLSelectQuery x) {
+		Class<?> clazz = x.getClass();
+		if (clazz == HiveSelectQueryBlock.class) {
+			visit((HiveSelectQueryBlock) x);
+		} else if (clazz == SQLUnionQuery.class) {
+			visit((SQLUnionQuery) x);
+		} else {
+			x.accept(this);
+		}
+	}
+	
+	public boolean visit(HiveSelectQueryBlock x) {
+		if (isPrettyFormat() && x.hasBeforeComment()) {
+			printlnComments(x.getBeforeCommentsDirect());
+		}
+
+		print0(ucase ? "SELECT " : "select ");
+
+		final int distinctOption = x.getDistionOption();
+		if (SQLSetQuantifier.ALL == distinctOption) {
+			print0(ucase ? "ALL " : "all ");
+		} else if (SQLSetQuantifier.DISTINCT == distinctOption) {
+			print0(ucase ? "DISTINCT " : "distinct ");
+		}
+
+		printSelectList(x.getSelectList());
+
+		SQLExprTableSource into = x.getInto();
+		if (into != null) {
+			println();
+			print0(ucase ? "INTO " : "into ");
+			into.accept(this);
+		}
+
+		SQLTableSource from = x.getFrom();
+		if (from != null) {
+			println();
+			print0(ucase ? "FROM " : "from ");
+			;
+			printTableSource(from);
+		}
+
+		SQLExpr where = x.getWhere();
+		if (where != null) {
+			println();
+			print0(ucase ? "WHERE " : "where ");
+			printExpr(where);
+		}
+
+		printHierarchical(x);
+
+		SQLSelectGroupByClause groupBy = x.getGroupBy();
+		if (groupBy != null) {
+			println();
+			visit(groupBy);
+		}
+		
+		HiveClusterBy hiveClusterBy = x.getHiveClusterBy();
+		if(hiveClusterBy != null) {
+			println();
+			hiveClusterBy.accept(this);
+		}
+		
+		HiveDistributeBy hiveDistributeBy = x.getHiveDistributeBy();
+		if(hiveDistributeBy != null) {
+			println();
+			hiveDistributeBy.accept(this);
+		}
+
+		HiveSortBy hiveSortBy = x.getHiveSortBy();
+		if (hiveSortBy != null) {
+			println();
+			hiveSortBy.accept(this);
+		}
+
+		SQLOrderBy orderBy = x.getOrderBy();
+		if (orderBy != null) {
+			println();
+			orderBy.accept(this);
+		}
+		
+		SQLLimit limit = x.getLimit();
+		if(limit != null) {
+			println();
+			limit.accept(this);
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean visit(HiveDistributeBy x) {
+		List<HiveDistributeByItem> items = x.getItems();
+		if (items.size() > 0) {
+			print0(ucase ? "DISTRIBUTE BY " : "distribute by ");
+			for (int i = 0, size = items.size(); i < size; ++i) {
+				if (i != 0) {
+					print0(", ");
+				}
+				HiveDistributeByItem item = items.get(i);
+				visit(item);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeBy x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveDistributeByItem x) {
+		SQLExpr expr = x.getExpr();
+
+		if (expr instanceof SQLIntegerExpr) {
+			print(((SQLIntegerExpr) expr).getNumber().longValue());
+		} else {
+			printExpr(expr);
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeByItem x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterBy x) {
+		List<HiveClusterByItem> items = x.getItems();
+		if (items.size() > 0) {
+			print0(ucase ? "CLUSTER BY " : "cluster by ");
+			for (int i = 0, size = items.size(); i < size; ++i) {
+				if (i != 0) {
+					print0(", ");
+				}
+				HiveClusterByItem item = items.get(i);
+				visit(item);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveClusterBy x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterByItem x) {
+		SQLExpr expr = x.getExpr();
+
+		if (expr instanceof SQLIntegerExpr) {
+			print(((SQLIntegerExpr) expr).getNumber().longValue());
+		} else {
+			printExpr(expr);
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveClusterByItem x) {
+		
+	}
+	
+	
+
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
@@ -47,6 +47,8 @@ import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowDatabasesStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowTablesStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveSelectQueryBlock;
@@ -560,6 +562,43 @@ public class HiveOutputVisitor extends SQLASTOutputVisitor implements HiveASTVis
 
 	@Override
 	public void endVisit(HiveClusterByItem x) {
+		
+	}
+
+	@Override
+	public boolean visit(HiveShowDatabasesStatement x) {
+		print0(ucase ? "SHOW DATABASES" : "show databases");
+		SQLExpr like = x.getLike();
+		if(like != null) {
+			print0(ucase ? " LIKE " : " like ");
+			printExpr(like);
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowDatabasesStatement x) {
+	
+	}
+
+	@Override
+	public boolean visit(HiveShowTablesStatement x) {
+		print0(ucase ? "SHOW TABLES" : "show tables");
+		SQLExpr database = x.getDatabase();
+		if(database != null) {
+			print0(ucase ? " IN " : " in ");
+			printExpr(database);
+		}
+		SQLExpr like = x.getLike();
+		if(like != null) {
+			print0(" ");
+			printExpr(like);
+		}
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowTablesStatement x) {
 		
 	}
 	

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveSchemaStatVisitor.java
@@ -28,6 +28,8 @@ import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowDatabasesStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveShowTablesStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
@@ -192,6 +194,30 @@ public class HiveSchemaStatVisitor extends SchemaStatVisitor implements HiveASTV
 
 	@Override
 	public void endVisit(HiveClusterByItem x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveShowDatabasesStatement x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowDatabasesStatement x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveShowTablesStatement x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveShowTablesStatement x) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveSchemaStatVisitor.java
@@ -20,9 +20,15 @@ import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveClusterByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeBy;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveDistributeByItem;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSelectSortByItem;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveSortBy;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.stat.TableStat;
@@ -117,5 +123,77 @@ public class HiveSchemaStatVisitor extends SchemaStatVisitor implements HiveASTV
 
         return false;
     }
+
+	@Override
+	public boolean visit(HiveSelectSortByItem x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveSelectSortByItem x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveSortBy x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveSortBy x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveDistributeBy x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeBy x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveDistributeByItem x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveDistributeByItem x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterBy x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveClusterBy x) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean visit(HiveClusterByItem x) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void endVisit(HiveClusterByItem x) {
+		// TODO Auto-generated method stub
+		
+	}
 
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGLexer.java
@@ -80,6 +80,8 @@ public class PGLexer extends Lexer {
         super(input);
         super.keywods = DEFAULT_PG_KEYWORDS;
         super.dbType = JdbcConstants.POSTGRESQL;
+        // postgresql not support chinese indentifier 
+        config(SQLParserFeature.IngoreChinese, true);
         for (SQLParserFeature feature : features) {
             config(feature, true);
         }
@@ -215,7 +217,7 @@ public class PGLexer extends Lexer {
         for (;;) {
             ch = charAt(++pos);
 
-            if (!isIdentifierChar(ch)) {
+            if (!isIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                 break;
             }
 
@@ -228,4 +230,6 @@ public class PGLexer extends Lexer {
         stringVal = addSymbol();
         token = Token.VARIANT;
     }
+    
+
 }

--- a/src/main/java/com/alibaba/druid/sql/parser/CharTypes.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/CharTypes.java
@@ -55,11 +55,23 @@ public class CharTypes {
     }
 
     public static boolean isFirstIdentifierChar(char c) {
-        if (c <= firstIdentifierFlags.length) {
-            return firstIdentifierFlags[c];
-        }
-        return c != '　' && c != '，';
+//        if (c <= firstIdentifierFlags.length) {
+//            return firstIdentifierFlags[c];
+//        }
+//        return c != '　' && c != '，';
+    	return isFirstIdentifierChar(c, false);
     }
+    
+	public static boolean isFirstIdentifierChar(char c, boolean ignoreChinese) {
+		if (c <= firstIdentifierFlags.length) {
+			return firstIdentifierFlags[c];
+		}
+		if (!ignoreChinese) {
+			return c != '　' && c != '，';
+		} else {
+			return true;
+		}
+	}
 
     private final static String[] stringCache = new String[256];
     private final static boolean[] identifierFlags = new boolean[256];
@@ -87,11 +99,23 @@ public class CharTypes {
     }
 
     public static boolean isIdentifierChar(char c) {
-        if (c <= identifierFlags.length) {
-            return identifierFlags[c];
-        }
-        return c != '　' && c != '，' && c != '）';
+//        if (c <= identifierFlags.length) {
+//            return identifierFlags[c];
+//        }
+//        return c != '　' && c != '，' && c != '）';
+    	return isIdentifierChar(c, false);
     }
+    
+	public static boolean isIdentifierChar(char c, boolean ignoreChinese) {
+		if (c <= identifierFlags.length) {
+			return identifierFlags[c];
+		}
+		if (!ignoreChinese) {
+			return c != '　' && c != '，' && c != '）';
+		} else {
+			return true;
+		}
+	}
 
     public static String valueOf(char ch) {
         if (ch < stringCache.length) {
@@ -118,8 +142,20 @@ public class CharTypes {
      * @return false if {@link LayoutCharacters#EOI}
      */
     public static boolean isWhitespace(char c) {
-        return (c <= whitespaceFlags.length && whitespaceFlags[c]) //
-               || c == '　'; // Chinese space
+//        return (c <= whitespaceFlags.length && whitespaceFlags[c]) //
+//               || c == '　'; // Chinese space
+    	return isWhitespace(c, false);
     }
+    
+	public static boolean isWhitespace(char c, boolean ignoreChinese) {
+		if (c <= whitespaceFlags.length) {
+			return whitespaceFlags[c];
+		}
+		if (!ignoreChinese) {
+			return c == '　';
+		} else {
+			return false;
+		}
+	}
 
 }

--- a/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -479,7 +479,7 @@ public class Lexer {
                     && ((c1 = text.charAt(pos + 1)) == 'u' || c1 == 'U')
                     && ((c2 = text.charAt(pos + 2)) == 'l' || c2 == 'L')
                     && ((c3 = text.charAt(pos + 3)) == 'l' || c3 == 'L')
-                    && (isWhitespace(c4 = text.charAt(pos + 4)) || c4 == ',' || c4 == ')')) {
+                    && (isWhitespace(c4 = text.charAt(pos + 4), isEnabled(SQLParserFeature.IngoreChinese)) || c4 == ',' || c4 == ')')) {
                 pos += 4;
                 ch = c4;
                 token = Token.NULL;
@@ -503,7 +503,7 @@ public class Lexer {
             return;
         }
 
-        if (isFirstIdentifierChar(ch)) {
+        if (isFirstIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
             scanIdentifier();
             return;
         }
@@ -546,7 +546,7 @@ public class Lexer {
 
             if ((c1 == 'o' || c1 == 'O')
                     && (c2 == 't' || c2 == 'T')
-                    && isWhitespace(c3)) {
+                    && isWhitespace(c3, isEnabled(SQLParserFeature.IngoreChinese))) {
                 pos += 3;
                 ch = c3;
                 token = Token.NOT;
@@ -576,7 +576,7 @@ public class Lexer {
             scanChar();
         }
 
-        if (isFirstIdentifierChar(ch)) {
+        if (isFirstIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
             scanIdentifier();
             return;
         }
@@ -601,7 +601,7 @@ public class Lexer {
         int startLine = line;
         
         for (;;) {
-            if (isWhitespace(ch)) {
+            if (isWhitespace(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                 if (ch == '\n') {
                     line++;
                     
@@ -617,16 +617,18 @@ public class Lexer {
                 return;
             }
 
-            if (isFirstIdentifierChar(ch)) {
-                if (ch == '（') {
-                    scanChar();
-                    token = LPAREN;
-                    return;
-                } else if (ch == '）') {
-                    scanChar();
-                    token = RPAREN;
-                    return;
-                }
+            if (isFirstIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
+				if (!isEnabled(SQLParserFeature.IngoreChinese)) {
+					if (ch == '（') {
+						scanChar();
+						token = LPAREN;
+						return;
+					} else if (ch == '）') {
+						scanChar();
+						token = RPAREN;
+						return;
+					}
+				}               
 
                 if (ch == 'N' || ch == 'n') {
                     if (charAt(pos + 1) == '\'') {
@@ -668,13 +670,21 @@ public class Lexer {
                     scanChar();
                     token = COMMA;
                     return;
-                case '(':
                 case '（':
+					if (isEnabled(SQLParserFeature.IngoreChinese)) {
+						scanChar();
+						return;
+					}
+                case '(':
                     scanChar();
                     token = LPAREN;
                     return;
-                case ')':
                 case '）':
+                	if (isEnabled(SQLParserFeature.IngoreChinese)) {
+						scanChar();
+						return;
+					}
+                case ')':
                     scanChar();
                     token = RPAREN;
                     return;
@@ -715,7 +725,7 @@ public class Lexer {
                     return;
                 case '.':
                     scanChar();
-                    if (isDigit(ch) && !isFirstIdentifierChar(charAt(pos - 2))) {
+                    if (isDigit(ch) && !isFirstIdentifierChar(charAt(pos - 2), isEnabled(SQLParserFeature.IngoreChinese))) {
                         unscan();
                         scanNumber();
                         return;
@@ -990,7 +1000,7 @@ public class Lexer {
                 break;
             case '!':
                 scanChar();
-                while (isWhitespace(ch)) {
+                while (isWhitespace(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                     scanChar();
                 }
                 if (ch == '=') {
@@ -1555,7 +1565,7 @@ public class Lexer {
         for (;;) {
             ch = charAt(++pos);
 
-            if (!isIdentifierChar(ch)) {
+            if (!isIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                 break;
             }
 
@@ -1587,7 +1597,7 @@ public class Lexer {
         for (;;) {
             ch = charAt(++pos);
 
-            if (!isIdentifierChar(ch)) {
+            if (!isIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                 break;
             }
 
@@ -1743,7 +1753,7 @@ public class Lexer {
             return;
         }
 
-        final boolean firstFlag = isFirstIdentifierChar(first);
+        final boolean firstFlag = isFirstIdentifierChar(first, isEnabled(SQLParserFeature.IngoreChinese));
         if (!firstFlag) {
             throw new ParserException("illegal identifier. " + info());
         }
@@ -1763,7 +1773,7 @@ public class Lexer {
         for (;;) {
             ch = charAt(++pos);
 
-            if (!isIdentifierChar(ch)) {
+            if (!isIdentifierChar(ch, isEnabled(SQLParserFeature.IngoreChinese))) {
                 break;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLParserFeature.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLParserFeature.java
@@ -27,6 +27,8 @@ public enum SQLParserFeature {
     StrictForWall,
 
     PipesAsConcat, // for mysql
+    
+    IngoreChinese, // for postgresql
     ;
 
     private SQLParserFeature(){

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -251,6 +251,7 @@ public enum Token {
     DISTRIBUTE("DISTRIBUTE"),
     
     // hive
+    CLUSTER("CLUSTER"),
 
     EOF, 
     ERROR,

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -18,7 +18,10 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_limit() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 5";
-		String expected = "SELECT col_1, col_2\nFROM table_1\nLIMIT 5";
+		
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "LIMIT 5"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -28,7 +31,10 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_sortby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 SORT BY col_1 ASC, col_2 DESC";
-		String expected = "SELECT col_1, col_2\nFROM table_1\nSORT BY col_1 ASC, col_2 DESC";
+		
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "SORT BY col_1 ASC, col_2 DESC"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -38,7 +44,10 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_distributeby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1";
-		String expected = "SELECT col_1, col_2\nFROM table_1\nDISTRIBUTE BY col_1";
+		
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "DISTRIBUTE BY col_1"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -48,7 +57,10 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_clusterby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 CLUSTER BY col_1";
-		String expected = "SELECT col_1, col_2\nFROM table_1\nCLUSTER BY col_1";
+		
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "CLUSTER BY col_1"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -57,8 +69,16 @@ public class HiveSelectParserTest extends TestCase {
 	}
 
 	public void test_complex() throws Exception {
-		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1 SORT BY col_1 ASC, col_2 DESC LIMIT 5";
-		String expected = "SELECT col_1, col_2\nFROM table_1\nDISTRIBUTE BY col_1\nSORT BY col_1 ASC, col_2 DESC\nLIMIT 5";
+		String sql = "SELECT col_1, col_2 FROM table_1 " //
+				+ "DISTRIBUTE BY col_1 " //
+				+ "SORT BY col_1 ASC, col_2 DESC " //
+				+ "LIMIT 5"; //
+		
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "DISTRIBUTE BY col_1\n" //
+				+ "SORT BY col_1 ASC, col_2 DESC\n" //
+				+ "LIMIT 5"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -67,10 +87,24 @@ public class HiveSelectParserTest extends TestCase {
 	}
 
 	public void test_union_order_limit_1() throws Exception {
-		String sql = "SELECT col_1 col FROM table_1 union SELECT col_2 col FROM table_2 union "
-				+ "SELECT col_3 col FROM table_3 ORDER BY col ASC LIMIT 5";
-		String expected = "SELECT col_1 AS col\nFROM table_1\nUNION\nSELECT col_2 AS col\nFROM table_2\nUNION\n"
-				+ "SELECT col_3 AS col\nFROM table_3\nORDER BY col ASC\nLIMIT 5";
+		String sql = "SELECT col_1 col FROM table_1 " //
+				+ "union " //
+				+ "SELECT col_2 col FROM table_2 " //
+				+ "union " //
+				+ "SELECT col_3 col FROM table_3 " //
+				+ "ORDER BY col ASC " //
+				+ "LIMIT 5"; //
+		
+		String expected = "SELECT col_1 AS col\n" //
+				+ "FROM table_1\n" //
+				+ "UNION\n" //
+				+ "SELECT col_2 AS col\n" //
+				+ "FROM table_2\n" //
+				+ "UNION\n" //
+				+ "SELECT col_3 AS col\n" //
+				+ "FROM table_3\n" //
+				+ "ORDER BY col ASC\n" //
+				+ "LIMIT 5"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -79,10 +113,28 @@ public class HiveSelectParserTest extends TestCase {
 	}
 
 	public void test_union_order_limit_2() throws Exception {
-		String sql = "select tmp.col col from (SELECT col_1 col FROM table_1 ORDER BY col LIMIT 5) tmp union "
-				+ "SELECT col_2 col FROM table_2 union SELECT col_3 col FROM table_3 ORDER BY col ASC LIMIT 5";
-		String expected = "SELECT tmp.col AS col\nFROM (\n\tSELECT col_1 AS col\n\tFROM table_1\n\tORDER BY col\n\tLIMIT 5\n) tmp\n"
-				+ "UNION\nSELECT col_2 AS col\nFROM table_2\nUNION\nSELECT col_3 AS col\nFROM table_3\nORDER BY col ASC\nLIMIT 5";
+		String sql = "select tmp.col col from (SELECT col_1 col FROM table_1 ORDER BY col LIMIT 5) tmp " //
+				+ "union " //
+				+ "SELECT col_2 col FROM table_2 " //
+				+ "union " //
+				+ "SELECT col_3 col FROM table_3 " //
+				+ "ORDER BY col ASC LIMIT 5"; //
+		
+		String expected = "SELECT tmp.col AS col\n" //
+				+ "FROM (\n" //
+				+ "\tSELECT col_1 AS col\n" //
+				+ "\tFROM table_1\n" //
+				+ "\tORDER BY col\n" //
+				+ "\tLIMIT 5\n" //
+				+ ") tmp\n" //
+				+ "UNION\n" //
+				+ "SELECT col_2 AS col\n" //
+				+ "FROM table_2\n" //
+				+ "UNION\n" //
+				+ "SELECT col_3 AS col\n" //
+				+ "FROM table_3\n" //
+				+ "ORDER BY col ASC\n" //
+				+ "LIMIT 5"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -65,7 +65,6 @@ public class HiveSelectParserTest extends TestCase {
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		for (SQLStatement stmt : stmtList) {
 			String result = stmt.toString();
-			System.out.println(result);
 			if (result == null || result.toUpperCase().indexOf("DISTRIBUTE BY") < 0) {
 				throw new Exception("'DISTRIBUTE BY' not found in the result");
 			}
@@ -78,4 +77,35 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 
+	public void test_union_order_limit_1() throws Exception {
+		String sql = "SELECT col_1 col FROM table_1 "
+				+ "union "
+				+ "SELECT col_2 col FROM table_2 "
+				+ "union "
+				+ "SELECT col_3 col FROM table_3 "
+				+ "ORDER BY col ASC LIMIT 5";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
+				throw new Exception("'LIMIT' not found in the result");
+			}
+		}
+	}
+	
+	public void test_union_order_limit_2() throws Exception {
+		String sql = "select tmp.col col from (SELECT col_1 col FROM table_1 ORDER BY col LIMIT 5) tmp "
+				+ "union "
+				+ "SELECT col_2 col FROM table_2 "
+				+ "union "
+				+ "SELECT col_3 col FROM table_3 "
+				+ "ORDER BY col ASC LIMIT 5";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
+				throw new Exception("'LIMIT' not found in the result");
+			}
+		}
+	}
 }

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -16,7 +16,7 @@ import junit.framework.TestCase;
  */
 public class HiveSelectParserTest extends TestCase {
 
-	public void _limit() throws Exception {
+	public void test_limit() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		for (SQLStatement stmt : stmtList) {
@@ -27,7 +27,7 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 
-	public void _sortby() throws Exception {
+	public void test_sortby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 SORT BY col_1 ASC, col_2 DESC";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		for (SQLStatement stmt : stmtList) {
@@ -38,7 +38,7 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 	
-	public void _distributeby() throws Exception {
+	public void test_distributeby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		for (SQLStatement stmt : stmtList) {
@@ -60,7 +60,7 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 	
-	public void _complex() throws Exception {
+	public void test_complex() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1 SORT BY col_1 ASC, col_2 DESC LIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		for (SQLStatement stmt : stmtList) {

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -18,94 +18,75 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_limit() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 5";
+		String expected = "SELECT col_1, col_2\nFROM table_1\nLIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
-				throw new Exception("'LIMIT' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
 
 	public void test_sortby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 SORT BY col_1 ASC, col_2 DESC";
+		String expected = "SELECT col_1, col_2\nFROM table_1\nSORT BY col_1 ASC, col_2 DESC";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("SORT BY") < 0) {
-				throw new Exception("'SORT BY' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
-	
+
 	public void test_distributeby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1";
+		String expected = "SELECT col_1, col_2\nFROM table_1\nDISTRIBUTE BY col_1";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("DISTRIBUTE BY") < 0) {
-				throw new Exception("'DISTRIBUTE BY' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
-	
+
 	public void test_clusterby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 CLUSTER BY col_1";
+		String expected = "SELECT col_1, col_2\nFROM table_1\nCLUSTER BY col_1";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("CLUSTER BY") < 0) {
-				throw new Exception("'CLUSTER BY' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
-	
+
 	public void test_complex() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1 SORT BY col_1 ASC, col_2 DESC LIMIT 5";
+		String expected = "SELECT col_1, col_2\nFROM table_1\nDISTRIBUTE BY col_1\nSORT BY col_1 ASC, col_2 DESC\nLIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("DISTRIBUTE BY") < 0) {
-				throw new Exception("'DISTRIBUTE BY' not found in the result");
-			}
-			if (result == null || result.toUpperCase().indexOf("SORT BY") < 0) {
-				throw new Exception("'SORT BY' not found in the result");
-			}
-			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
-				throw new Exception("'LIMIT' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
 
 	public void test_union_order_limit_1() throws Exception {
-		String sql = "SELECT col_1 col FROM table_1 "
-				+ "union "
-				+ "SELECT col_2 col FROM table_2 "
-				+ "union "
-				+ "SELECT col_3 col FROM table_3 "
-				+ "ORDER BY col ASC LIMIT 5";
+		String sql = "SELECT col_1 col FROM table_1 union SELECT col_2 col FROM table_2 union "
+				+ "SELECT col_3 col FROM table_3 ORDER BY col ASC LIMIT 5";
+		String expected = "SELECT col_1 AS col\nFROM table_1\nUNION\nSELECT col_2 AS col\nFROM table_2\nUNION\n"
+				+ "SELECT col_3 AS col\nFROM table_3\nORDER BY col ASC\nLIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
-				throw new Exception("'LIMIT' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
-	
+
 	public void test_union_order_limit_2() throws Exception {
-		String sql = "select tmp.col col from (SELECT col_1 col FROM table_1 ORDER BY col LIMIT 5) tmp "
-				+ "union "
-				+ "SELECT col_2 col FROM table_2 "
-				+ "union "
-				+ "SELECT col_3 col FROM table_3 "
-				+ "ORDER BY col ASC LIMIT 5";
+		String sql = "select tmp.col col from (SELECT col_1 col FROM table_1 ORDER BY col LIMIT 5) tmp union "
+				+ "SELECT col_2 col FROM table_2 union SELECT col_3 col FROM table_3 ORDER BY col ASC LIMIT 5";
+		String expected = "SELECT tmp.col AS col\nFROM (\n\tSELECT col_1 AS col\n\tFROM table_1\n\tORDER BY col\n\tLIMIT 5\n) tmp\n"
+				+ "UNION\nSELECT col_2 AS col\nFROM table_2\nUNION\nSELECT col_3 AS col\nFROM table_3\nORDER BY col ASC\nLIMIT 5";
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
-			String result = stmt.toString();
-			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
-				throw new Exception("'LIMIT' not found in the result");
-			}
+			assertEquals(expected, stmt.toString());
 		}
 	}
 }

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -1,0 +1,81 @@
+package com.alibaba.druid.sql.parser;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.util.JdbcConstants;
+
+import junit.framework.TestCase;
+
+/**
+ * Hivesql syntax parser test
+ * 
+ * @author garfield
+ *
+ */
+public class HiveSelectParserTest extends TestCase {
+
+	public void _limit() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 5";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
+				throw new Exception("'LIMIT' not found in the result");
+			}
+		}
+	}
+
+	public void _sortby() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 SORT BY col_1 ASC, col_2 DESC";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("SORT BY") < 0) {
+				throw new Exception("'SORT BY' not found in the result");
+			}
+		}
+	}
+	
+	public void _distributeby() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("DISTRIBUTE BY") < 0) {
+				throw new Exception("'DISTRIBUTE BY' not found in the result");
+			}
+		}
+	}
+	
+	public void test_clusterby() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 CLUSTER BY col_1";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			if (result == null || result.toUpperCase().indexOf("CLUSTER BY") < 0) {
+				throw new Exception("'CLUSTER BY' not found in the result");
+			}
+		}
+	}
+	
+	public void _complex() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1 SORT BY col_1 ASC, col_2 DESC LIMIT 5";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			System.out.println(result);
+			if (result == null || result.toUpperCase().indexOf("DISTRIBUTE BY") < 0) {
+				throw new Exception("'DISTRIBUTE BY' not found in the result");
+			}
+			if (result == null || result.toUpperCase().indexOf("SORT BY") < 0) {
+				throw new Exception("'SORT BY' not found in the result");
+			}
+			if (result == null || result.toUpperCase().indexOf("LIMIT") < 0) {
+				throw new Exception("'LIMIT' not found in the result");
+			}
+		}
+	}
+
+}

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveSelectParserTest.java
@@ -9,16 +9,98 @@ import com.alibaba.druid.util.JdbcConstants;
 import junit.framework.TestCase;
 
 /**
- * Hivesql syntax parser test
+ * <pre>
+ * HiveSQL Syntax Parsing Test <br>
+ * Unsupported Syntax <br>
+ * 1. Hint <br>
+ * SELECT / *+ STREAMTABLE(a) * / ... <br>
+ * SELECT / *+ MAPJOIN(b) * / ... <br>
+ * 
+ * 2. TABLESAMPLE
+ * SELECT * FROM source TABLESAMPLE(BUCKET 3 OUT OF 32 ON rand()) s;
+ * 
+ * 3. Outer Lateral Views
+ * SELECT * FROM src LATERAL VIEW OUTER explode(array()) C AS a limit 10;
+ * 
+ * 4. WINDOW clause
+ * SELECT a, SUM(b) OVER w
+ * FROM T
+ * WINDOW w AS (PARTITION BY c ORDER BY d ROWS UNBOUNDED PRECEDING);
+ * 
+ * ***** ATTACHED SELECT SYNTAX ***** <br>
+ * [WITH CommonTableExpression (, CommonTableExpression)*] <br>
+ * SELECT [ALL | DISTINCT] select_expr, select_expr, ... <br>
+ * FROM table_reference <br>
+ * [WHERE where_condition] <br>
+ * [GROUP BY col_list] <br>
+ * [ORDER BY col_list] <br>
+ * [CLUSTER BY col_list <br>
+ * | [DISTRIBUTE BY col_list] [SORT BY col_list] <br>
+ * ] <br>
+ * [LIMIT [offset,] rows] <br>
+ * </pre>
+ * 
+ * 
  * 
  * @author garfield
  *
  */
 public class HiveSelectParserTest extends TestCase {
 
+	public void test_distinct() throws Exception {
+		String sql = "SELECT DISTINCT col1, col2 FROM t1";
+
+		String expected = "SELECT DISTINCT col1, col2\n" //
+				+ "FROM t1"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_all() throws Exception {
+		String sql = "SELECT ALL col1, col2 FROM t1";
+
+		String expected = "SELECT ALL col1, col2\n" //
+				+ "FROM t1"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_with() throws Exception {
+		String sql = "with q1 as (select * from src where key= '5')," //
+				+ "q2 as (select * from src s2 where key = '4') " //
+				+ "select * from q1 union all select * from q2"; //
+
+		String expected = "WITH q1 AS (\n" //
+				+ "\t\tSELECT *\n" //
+				+ "\t\tFROM src\n" //
+				+ "\t\tWHERE key = '5'\n" //
+				+ "\t), \n" //
+				+ "\tq2 AS (\n" //
+				+ "\t\tSELECT *\n" //
+				+ "\t\tFROM src s2\n" //
+				+ "\t\tWHERE key = '4'\n" //
+				+ "\t)\n" //
+				+ "SELECT *\n" //
+				+ "FROM q1\n" //
+				+ "UNION ALL\n" //
+				+ "SELECT *\n" //
+				+ "FROM q2"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
 	public void test_limit() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 5";
-		
+
 		String expected = "SELECT col_1, col_2\n" //
 				+ "FROM table_1\n" //
 				+ "LIMIT 5"; //
@@ -29,9 +111,41 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 
+	public void test_limit_offset() throws Exception {
+		String sql = "SELECT col_1, col_2 FROM table_1 LIMIT 2,5";
+
+		String expected = "SELECT col_1, col_2\n" //
+				+ "FROM table_1\n" //
+				+ "LIMIT 2, 5"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_groupby() throws Exception {
+		String sql = "SELECT pv_users.gender, " //
+				+ "count(DISTINCT pv_users.userid), " //
+				+ "count(*), " //
+				+ "sum(DISTINCT pv_users.userid) " //
+				+ "FROM pv_users " //
+				+ "GROUP BY pv_users.gender";//
+
+		String expected = "SELECT pv_users.gender, COUNT(DISTINCT pv_users.userid), COUNT(*)\n" //
+				+ "\t, SUM(DISTINCT pv_users.userid)\n" //
+				+ "FROM pv_users\n" //
+				+ "GROUP BY pv_users.gender"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
 	public void test_sortby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 SORT BY col_1 ASC, col_2 DESC";
-		
+
 		String expected = "SELECT col_1, col_2\n" //
 				+ "FROM table_1\n" //
 				+ "SORT BY col_1 ASC, col_2 DESC"; //
@@ -44,7 +158,7 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_distributeby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 DISTRIBUTE BY col_1";
-		
+
 		String expected = "SELECT col_1, col_2\n" //
 				+ "FROM table_1\n" //
 				+ "DISTRIBUTE BY col_1"; //
@@ -57,7 +171,7 @@ public class HiveSelectParserTest extends TestCase {
 
 	public void test_clusterby() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 CLUSTER BY col_1";
-		
+
 		String expected = "SELECT col_1, col_2\n" //
 				+ "FROM table_1\n" //
 				+ "CLUSTER BY col_1"; //
@@ -68,17 +182,46 @@ public class HiveSelectParserTest extends TestCase {
 		}
 	}
 
-	public void test_complex() throws Exception {
+	public void test_distributeby_sortby_limit() throws Exception {
 		String sql = "SELECT col_1, col_2 FROM table_1 " //
 				+ "DISTRIBUTE BY col_1 " //
 				+ "SORT BY col_1 ASC, col_2 DESC " //
 				+ "LIMIT 5"; //
-		
+
 		String expected = "SELECT col_1, col_2\n" //
 				+ "FROM table_1\n" //
 				+ "DISTRIBUTE BY col_1\n" //
 				+ "SORT BY col_1 ASC, col_2 DESC\n" //
 				+ "LIMIT 5"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_join_multi_table() throws Exception {
+		String sql = "SELECT a.val, b.val, c.val FROM a " //
+				+ "JOIN b ON (a.key = b.key1) " //
+				+ "JOIN c ON (c.key = b.key2)"; //
+
+		String expected = "SELECT a.val, b.val, c.val\n" //
+				+ "FROM a\n" //
+				+ "\tJOIN b ON a.key = b.key1\n" //
+				+ "\tJOIN c ON c.key = b.key2"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_join_semi() throws Exception {
+		String sql = "SELECT a.key, a.val FROM a LEFT SEMI JOIN b ON (a.key = b.key)";
+
+		String expected = "SELECT a.key, a.val\n" //
+				+ "FROM a\n" //
+				+ "\tLEFT SEMI JOIN b ON a.key = b.key"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {
@@ -94,7 +237,7 @@ public class HiveSelectParserTest extends TestCase {
 				+ "SELECT col_3 col FROM table_3 " //
 				+ "ORDER BY col ASC " //
 				+ "LIMIT 5"; //
-		
+
 		String expected = "SELECT col_1 AS col\n" //
 				+ "FROM table_1\n" //
 				+ "UNION\n" //
@@ -119,7 +262,7 @@ public class HiveSelectParserTest extends TestCase {
 				+ "union " //
 				+ "SELECT col_3 col FROM table_3 " //
 				+ "ORDER BY col ASC LIMIT 5"; //
-		
+
 		String expected = "SELECT tmp.col AS col\n" //
 				+ "FROM (\n" //
 				+ "\tSELECT col_1 AS col\n" //
@@ -135,6 +278,53 @@ public class HiveSelectParserTest extends TestCase {
 				+ "FROM table_3\n" //
 				+ "ORDER BY col ASC\n" //
 				+ "LIMIT 5"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_regex_column() throws Exception {
+		String sql = "SELECT `(ds|hr)?+.+` FROM sales";
+
+		String expected = "SELECT `(ds|hr)?+.+`\n" //
+				+ "FROM sales"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_subquery() throws Exception {
+		String sql = "SELECT t3.col FROM (" //
+				+ "SELECT a+b AS col FROM t1 " //
+				+ "UNION ALL " //
+				+ "SELECT c+d AS col FROM t2) t3"; //
+
+		String expected = "SELECT t3.col\n" //
+				+ "FROM (\n" //
+				+ "\tSELECT a + b AS col\n" //
+				+ "\tFROM t1\n" //
+				+ "\tUNION ALL\n" //
+				+ "\tSELECT c + d AS col\n" //
+				+ "\tFROM t2\n" //
+				+ ") t3"; //
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+
+	public void test_lateral_view() throws Exception {
+		String sql = "SELECT * FROM exampleTable " + "LATERAL VIEW explode(col1) myTable1 AS myCol1 "
+				+ "LATERAL VIEW explode(myCol1) myTable2 AS myCol2";
+
+		String expected = "SELECT *\n" //
+				+ "FROM exampleTable\n" + "\tLATERAL VIEW explode(col1) myTable1 AS myCol1\n"
+				+ "\tLATERAL VIEW explode(myCol1) myTable2 AS myCol2"; //
 		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
 		assertEquals(1, stmtList.size());
 		for (SQLStatement stmt : stmtList) {

--- a/src/test/java/com/alibaba/druid/sql/parser/HiveShowParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/HiveShowParserTest.java
@@ -1,0 +1,72 @@
+package com.alibaba.druid.sql.parser;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.util.JdbcConstants;
+
+import junit.framework.TestCase;
+
+/**
+ * Hivesql syntax "SHOW" parser test
+ * 
+ * @author garfield
+ *
+ */
+public class HiveShowParserTest extends TestCase {
+
+	public void test_show_databases_0() throws Exception {
+		String sql = "SHOW DATABASES LIKE 'test*'";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW DATABASES LIKE 'test*'", result);
+		}
+	}
+	
+	public void test_show_databases_1() throws Exception {
+		String sql = "SHOW DATABASES";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW DATABASES", result);
+		}
+	}
+	
+	public void test_show_tables_0() throws Exception {
+		String sql = "SHOW TABLES IN TEST_DB 'test*'";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW TABLES IN TEST_DB 'test*'", result);
+		}
+	}
+	
+	public void test_show_tables_1() throws Exception {
+		String sql = "SHOW TABLES";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW TABLES", result);
+		}
+	}
+	
+	public void test_show_tables_2() throws Exception {
+		String sql = "SHOW TABLES IN TEST_DB";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW TABLES IN TEST_DB", result);
+		}
+	}
+	
+	public void test_show_tables_3() throws Exception {
+		String sql = "SHOW TABLES 'test*'";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.HIVE);
+		for (SQLStatement stmt : stmtList) {
+			String result = stmt.toString();
+			assertEquals("SHOW TABLES 'test*'", result);
+		}
+	}
+}

--- a/src/test/java/com/alibaba/druid/sql/parser/PGChineseSQLParseTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/PGChineseSQLParseTest.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.sql.parser;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.util.JdbcConstants;
+
+import junit.framework.TestCase;
+
+/**
+ * <p>
+ * 测试PostgreSQL包含中文SQL语句兼容性
+ * </p>
+ * <p>
+ * 备注：Druid支持可以使用中文标点（空格、括号、逗号）作为标识符。
+ * PostgreSQL将中文标点仅作为字符串，将导致SQL解析出错，例如:
+ * <code>SELECT col_1 AS 一级（测试）列 FROM table_1</code>
+ * 通过增加词法分析器IgnoreChinese特性和对应处理，支持忽略中文标点。
+ * </p>
+ * 
+ * @author garfield
+ *
+ */
+public class PGChineseSQLParseTest extends TestCase {
+
+	public void test_chinese() throws Exception {
+		String sql = "SELECT col_1 AS 一级（测试）列 FROM table_1";
+		String expected = "SELECT col_1 AS 一级（测试）列\nFROM table_1";
+		List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, JdbcConstants.POSTGRESQL);
+		assertEquals(1, stmtList.size());
+		for (SQLStatement stmt : stmtList) {
+			assertEquals(expected, stmt.toString());
+		}
+	}
+}


### PR DESCRIPTION
1. Improve HiveSelectParser to support 'sort by' which the result cannot be printed correctly
2. Improve HiveOutputVisitor to support print 'limit' in the result
3. Support Hive 'cluster by' clause in SELECT
4. Support Hive 'distribute by' clause in SELECT
5. Support Hive 'LIMIT' in 'ORDER BY' clause to entire UNION result
6. Support Hive 'SHOW DATABASES / TABLES' syntax
7. Support Ignore Chinese Identifier for PostgreSQL

Unit test
com.alibaba.druid.sql.parser.HiveSelectParserTest.java
com.alibaba.druid.sql.parser.HiveShowParserTest.java
com.alibaba.druid.sql.parser.PGChineseSQLParseTest