### PR TITLE
fix https://github.com/alibaba/druid/issues/3707

### DIFF
--- a/src/main/java/com/alibaba/druid/util/OracleUtils.java
+++ b/src/main/java/com/alibaba/druid/util/OracleUtils.java
@@ -38,6 +38,7 @@ import com.alibaba.druid.support.logging.LogFactory;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleResultSet;
 import oracle.jdbc.OracleStatement;
+import oracle.jdbc.driver.T4CXAConnection;
 import oracle.jdbc.internal.OraclePreparedStatement;
 import oracle.jdbc.xa.client.OracleXAConnection;
 import oracle.sql.ROWID;
@@ -47,7 +48,12 @@ public class OracleUtils {
     private final static Log LOG = LogFactory.getLog(OracleUtils.class);
 
     public static XAConnection OracleXAConnection(Connection oracleConnection) throws XAException {
-        return new OracleXAConnection(oracleConnection);
+        String oracleConnectionClassName = oracleConnection.getClass().getName();
+        if ("oracle.jdbc.driver.T4CConnection".equals(oracleConnectionClassName)) {
+            return new T4CXAConnection(oracleConnection);
+        } else {
+            return new OracleXAConnection(oracleConnection);
+        }
     }
 
     public static int getRowPrefetch(PreparedStatement stmt) throws SQLException {


### PR DESCRIPTION
Basically, for a  T4CConnection physical connection, we should wrap it with T4CXAConnection.

FIXME: According to logic of oracle.jdbc.xa.client.OracleXADataSource#getPooledConnection(java.util.Properties), it's NOT a  total solution. Just work for most cases.