### PR TITLE
improve pg statement parser. fix the missing bracket in select block

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -69,6 +69,7 @@ public class PGSelectParser extends SQLSelectParser {
             lexer.nextToken();
 
             SQLSelectQuery select = query();
+            select.setBracket(true);
             if (select instanceof SQLSelectQueryBlock) {
                 ((SQLSelectQueryBlock) select).setParenthesized(true);
             }

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -249,6 +249,11 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
 
     public boolean visit(PGSelectQueryBlock x) {
+        final boolean bracket = x.isBracket();
+        if (bracket) {
+            print('(');
+        }
+
         print0(ucase ? "SELECT " : "select ");
 
         if (SQLSetQuantifier.ALL == x.getDistionOption()) {
@@ -315,6 +320,10 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
         if (x.getForClause() != null) {
             println();
             x.getForClause().accept(this);
+        }
+
+        if (bracket) {
+            print(')');
         }
 
         return false;

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -245,6 +245,7 @@ public class SQLSelectParser extends SQLParser {
             lexer.nextToken();
 
             SQLSelectQuery select = query();
+            select.setBracket(true);
             accept(Token.RPAREN);
 
             return queryRest(select, acceptUnion);

--- a/src/test/java/com/alibaba/druid/postgresql/PGUnionTest.java
+++ b/src/test/java/com/alibaba/druid/postgresql/PGUnionTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.druid.postgresql;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class PGUnionTest extends TestCase  {
+
+  public void testUnion(){
+    String sql = "(select id,name from t1) union (select id,name from t2)";
+    String targetSql = "(SELECT id, name\n"
+        + "FROM t1)\n"
+        + "UNION\n"
+        + "(SELECT id, name\n"
+        + "FROM t2)";
+
+    PGSQLStatementParser pgparser=new PGSQLStatementParser(sql);
+    SQLStatement pgstatement = pgparser.parseStatement();
+    Assert.assertEquals(targetSql, pgstatement.toString());
+    System.out.println(pgstatement.toString());
+  }
+
+}


### PR DESCRIPTION
when a select block is bracket. PGStatementParser will miss the bracket when giving the output.

fix the issue

test case class is :
com.alibaba.druid.postgresql.PGUnionTest