### PR TITLE
修复：pg 的 update 如果带有from，在visit的时候略过了from块。fix: from block should be visit in update statement. 

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGUpdateStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGUpdateStatement.java
@@ -51,6 +51,7 @@ public class PGUpdateStatement extends SQLUpdateStatement implements PGSQLStatem
             acceptChild(visitor, with);
             acceptChild(visitor, tableSource);
             acceptChild(visitor, items);
+            acceptChild(visitor, from);
             acceptChild(visitor, where);
         }
         visitor.endVisit(this);

--- a/src/test/java/com/alibaba/druid/postgresql/PGUpdateFromTest.java
+++ b/src/test/java/com/alibaba/druid/postgresql/PGUpdateFromTest.java
@@ -1,0 +1,39 @@
+package com.alibaba.druid.postgresql;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitorAdapter;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class PGUpdateFromTest extends TestCase {
+
+  public void testUpdateFromTest(){
+    String sql = "UPDATE TABLE_A TA SET A_VALUE = TB.B_VALUE FROM TABLE_B TB WHERE TB.FKEY = TA.KEY";
+    final String schemaName = "myschema";
+    String targetSql = "UPDATE MYSCHEMA.TABLE_A TA\n"
+        + "SET A_VALUE = TB.B_VALUE\n"
+        + "FROM MYSCHEMA.TABLE_B TB\n"
+        + "WHERE TB.FKEY = TA.KEY";
+    PGSQLStatementParser parser=new PGSQLStatementParser(sql);
+    SQLStatement statement = parser.parseStatement();
+
+    statement.accept(new PGASTVisitorAdapter(){
+      @Override
+      public boolean visit(SQLExprTableSource x) {
+        x.getExpr().accept(this);
+        if(!(x.getExpr() instanceof SQLIdentifierExpr)) {
+          return true;
+        }
+        SQLIdentifierExpr expr = (SQLIdentifierExpr) x.getExpr();
+        String newTableName = schemaName.toUpperCase() + "." + expr.getName().toUpperCase().trim();
+        expr.setName(newTableName);
+        return true;
+      }
+    });
+
+    Assert.assertEquals(targetSql, statement.toString());
+  }
+}


### PR DESCRIPTION
有一个需求，想要解析语法数之后重新PGVisiter的visit方法给表明添加schema前缀。发现update语句中的visiter忽略了对from语块的visit，补回行代码。