### PR TITLE
修复StatViewServlet设置url pattern后重定向时404的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/support/http/ResourceServlet.java
+++ b/src/main/java/com/alibaba/druid/support/http/ResourceServlet.java
@@ -220,29 +220,12 @@ public abstract class ResourceServlet extends HttpServlet {
                  || path.startsWith("/css")//
                  || path.startsWith("/js") //
             || path.startsWith("/img"))) {
-            if (contextPath.equals("") || contextPath.equals("/")) {
-                response.sendRedirect("/druid/login.html");
-            } else {
-                if ("".equals(path)) {
-                    response.sendRedirect("druid/login.html");
-                } else {
-                    response.sendRedirect("login.html");
-                }
-            }
+            response.sendRedirect(uri + "/login.html");
             return;
         }
 
-        if ("".equals(path)) {
-            if (contextPath.equals("") || contextPath.equals("/")) {
-                response.sendRedirect("/druid/index.html");
-            } else {
-                response.sendRedirect("druid/index.html");
-            }
-            return;
-        }
-
-        if ("/".equals(path)) {
-            response.sendRedirect("index.html");
+        if ("".equals(path) || "/".equals(path)) {
+            response.sendRedirect(uri + "/index.html");
             return;
         }
 


### PR DESCRIPTION
StatViewServlet设置了url pattern之后，重定向时忽略了servletPath前缀，直接重定向到了`/druid/xxx`，导致404。