### PR TITLE
解决 SQLExprParser.primary方法 union all 前面直接包含子查询 解析异常问题

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -362,8 +362,6 @@ public class SQLExprParser extends SQLParser {
                 if (sqlExpr instanceof SQLBinaryOpExpr) {
                     ((SQLBinaryOpExpr) sqlExpr).setBracket(true);
                 }
-                
-                accept(Token.RPAREN);
 
                 if (lexer.token == Token.UNION && sqlExpr instanceof SQLQueryExpr) {
                     SQLQueryExpr queryExpr = (SQLQueryExpr) sqlExpr;
@@ -371,6 +369,13 @@ public class SQLExprParser extends SQLParser {
                     SQLSelectQuery query = this.createSelectParser().queryRest(queryExpr.getSubQuery().getQuery());
                     queryExpr.getSubQuery().setQuery(query);
                 }
+
+                //accept(Token.RPAREN) 在处理UNION 之前，导致 以下类型的语句解析异常
+                //select * from test_a where id=(select id from test_b where id = 1) union all select * from test_c .....
+                //会解析为 select * from select * from test_a where id=(select id from test_b where id = 1 union all select * from test_c .....
+                //所以需要将accept(Token.RPAREN) 移动到 处理 Union all 以及 子查询之后
+                accept(Token.RPAREN);
+
                 break;
             case INSERT:
                 lexer.nextToken();


### PR DESCRIPTION
解决 SQLExprParser.primary方法  union all 前面直接包含子查询 解析异常问题
在SQLExprParser.SQLParser 方法第366行当中
调用 accept(Token.RPAREN) 位置 在处理UNION 以及子查询 之前，导致 以下类型的语句解析异常
select * from test_a where id=(select id from test_b where id = 1) union all select * from test_c .....
会解析为
select * from select * from test_a where id=(select id from test_b where id = 1 union all select * from test_c .....
所以需要将accept(Token.RPAREN) 移动到 处理 Union all 以及 子查询之后