### PR TITLE
优化DB2 Driver的推断逻辑

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -883,24 +883,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
 
             initFromSPIServiceLoader();
 
-            if (this.driver == null) {
-                if (this.driverClass == null || this.driverClass.isEmpty()) {
-                    this.driverClass = JdbcUtils.getDriverClassName(this.jdbcUrl);
-                }
-
-                if (MockDriver.class.getName().equals(driverClass)) {
-                    driver = MockDriver.instance;
-                } else {
-                    if (jdbcUrl == null && (driverClass == null || driverClass.length() == 0)) {
-                        throw new SQLException("url not set");
-                    }
-                    driver = JdbcUtils.createDriver(driverClassLoader, driverClass);
-                }
-            } else {
-                if (this.driverClass == null) {
-                    this.driverClass = driver.getClass().getName();
-                }
-            }
+            resolveDriver();
 
             initCheck();
 
@@ -1211,6 +1194,27 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
         }
 
         LOG.error(errorMessage + "validationQuery not set");
+    }
+
+    protected void resolveDriver() throws SQLException {
+        if (this.driver == null) {
+            if (this.driverClass == null || this.driverClass.isEmpty()) {
+                this.driverClass = JdbcUtils.getDriverClassName(this.jdbcUrl);
+            }
+
+            if (MockDriver.class.getName().equals(driverClass)) {
+                driver = MockDriver.instance;
+            } else {
+                if (jdbcUrl == null && (driverClass == null || driverClass.length() == 0)) {
+                    throw new SQLException("url not set");
+                }
+                driver = JdbcUtils.createDriver(driverClassLoader, driverClass);
+            }
+        } else {
+            if (this.driverClass == null) {
+                this.driverClass = driver.getClass().getName();
+            }
+        }
     }
 
     protected void initCheck() throws SQLException {

--- a/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -25,7 +25,9 @@ public interface JdbcConstants {
 
     String DB2                        = "db2";
 
-    String DB2_DRIVER                 = "com.ibm.db2.jcc.DB2Driver";
+    String DB2_DRIVER                 = "com.ibm.db2.jcc.DB2Driver"; // Type4
+    String DB2_DRIVER2                = "COM.ibm.db2.jdbc.app.DB2Driver"; // Type2
+    String DB2_DRIVER3                = "COM.ibm.db2.jdbc.net.DB2Driver"; // Type3
 
     String POSTGRESQL                 = "postgresql";
     String POSTGRESQL_DRIVER          = "org.postgresql.Driver";

--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -436,7 +436,21 @@ public final class JdbcUtils implements JdbcConstants {
         } else if (rawUrl.startsWith("jdbc:hsqldb:")) {
             return "org.hsqldb.jdbcDriver";
         } else if (rawUrl.startsWith("jdbc:db2:")) {
-            return DB2_DRIVER;
+            // Resolve the DB2 driver from JDBC URL
+            // Type2 COM.ibm.db2.jdbc.app.DB2Driver, url = jdbc:db2:databasename
+            // Type3 COM.ibm.db2.jdbc.net.DB2Driver, url = jdbc:db2:ServerIP:6789:databasename
+            // Type4 8.1+ com.ibm.db2.jcc.DB2Driver, url = jdbc:db2://ServerIP:50000/databasename
+            String prefix = "jdbc:db2:";
+            if (rawUrl.startsWith(prefix + "//")) { // Type4
+                return DB2_DRIVER; // "com.ibm.db2.jcc.DB2Driver";
+            } else {
+                String suffix = rawUrl.substring(prefix.length());
+                if (suffix.indexOf(':') > 0) { // Type3
+                    return DB2_DRIVER3; // COM.ibm.db2.jdbc.net.DB2Driver
+                } else { // Type2
+                    return DB2_DRIVER2; // COM.ibm.db2.jdbc.app.DB2Driver
+                }
+            }
         } else if (rawUrl.startsWith("jdbc:sqlite:")) {
             return SQLITE_DRIVER;
         } else if (rawUrl.startsWith("jdbc:ingres:")) {


### PR DESCRIPTION
1、推断Driver的逻辑不稳定, 应抽取方法给子类保留替换的机会
2、优化DB2 Driver的推断逻辑，参考自 https://www.cnblogs.com/lidg/articles/3588566.html