### PR TITLE
fix for JdbcSqlStat.getValue lost name/file. issue #1685

### DIFF
--- a/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java
+++ b/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java
@@ -389,6 +389,8 @@ public final class JdbcSqlStat implements JdbcSqlStatMBean, Comparable<JdbcSqlSt
         val.setSql(sql);
         val.setSqlHash(getSqlHash());
         val.setId(id);
+        val.setName(name);
+        val.setFile(file);
         val.setExecuteLastStartTime(executeLastStartTime);
         if (reset) {
             executeLastStartTime = 0;


### PR DESCRIPTION
Input name through JdbcSqlStat#setContextSqlName().
Output name through DruidDataSourceStatLoggerAdapter#log().
But the name is lost when JdbcSqlStat#getValue() copy properties from JdbcSqlStat to JdbcSqlStatValue.