### PR TITLE
fixed lexer parameter pos exceed integer.max

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -1533,6 +1533,8 @@ public class Lexer {
 
                 if (ch == '}') {
                     break;
+                } else if (ch == EOI){
+                    throw new ParserException("illegal identifier. " + info());
                 }
 
                 bufPos++;


### PR DESCRIPTION
case: select name from test where cat=#{cat   and  dog > 0
直接使用Lexer，会触发scanVariable里面pos循环超过int最大值，再抛出异常。