### PR TITLE
modify Message "sessionStatMap is full" log-level form error to warn

### DIFF
--- a/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
+++ b/src/main/java/com/alibaba/druid/support/http/stat/WebAppStat.java
@@ -335,7 +335,7 @@ public class WebAppStat {
                     long fullCount = uriSessionMapFullCount.getAndIncrement();
 
                     if (fullCount == 0) {
-                        LOG.error("sessionStatMap is full");
+                        LOG.warn("sessionStatMap is full");
                     }
                 }
 


### PR DESCRIPTION
I think the log-level of message "sessionStatMap is full"  should be WRAN not ERROR