### PR TITLE
fix article word use in pom description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<packaging>jar</packaging>
 	<name>druid</name>
-	<description>An JDBC datasource implementation.</description>
+	<description>A JDBC datasource implementation.</description>
 	<url>https://github.com/alibaba/druid</url>
 	<inceptionYear>2013</inceptionYear>
 


### PR DESCRIPTION
The article word before **JDBC** should be **a** but not **an**, because the first letter **J** is pronounced as /ˈdʒaɪ/, which begins with a consonant sound. See https://en.wikipedia.org/wiki/Article_(grammar)