### PR TITLE
Fix clone() bug in SQLJoinTableSource

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLJoinTableSource.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLJoinTableSource.java
@@ -271,7 +271,7 @@ public class SQLJoinTableSource extends SQLTableSourceImpl implements SQLReplace
         }
 
         if(condition != null){
-            x.setCondition(condition);
+            x.setCondition(condition.clone());
         }
 
         for (SQLExpr item : using) {


### PR DESCRIPTION
Before this fix, the join condition is not properly cloned but is rather being referenced, so when an AST is cloned, source and target ASTs will share the same join condition node.