### PR TITLE
去除 execute 中的注释，让 execute 与 executeQuery 执行流程保持一致

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidPooledPreparedStatement.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidPooledPreparedStatement.java
@@ -490,7 +490,7 @@ public class DruidPooledPreparedStatement extends DruidPooledStatement implement
         incrementExecuteCount();
         transactionRecord(sql);
 
-        // oracleSetRowPrefetch();
+        oracleSetRowPrefetch();
 
         conn.beforeExecute();
         try {


### PR DESCRIPTION
DruidPooledPreparedStatement#execute 注释 oracleSetRowPrefetch，将会导致一些问题，详情参考
#3356 