### PR TITLE
Improve getObject support, fixed #3302,#3340,#3393

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidPooledResultSet.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidPooledResultSet.java
@@ -27,7 +27,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -1763,11 +1762,21 @@ public final class DruidPooledResultSet extends PoolableWrapper implements Resul
         }
     }
 
+    @Override
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-        return rs.getObject(columnIndex, type);
+        try {
+            return rs.getObject(columnIndex, type);
+        } catch (Throwable t) {
+            throw checkException(t);
+        }
     }
 
+    @Override
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
-        return rs.getObject(columnLabel, type);
+        try {
+            return rs.getObject(columnLabel, type);
+        } catch (Throwable t) {
+            throw checkException(t);
+        }
     }
 }

--- a/src/main/java/com/alibaba/druid/proxy/jdbc/ResultSetProxyImpl.java
+++ b/src/main/java/com/alibaba/druid/proxy/jdbc/ResultSetProxyImpl.java
@@ -29,7 +29,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -1548,15 +1547,20 @@ public class ResultSetProxyImpl extends WrapperProxyImpl implements ResultSetPro
         return result;
     }
 
+    @Override
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         FilterChainImpl chain = createChain();
-        Object value = chain.resultSet_getObject(this, columnIndex, type);
+        T value = chain.resultSet_getObject(this, columnIndex, type);
         recycleFilterChain(chain);
-        return (T) value;
+        return value;
     }
 
+    @Override
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        FilterChainImpl chain = createChain();
+        T value = chain.resultSet_getObject(this, columnLabel, type);
+        recycleFilterChain(chain);
+        return value;
     }
 
     public int getCloseCount() {
@@ -1604,6 +1608,7 @@ public class ResultSetProxyImpl extends WrapperProxyImpl implements ResultSetPro
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         if (iface == ResultSetProxy.class || iface == ResultSetProxyImpl.class) {
             return (T) this;
@@ -1612,6 +1617,7 @@ public class ResultSetProxyImpl extends WrapperProxyImpl implements ResultSetPro
         return super.unwrap(iface);
     }
 
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         if (iface == ResultSetProxy.class || iface == ResultSetProxyImpl.class) {
             return true;


### PR DESCRIPTION
修复上版本未完全修复的bug #3302,#3340,#3393

相关覆盖方法添加`@Override`注解

相关方法捕获处理`checkException`异常

还有一个建议是：可以对全库的代码的行分隔符做一个统一格式化，Unix/Linux使用的是LF，Mac也是LF，但Windows是CRLF，推荐格式化为LF，可以避免Git自动转换换行符导致整个文件被修改的尴尬情况。