### PR TITLE
不做任何配置只允许本地访问不太人性化

### DIFF
--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidStatViewServletConfiguration.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidStatViewServletConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnWebApplication
 @ConditionalOnProperty(name = "spring.datasource.druid.stat-view-servlet.enabled", havingValue = "true")
 public class DruidStatViewServletConfiguration {
-    private static final String DEFAULT_ALLOW_IP = "127.0.0.1";
 
     @Bean
     public ServletRegistrationBean statViewServletRegistrationBean(DruidStatProperties properties) {
@@ -38,8 +37,6 @@ public class DruidStatViewServletConfiguration {
         registrationBean.addUrlMappings(config.getUrlPattern() != null ? config.getUrlPattern() : "/druid/*");
         if (config.getAllow() != null) {
             registrationBean.addInitParameter("allow", config.getAllow());
-        } else {
-            registrationBean.addInitParameter("allow", DEFAULT_ALLOW_IP);
         }
         if (config.getDeny() != null) {
             registrationBean.addInitParameter("deny", config.getDeny());


### PR DESCRIPTION
deny优先于allow，如果在deny列表中，就算在allow列表中，也会被拒绝。
如果allow没有配置或者为空，则允许所有访问

查看源码后发下 com.alibaba.druid.spring.boot.autoconfigure.stat.DruidStatViewServletConfiguration类在配置allow时 ,做了一个判断(如果用户未做任何配置,则将127.0.0.1 设为了默认值)
该方式导致如果我默认允许所有ip访问(也就是allow,deny不做任何配置)则只能通过本地访问,此处实现违背了我的本来用意,望采纳!