### PR TITLE
修复PGOutputVisitor 输出PGInsertStatementParser的时候on Conflict Update语法的输出错误

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -455,7 +455,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             if (onConflictDoNothing) {
                 print0(ucase ? " DO NOTHING" : " do nothing");
             } else if ((onConflictUpdateSetItems != null && onConflictUpdateSetItems.size() > 0)) {
-                print0(ucase ? " UPDATE SET " : " update set ");
+                print0(ucase ? " DO UPDATE SET " : " do update set ");
                 printAndAccept(onConflictUpdateSetItems, ", ");
             }
         }

--- a/src/test/java/com/alibaba/druid/postgresql/PGUpsertTest.java
+++ b/src/test/java/com/alibaba/druid/postgresql/PGUpsertTest.java
@@ -1,0 +1,20 @@
+package com.alibaba.druid.postgresql;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class PGUpsertTest extends TestCase  {
+
+  public void testUpsert(){
+    String sql = "insert into \"test_dup\" values(1,'2',-100) on conflict(id) do update set \"count\" = test_dup.\"count\" + 1;";
+    String targetSql = "INSERT INTO \"test_dup\"\n"
+        + "VALUES (1, '2', -100)\n"
+        + "ON CONFLICT (id) DO UPDATE SET \"count\" = test_dup.\"count\" + 1";
+    PGSQLStatementParser parser=new PGSQLStatementParser(sql);
+    SQLStatement statement = parser.parseStatement();
+    Assert.assertEquals(targetSql, statement.toString());
+  }
+
+}


### PR DESCRIPTION
修复PGoutputVisitor 在visit PGInsertStatementParser的时候，遇到on Clonflict Update语法，输出错误sql的问题。

单元测试类：
com.alibaba.druid.postgresql.PGUpsertTest