### PR TITLE
Update DruidAbstractDataSource.java

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -344,7 +344,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     }
 
     public void setUseUnfairLock(boolean useUnfairLock) {
-        if (lock.isFair() == !useUnfairLock) {
+        if (lock.isFair() == !useUnfairLock&&this.useUnfairLock!=null) {
             return;
         }
 


### PR DESCRIPTION
setUseUnfairLock(true);
setMaxWait(100);
这样顺序写时，在maxwait中会将非公平锁又变成公平锁，反之没有问题；