### PR TITLE
(fix): 修复两个PG insert/update不支持的语法

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGInsertStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGInsertStatement.java
@@ -38,6 +38,7 @@ public class PGInsertStatement extends SQLInsertStatement implements PGSQLStatem
     private SQLExpr                onConflictWhere;
     private boolean                onConflictDoNothing;
     private List<SQLUpdateSetItem> onConflictUpdateSetItems;
+    private SQLExpr                onConflictSetWhere;
 
     public PGInsertStatement() {
         dbType = JdbcConstants.POSTGRESQL;
@@ -141,7 +142,12 @@ public class PGInsertStatement extends SQLInsertStatement implements PGSQLStatem
         return onConflictUpdateSetItems;
     }
 
+    @Deprecated
     public void addConflicUpdateItem(SQLUpdateSetItem item) {
+        this.addConflictUpdateItem(item);
+    }
+
+    public void addConflictUpdateItem(SQLUpdateSetItem item) {
         if (onConflictUpdateSetItems == null) {
             onConflictUpdateSetItems = new ArrayList<SQLUpdateSetItem>();
         }
@@ -152,6 +158,14 @@ public class PGInsertStatement extends SQLInsertStatement implements PGSQLStatem
 
     public SQLName getOnConflictConstraint() {
         return onConflictConstraint;
+    }
+
+    public void setOnConflictSetWhere(SQLExpr onConflictSetWhere) {
+        this.onConflictSetWhere = onConflictSetWhere;
+    }
+
+    public SQLExpr getOnConflictSetWhere() {
+        return onConflictSetWhere;
     }
 
     public void setOnConflictConstraint(SQLName x) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -84,7 +84,7 @@ public class PGExprParser extends SQLExprParser {
         this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
         this.dbType = JdbcConstants.POSTGRESQL;
     }
-    
+
     @Override
     public SQLDataType parseDataType() {
         if (lexer.token() == Token.TYPE) {
@@ -92,7 +92,7 @@ public class PGExprParser extends SQLExprParser {
         }
         return super.parseDataType();
     }
-    
+
     public PGSelectParser createSelectParser() {
         return new PGSelectParser(this);
     }
@@ -150,7 +150,7 @@ public class PGExprParser extends SQLExprParser {
             }
             return values;
         }
-        
+
         return super.primary();
     }
 
@@ -166,19 +166,20 @@ public class PGExprParser extends SQLExprParser {
         return intervalExpr;
     }
 
+    @Override
     public SQLExpr primaryRest(SQLExpr expr) {
         if (lexer.token() == Token.COLONCOLON) {
             lexer.nextToken();
             SQLDataType dataType = this.parseDataType();
-            
+
             PGTypeCastExpr castExpr = new PGTypeCastExpr();
-            
+
             castExpr.setExpr(expr);
             castExpr.setDataType(dataType);
 
             return primaryRest(castExpr);
         }
-        
+
         if (lexer.token() == Token.LBRACKET) {
             SQLArrayExpr array = new SQLArrayExpr();
             array.setExpr(expr);
@@ -187,7 +188,7 @@ public class PGExprParser extends SQLExprParser {
             accept(Token.RBRACKET);
             return primaryRest(array);
         }
-        
+
         if (expr.getClass() == SQLIdentifierExpr.class) {
             String ident = ((SQLIdentifierExpr)expr).getName();
 
@@ -257,23 +258,23 @@ public class PGExprParser extends SQLExprParser {
                 return primaryRest(timestamp);
             } else if ("EXTRACT".equalsIgnoreCase(ident)) {
                 accept(Token.LPAREN);
-                
+
                 PGExtractExpr extract = new PGExtractExpr();
-                
+
                 String fieldName = lexer.stringVal();
                 PGDateField field = PGDateField.valueOf(fieldName.toUpperCase());
                 lexer.nextToken();
-                
+
                 extract.setField(field);
-                
+
                 accept(Token.FROM);
                 SQLExpr source = this.expr();
-                
+
                 extract.setSource(source);
-                
+
                 accept(Token.RPAREN);
-                
-                return primaryRest(extract);     
+
+                return primaryRest(extract);
             } else if ("POINT".equalsIgnoreCase(ident)) {
                 SQLExpr value = this.primary();
                 PGPointExpr point = new PGPointExpr();

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -140,7 +140,11 @@ public class PGSelectParser extends SQLSelectParser {
 
         for (;;) {
             if (lexer.token() == Token.LIMIT) {
-                SQLLimit limit = new SQLLimit();
+                // PG支持 offset xxx limit xxx和limit xxx offset xxx
+                SQLLimit limit = queryBlock.getLimit();
+                if (limit == null) {
+                    limit = new SQLLimit();
+                }
 
                 lexer.nextToken();
                 if (lexer.token() == Token.ALL) {
@@ -155,11 +159,11 @@ public class PGSelectParser extends SQLSelectParser {
                 SQLLimit limit = queryBlock.getLimit();
                 if (limit == null) {
                     limit = new SQLLimit();
-                    queryBlock.setLimit(limit);
                 }
                 lexer.nextToken();
                 SQLExpr offset = expr();
                 limit.setOffset(offset);
+                queryBlock.setLimit(limit);
 
                 if (lexer.token() == Token.ROW || lexer.token() == Token.ROWS) {
                     lexer.nextToken();
@@ -236,6 +240,7 @@ public class PGSelectParser extends SQLSelectParser {
         }
 
         return queryRest(queryBlock, acceptUnion);
+
     }
 
     protected SQLTableSource parseTableSourceRest(SQLTableSource tableSource) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -485,6 +485,11 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             } else if ((onConflictUpdateSetItems != null && onConflictUpdateSetItems.size() > 0)) {
                 print0(ucase ? " DO UPDATE SET " : " do update set ");
                 printAndAccept(onConflictUpdateSetItems, ", ");
+                SQLExpr onConflictSetWhere = x.getOnConflictSetWhere();
+                if (onConflictSetWhere != null) {
+                    print0(ucase ? " WHERE " : " where ");
+                    printExpr(onConflictSetWhere);
+                }
             }
         }
 
@@ -545,6 +550,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             printTableSource(from);
         }
 
+        // where condition | where cursor of name
         SQLExpr where = x.getWhere();
         if (where != null) {
             println();

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGInsertTest15.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGInsertTest15.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+
+import java.util.List;
+
+public class PGInsertTest15 extends PGTest {
+
+    public void test_0() throws Exception {
+        String sql = "insert into tb1\n" +
+                "         (a, b, c, d, e, f, g, create_time, update_time )\n" +
+                "         values\n" +
+                "         ('a1', 'b1', 'c1', 'd1', 1, 'f1', 1, '2019-11-26 21:43:08.417', '2019-11-26 21:43:08.417')\n" +
+                "        ON CONFLICT ON CONSTRAINT pk_tb1_a\n" +
+                "        DO\n" +
+                "        UPDATE\n" +
+                "        SET\n" +
+                "          f = 'f2',\n" +
+                "          g = 2,\n" +
+                "          update_time = '2019-11-26 21:43:08.417'\n" +
+                "        WHERE a = 'a1'";
+
+        PGSQLStatementParser parser = new PGSQLStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+    }
+
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGUpdateTest0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGUpdateTest0.java
@@ -17,6 +17,7 @@ package com.alibaba.druid.bvt.sql.postgresql;
 
 import com.alibaba.druid.sql.PGTest;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
 import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGSchemaStatVisitor;
 import com.alibaba.druid.stat.TableStat;
@@ -54,5 +55,12 @@ public class PGUpdateTest0 extends PGTest {
         assertTrue(visitor.containsColumn("student", "grade"));
     }
 
+    public void test_1() throws Exception {
+        String sql = "update t1 as t set a = 'a1',b = ? ,c = default where current of c1 returning *";
+        PGSQLStatementParser parser = new PGSQLStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        PGUpdateStatement stmt = (PGUpdateStatement) statementList.get(0);
+        System.out.println(stmt);
+    }
     
 }


### PR DESCRIPTION
1. PG insert,支持conflict_action子句中使用where [insert语法](https://www.postgresql.org/docs/12/sql-insert.html)
```SQL
conflict_action is one of:

    DO NOTHING
    DO UPDATE SET { column_name = { expression | DEFAULT } |
                    ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT } [, ...] ) |
                    ( column_name [, ...] ) = ( sub-SELECT )
                  } [, ...]
              [ WHERE condition ]
```
未修改之前的insert语句，并未解析 **WHERE** 
2. PG update,支持where current of cursor_name [update语法](https://www.postgresql.org/docs/12/sql-update.html)
```SQL
[ WHERE condition | WHERE CURRENT OF cursor_name ]
```
未修改之前的update语句，并未解析 **WHERE CURRENT OF** 

3. PG select语句支持``` offset xxx limit xxx和limit xxx offset xxx ``` 但是druid仅支持 ```limit xxx offset xxx ```