### PR TITLE
bug fix 解决PagerUtils修改offset的bug，当offset需要修改为0时，取值不正确

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -400,7 +400,7 @@ public class PagerUtils {
     private static boolean limitMySqlQueryBlock(SQLSelectQueryBlock queryBlock, String dbType, int offset, int count, boolean check) {
         SQLLimit limit = queryBlock.getLimit();
         if (limit != null) {
-            if (offset > 0) {
+            if (offset >= 0) {
                 limit.setOffset(new SQLIntegerExpr(offset));
             }
 

--- a/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
@@ -41,4 +41,12 @@ public class PagerUtilsTest_Limit_mysql_0 extends TestCase {
                             "\nORDER BY id, name" + //
                             "\nLIMIT 20, 10", result);
     }
+
+    public void test_mysql_4() throws Exception {
+        String sql = "select id, name, salary from t limit 100 offset 5";
+        String result = PagerUtils.limit(sql, JdbcConstants.MYSQL, 0, 20);
+        Assert.assertEquals("SELECT id, name, salary" + //
+            "\nFROM t" + //
+            "\nLIMIT 0, 20", result);
+    }
 }


### PR DESCRIPTION
PagerUtils工具类修改分页offset参数的bug
原始sql：
        select * from user limit 100 offset 5
修改limit及offset参数：
        String result = PagerUtils.limit(sql, JdbcConstants.MYSQL, 0, 20);
最终结果输出：
        select * from user limit 5, 20

预期输出：select * from user limit 0, 20