### PR TITLE
新增Impala语法解析器

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -46,6 +46,7 @@ import com.alibaba.druid.sql.dialect.h2.visitor.H2OutputVisitor;
 import com.alibaba.druid.sql.dialect.h2.visitor.H2SchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.hive.visitor.HiveOutputVisitor;
 import com.alibaba.druid.sql.dialect.hive.visitor.HiveSchemaStatVisitor;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaOutputVisitor;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlOutputVisitor;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.odps.visitor.OdpsOutputVisitor;
@@ -432,6 +433,10 @@ public class SQLUtils {
 
         if (JdbcConstants.ELASTIC_SEARCH.equals(dbType)) {
             return new MySqlOutputVisitor(out);
+        }
+
+        if (JdbcConstants.IMPALA.equals(dbType)){
+            return new ImpalaOutputVisitor(out);
         }
 
         return new SQLASTOutputVisitor(out, dbType);

--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -47,6 +47,7 @@ import com.alibaba.druid.sql.dialect.h2.visitor.H2SchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.hive.visitor.HiveOutputVisitor;
 import com.alibaba.druid.sql.dialect.hive.visitor.HiveSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaOutputVisitor;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlOutputVisitor;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.odps.visitor.OdpsOutputVisitor;
@@ -160,6 +161,10 @@ public class SQLUtils {
 
     public static String formatHive(String sql) {
         return format(sql, JdbcConstants.HIVE);
+    }
+
+    public static String formatImpala(String sql) {
+        return format(sql, JdbcConstants.IMPALA);
     }
 
     public static String formatOdps(String sql, FormatOption option) {
@@ -483,6 +488,10 @@ public class SQLUtils {
 
         if (JdbcConstants.ELASTIC_SEARCH.equals(dbType)) {
             return new MySqlSchemaStatVisitor();
+        }
+
+        if (JdbcConstants.IMPALA.equals(dbType)){
+            return new ImpalaSchemaStatVisitor();
         }
 
         return new SchemaStatVisitor();

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
@@ -153,7 +153,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
     }
 
     public static enum Type {
-                             GLOBAL_TEMPORARY, LOCAL_TEMPORARY
+                             GLOBAL_TEMPORARY, LOCAL_TEMPORARY, EXTERNAL
     }
 
     public List<SQLTableElement> getTableElementList() {

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
@@ -88,7 +88,7 @@ public class HiveStatementParser extends SQLStatementParser {
         return new HiveCreateTableParser(this.exprParser);
     }
 
-    public SQLStatement parseInsert() {
+    public SQLStatement parseHiveInsertStmt() {
         if (lexer.token() == Token.FROM) {
             lexer.nextToken();
 
@@ -136,7 +136,7 @@ public class HiveStatementParser extends SQLStatementParser {
 
     public boolean parseStatementListDialect(List<SQLStatement> statementList) {
         if (lexer.token() == Token.FROM) {
-            SQLStatement stmt = this.parseInsert();
+            SQLStatement stmt = this.parseHiveInsertStmt();
             statementList.add(stmt);
             return true;
         }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
@@ -88,7 +88,7 @@ public class HiveStatementParser extends SQLStatementParser {
         return new HiveCreateTableParser(this.exprParser);
     }
 
-    public SQLStatement parseHiveInsertStmt() {
+    public SQLStatement parseInsert() {
         if (lexer.token() == Token.FROM) {
             lexer.nextToken();
 
@@ -136,7 +136,7 @@ public class HiveStatementParser extends SQLStatementParser {
 
     public boolean parseStatementListDialect(List<SQLStatement> statementList) {
         if (lexer.token() == Token.FROM) {
-            SQLStatement stmt = this.parseHiveInsertStmt();
+            SQLStatement stmt = this.parseInsert();
             statementList.add(stmt);
             return true;
         }

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
@@ -131,7 +131,7 @@ public class HiveStatementParser extends SQLStatementParser {
             return stmt;
         }
 
-        return parseHiveInsertStmt();
+        return parseInsert();
     }
 
     public boolean parseStatementListDialect(List<SQLStatement> statementList) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveStatementParser.java
@@ -131,7 +131,7 @@ public class HiveStatementParser extends SQLStatementParser {
             return stmt;
         }
 
-        return parseInsert();
+        return parseHiveInsertStmt();
     }
 
     public boolean parseStatementListDialect(List<SQLStatement> statementList) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaInsert.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaInsert.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.ast;
+
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLInsertInto;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.dialect.odps.visitor.OdpsASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaInsert extends SQLInsertInto {
+
+    private boolean              overwrite  = false;
+    private List<SQLAssignItem>  partitions = new ArrayList<SQLAssignItem>();
+
+    public ImpalaInsert() {
+
+    }
+
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    public void setOverwrite(boolean overwrite) {
+        this.overwrite = overwrite;
+    }
+
+    public List<SQLAssignItem> getPartitions() {
+        return partitions;
+    }
+    
+    public void addPartition(SQLAssignItem partition) {
+        if (partition != null) {
+            partition.setParent(this);
+        }
+        this.partitions.add(partition);
+    }
+
+    public void setPartitions(List<SQLAssignItem> partitions) {
+        this.partitions = partitions;
+    }
+
+    public void cloneTo(ImpalaInsert x) {
+        cloneTo(x);
+        x.overwrite = overwrite;
+        for (SQLAssignItem item : partitions) {
+            x.addPartition(item.clone());
+        }
+    }
+
+    @Override
+    public SQLInsertInto clone() {
+        ImpalaInsert x = new ImpalaInsert();
+        cloneTo(x);
+        return x;
+    }
+
+    public SQLExprTableSource getTableSource() {
+        return tableSource;
+    }
+
+    public void setTableSource(SQLExprTableSource tableSource) {
+        if (tableSource != null) {
+            tableSource.setParent(this);
+        }
+        this.tableSource = tableSource;
+    }
+
+    public void setTableSource(SQLName tableName) {
+        this.setTableSource(new SQLExprTableSource(tableName));
+    }
+
+    public SQLSelect getQuery() {
+        return query;
+    }
+
+    public void setQuery(SQLSelect query) {
+        if (query != null) {
+            query.setParent(this);
+        }
+        this.query = query;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof ImpalaASTVisitor) {
+            accept0((ImpalaASTVisitor) visitor);
+        } else {
+            accept0((OdpsASTVisitor) visitor);
+        }
+    }
+
+    protected void accept0(OdpsASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+            acceptChild(visitor, query);
+        }
+        visitor.endVisit(this);
+    }
+
+    protected void accept0(ImpalaASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+            acceptChild(visitor, query);
+        }
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaInsertStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaInsertStatement.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.ast;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaOutputVisitor;
+import com.alibaba.druid.sql.dialect.odps.visitor.OdpsASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaInsertStatement extends SQLInsertStatement implements SQLStatement {
+    private boolean              overwrite  = false;
+    private List<SQLAssignItem>  partitions = new ArrayList<SQLAssignItem>();
+
+    public ImpalaInsertStatement() {
+        dbType = JdbcConstants.IMPALA;
+    }
+
+    @Override
+    public String getDbType() {
+        return dbType;
+    }
+
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    public void setOverwrite(boolean overwrite) {
+        this.overwrite = overwrite;
+    }
+
+    public List<SQLAssignItem> getPartitions() {
+        return partitions;
+    }
+
+    public ImpalaInsertStatement clone() {
+        ImpalaInsertStatement x = new ImpalaInsertStatement();
+        super.cloneTo(x);
+        return x;
+    }
+
+    public void addPartition(SQLAssignItem partition) {
+        if (partition != null) {
+            partition.setParent(this);
+        }
+        this.partitions.add(partition);
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof OdpsASTVisitor) {
+            accept0((OdpsASTVisitor) visitor);
+        } else if (visitor instanceof ImpalaASTVisitor) {
+            accept0((ImpalaASTVisitor) visitor);
+        } else{
+            super.accept0(visitor);
+        }
+    }
+
+    protected void accept0(ImpalaOutputVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+            acceptChild(visitor, valuesList);
+            acceptChild(visitor, query);
+        }
+        visitor.endVisit(this);
+    }
+
+    protected void accept0(ImpalaASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+            acceptChild(visitor, valuesList);
+            acceptChild(visitor, query);
+        }
+        visitor.endVisit(this);
+    }
+
+    protected void accept0(OdpsASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+            acceptChild(visitor, valuesList);
+            acceptChild(visitor, query);
+        }
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaKuduPartition.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaKuduPartition.java
@@ -1,0 +1,44 @@
+package com.alibaba.druid.sql.dialect.impala.ast;
+
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
+import com.alibaba.druid.sql.parser.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaKuduPartition {
+  protected Token type;
+  protected final List<SQLColumnDefinition> partitionColumns = new ArrayList<SQLColumnDefinition>();
+  protected final List<String> partitionAssign = new ArrayList<String>();
+  protected int number = -1;
+
+  private ImpalaKuduPartition(){};
+  public ImpalaKuduPartition(Token t){
+    this.type = t;
+  }
+
+  public Token getType() {
+    return type;
+  }
+
+  public void setType(Token type) {
+    this.type = type;
+  }
+
+  public List<SQLColumnDefinition> getPartitionColumns() {
+    return partitionColumns;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+
+  public void setNumber(int number) {
+    this.number = number;
+  }
+
+  public List<String> getPartitionAssign() {
+    return partitionAssign;
+  }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaMultiInsertStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/ast/ImpalaMultiInsertStatement.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.ast;
+
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.ast.statement.SQLTableSource;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaMultiInsertStatement extends SQLStatementImpl {
+
+    private SQLTableSource from;
+
+    private List<ImpalaInsert>       items = new ArrayList<ImpalaInsert>();
+    
+    public ImpalaMultiInsertStatement() {
+        dbType = JdbcConstants.HIVE;
+    }
+
+    public void setFrom(SQLTableSource from) {
+        this.from = from;
+    }
+
+    public SQLTableSource getFrom() {
+        return from;
+    }
+
+    public List<ImpalaInsert> getItems() {
+        return items;
+    }
+    
+    public void addItem(ImpalaInsert item) {
+        if (item != null) {
+            item.setParent(this);
+        }
+        this.items.add(item);
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof ImpalaASTVisitor) {
+            accept0((ImpalaASTVisitor) visitor);
+        } else {
+            acceptChild(visitor, from);
+            acceptChild(visitor, items);
+        }
+    }
+
+    public void accept0(ImpalaASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, from);
+            acceptChild(visitor, items);
+        }
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaCreateTableParser.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.parser;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.parser.*;
+import com.alibaba.druid.util.FnvHash;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class ImpalaCreateTableParser extends SQLCreateTableParser {
+    public ImpalaCreateTableParser(SQLExprParser exprParser) {
+        super(exprParser);
+    }
+
+    public ImpalaCreateTableParser(Lexer lexer) {
+        super(new ImpalaExprParser(lexer));
+    }
+
+    public SQLCreateTableStatement parseCreateTable(boolean acceptCreate) {
+        ImpalaCreateTableStatement stmt = newCreateStatement();
+
+        if (acceptCreate) {
+            if (lexer.hasComment() && lexer.isKeepComments()) {
+                stmt.addBeforeComment(lexer.readAndResetComments());
+            }
+
+            accept(Token.CREATE);
+        }
+
+        if (lexer.identifierEquals("GLOBAL")) {
+            lexer.nextToken();
+
+            if (lexer.identifierEquals("TEMPORARY")) {
+                lexer.nextToken();
+                stmt.setType(SQLCreateTableStatement.Type.GLOBAL_TEMPORARY);
+            } else {
+                throw new ParserException("syntax error " + lexer.info());
+            }
+        } else if (lexer.token() == Token.IDENTIFIER && lexer.stringVal().equalsIgnoreCase("LOCAL")) {
+            lexer.nextToken();
+            if (lexer.token() == Token.IDENTIFIER && lexer.stringVal().equalsIgnoreCase("TEMPORAY")) {
+                lexer.nextToken();
+                stmt.setType(SQLCreateTableStatement.Type.LOCAL_TEMPORARY);
+            } else {
+                throw new ParserException("syntax error. " + lexer.info());
+            }
+        }
+
+        accept(Token.TABLE);
+
+        if (lexer.token() == Token.IF || lexer.identifierEquals("IF")) {
+            lexer.nextToken();
+            accept(Token.NOT);
+            accept(Token.EXISTS);
+
+            stmt.setIfNotExiists(true);
+        }
+
+        stmt.setName(this.exprParser.name());
+
+        if (lexer.token() == Token.LPAREN) {
+            lexer.nextToken();
+
+            for (; ; ) {
+                Token token = lexer.token();
+                if (token == Token.IDENTIFIER
+                        && lexer.stringVal().equalsIgnoreCase("SUPPLEMENTAL")
+                        && JdbcConstants.ORACLE.equals(dbType)) {
+                    this.parseCreateTableSupplementalLogingProps(stmt);
+                } else if (token == Token.IDENTIFIER //
+                        || token == Token.LITERAL_ALIAS) {
+                    SQLColumnDefinition column = this.exprParser.parseColumn();
+                    stmt.getTableElementList().add(column);
+                } else if (token == Token.PRIMARY //
+                        || token == Token.UNIQUE //
+                        || token == Token.CHECK //
+                        || token == Token.CONSTRAINT
+                        || token == Token.FOREIGN) {
+                    SQLConstraint constraint = this.exprParser.parseConstaint();
+                    constraint.setParent(stmt);
+                    stmt.getTableElementList().add((SQLTableElement) constraint);
+                } else if (token == Token.TABLESPACE) {
+                    throw new ParserException("TODO "  + lexer.info());
+                } else {
+                    SQLColumnDefinition column = this.exprParser.parseColumn();
+                    stmt.getTableElementList().add(column);
+                }
+
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+
+                    if (lexer.token() == Token.RPAREN) { // compatible for sql server
+                        break;
+                    }
+                    continue;
+                }
+
+                break;
+            }
+
+            accept(Token.RPAREN);
+
+            if (lexer.identifierEquals("INHERITS")) {
+                lexer.nextToken();
+                accept(Token.LPAREN);
+                SQLName inherits = this.exprParser.name();
+                stmt.setInherits(new SQLExprTableSource(inherits));
+                accept(Token.RPAREN);
+            }
+        }
+
+        if (lexer.token() == Token.COMMENT) {
+            lexer.nextToken();
+            SQLExpr comment = this.exprParser.expr();
+            stmt.setComment(comment);
+        }
+
+        if (lexer.token() == Token.PARTITIONED) {
+            lexer.nextToken();
+            accept(Token.BY);
+            accept(Token.LPAREN);
+
+            for (;;) {
+                if (lexer.token() != Token.IDENTIFIER) {
+                    throw new ParserException("expect identifier. " + lexer.info());
+                }
+
+                SQLColumnDefinition column = this.exprParser.parseColumn();
+                stmt.addPartitionColumn(column);
+
+                if (lexer.isKeepComments() && lexer.hasComment()) {
+                    column.addAfterComment(lexer.readAndResetComments());
+                }
+
+                if (lexer.token() != Token.COMMA) {
+                    break;
+                } else {
+                    lexer.nextToken();
+                    if (lexer.isKeepComments() && lexer.hasComment()) {
+                        column.addAfterComment(lexer.readAndResetComments());
+                    }
+                }
+            }
+
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.CLUSTERED)) {
+            lexer.nextToken();
+            accept(Token.BY);
+            accept(Token.LPAREN);
+            for (; ; ) {
+                SQLSelectOrderByItem item = this.exprParser.parseSelectOrderByItem();
+                stmt.addClusteredByItem(item);
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    continue;
+                }
+                break;
+            }
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.ROW) {
+            lexer.nextToken();
+            acceptIdentifier("FORMAT");
+
+            if (lexer.identifierEquals(FnvHash.Constants.DELIMITED)) {
+                lexer.nextToken();
+                acceptIdentifier("FIELDS");
+                acceptIdentifier("TERMINATED");
+                accept(Token.BY);
+                SQLExternalRecordFormat format = new SQLExternalRecordFormat();
+                format.setTerminatedBy(this.exprParser.expr());
+                stmt.setRowFormat(format);
+            } else {
+                throw new ParserException("TODO " + lexer.info());
+            }
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.SORTED)) {
+            lexer.nextToken();
+            accept(Token.BY);
+            accept(Token.LPAREN);
+            for (; ; ) {
+                SQLSelectOrderByItem item = this.exprParser.parseSelectOrderByItem();
+                stmt.addSortedByItem(item);
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    continue;
+                }
+                break;
+            }
+            accept(Token.RPAREN);
+        }
+
+        if (stmt.getClusteredBy().size() > 0 || stmt.getSortedBy().size() > 0) {
+            accept(Token.INTO);
+            if (lexer.token() == Token.LITERAL_INT) {
+                stmt.setBuckets(lexer.integerValue().intValue());
+                lexer.nextToken();
+            } else {
+                throw new ParserException("into buckets must be integer. " + lexer.info());
+            }
+            acceptIdentifier("BUCKETS");
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.STORED)) {
+            lexer.nextToken();
+            accept(Token.AS);
+            SQLName name = this.exprParser.name();
+            stmt.setStoredAs(name);
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.TBLPROPERTIES)) {
+            lexer.nextToken();
+            accept(Token.LPAREN);
+
+            for (;;) {
+                String name = lexer.stringVal();
+                lexer.nextToken();
+                accept(Token.EQ);
+                SQLExpr value = this.exprParser.primary();
+                stmt.getTableOptions().put(name, value);
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    continue;
+                }
+                break;
+            }
+
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.AS) {
+            lexer.nextToken();
+            SQLSelect select = this.createSQLSelectParser().select();
+            stmt.setSelect(select);
+        }
+        return stmt;
+    }
+
+    protected ImpalaCreateTableStatement newCreateStatement() {
+        return new ImpalaCreateTableStatement();
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaExprParser.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.parser;
+
+import com.alibaba.druid.sql.ast.SQLCurrentTimeExpr;
+import com.alibaba.druid.sql.ast.SQLCurrentUserExpr;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
+import com.alibaba.druid.sql.ast.statement.SQLExternalRecordFormat;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOutFileExpr;
+import com.alibaba.druid.sql.parser.*;
+import com.alibaba.druid.util.FnvHash;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.Arrays;
+
+public class ImpalaExprParser extends SQLExprParser {
+    private final static String[] AGGREGATE_FUNCTIONS;
+    private final static long[] AGGREGATE_FUNCTIONS_CODES;
+
+    static {
+        String[] strings = { "AVG", "COUNT", "MAX", "MIN", "STDDEV", "SUM", "ROW_NUMBER",
+                             "ROWNUMBER" };
+
+        AGGREGATE_FUNCTIONS_CODES = FnvHash.fnv1a_64_lower(strings, true);
+        AGGREGATE_FUNCTIONS = new String[AGGREGATE_FUNCTIONS_CODES.length];
+        for (String str : strings) {
+            long hash = FnvHash.fnv1a_64_lower(str);
+            int index = Arrays.binarySearch(AGGREGATE_FUNCTIONS_CODES, hash);
+            AGGREGATE_FUNCTIONS[index] = str;
+        }
+    }
+
+    public ImpalaExprParser(String sql){
+        this(new ImpalaLexer(sql));
+        this.dbType = JdbcConstants.IMPALA;
+        this.lexer.nextToken();
+    }
+
+    public ImpalaExprParser(String sql, SQLParserFeature... features){
+        this(new ImpalaLexer(sql, features));
+        this.lexer.nextToken();
+    }
+
+    public ImpalaExprParser(Lexer lexer){
+        super(lexer);
+        this.aggregateFunctions = AGGREGATE_FUNCTIONS;
+        this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
+    }
+
+    public SQLExpr primaryRest(SQLExpr expr) {
+//        if(lexer.token() == Token.COLON) {
+//            lexer.nextToken();
+//            expr = dotRest(expr);
+//            return expr;
+//        }
+
+        switch (lexer.token()) {
+            case LBRACKET:
+                SQLArrayExpr array = new SQLArrayExpr();
+                array.setExpr(expr);
+                lexer.nextToken();
+                this.exprList(array.getValues(), array);
+                accept(Token.RBRACKET);
+                return primaryRest(array);
+            case LITERAL_CHARS:
+                if (expr instanceof SQLCharExpr) {
+                    String text2 = ((SQLCharExpr) expr).getText();
+                    do {
+                        String chars = lexer.stringVal();
+                        text2 += chars;
+                        lexer.nextToken();
+                    } while (lexer.token() == Token.LITERAL_CHARS || lexer.token() == Token.LITERAL_ALIAS);
+                    expr = new SQLCharExpr(text2);
+                }
+                break;
+            case IDENTIFIER:
+                if (lexer.identifierEquals(FnvHash.Constants.BD) && expr instanceof SQLNumericLiteralExpr) {
+                    lexer.nextToken();
+                    Number num = ((SQLNumericLiteralExpr) expr).getNumber();
+                    expr = new SQLDecimalExpr(num.toString());
+                }
+                break;
+            default:
+                break;
+        }
+
+        return super.primaryRest(expr);
+    }
+
+    public SQLExpr primary() {
+        final Token tok = lexer.token();
+        switch (tok) {
+            case IDENTIFIER:
+                final long hash_lower = lexer.hash_lower();
+                if (hash_lower == FnvHash.Constants.OUTLINE) {
+                    lexer.nextToken();
+                    SQLExpr file = primary();
+                    SQLExpr expr = new MySqlOutFileExpr(file);
+
+                    return primaryRest(expr);
+                }
+
+                SQLCurrentTimeExpr currentTimeExpr = null;
+                if (hash_lower == FnvHash.Constants.CURRENT_TIMESTAMP) {
+                    currentTimeExpr = new SQLCurrentTimeExpr(SQLCurrentTimeExpr.Type.CURRENT_TIMESTAMP);
+                } else if (hash_lower == FnvHash.Constants.CURRENT_DATE) {
+                    currentTimeExpr = new SQLCurrentTimeExpr(SQLCurrentTimeExpr.Type.CURRENT_DATE);
+                } else if (hash_lower == FnvHash.Constants.CURRENT_USER && isEnabled(SQLParserFeature.EnableCurrentUserExpr)) {
+                    lexer.nextToken();
+                    return primaryRest(new SQLCurrentUserExpr());
+                }
+
+                if (currentTimeExpr != null) {
+                    String methodName = lexer.stringVal();
+                    lexer.nextToken();
+
+                    if (lexer.token() == Token.LPAREN) {
+                        lexer.nextToken();
+                        if (lexer.token() == Token.LPAREN) {
+                            lexer.nextToken();
+                        } else {
+                            return primaryRest(
+                                    methodRest(new SQLIdentifierExpr(methodName), false)
+                            );
+                        }
+                    }
+
+                    return primaryRest(currentTimeExpr);
+                }
+            default:
+                break;
+        }
+
+        return super.primary();
+    }
+
+    public SQLExternalRecordFormat parseRowFormat() {
+        lexer.nextToken();
+        acceptIdentifier("FORMAT");
+
+        if (lexer.identifierEquals(FnvHash.Constants.DELIMITED)) {
+            lexer.nextToken();
+        }
+
+        SQLExternalRecordFormat format = new SQLExternalRecordFormat();
+
+        if (lexer.identifierEquals(FnvHash.Constants.FIELDS)) {
+            lexer.nextToken();
+            acceptIdentifier("TERMINATED");
+            accept(Token.BY);
+
+            format.setTerminatedBy(this.expr());
+        } else if (lexer.identifierEquals("FIELD")) {
+            throw new ParserException("syntax error, expect FIELDS, " + lexer.info());
+        }
+
+        if (lexer.token() == Token.ESCAPE || lexer.identifierEquals(FnvHash.Constants.ESCAPED)) {
+            lexer.nextToken();
+            accept(Token.BY);
+            format.setEscapedBy(this.expr());
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.LINES)) {
+            lexer.nextToken();
+            acceptIdentifier("TERMINATED");
+            accept(Token.BY);
+
+            format.setLinesTerminatedBy(this.expr());
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.COLLECTION)) {
+            lexer.nextToken();
+            acceptIdentifier("ITEMS");
+            acceptIdentifier("TERMINATED");
+            accept(Token.BY);
+            format.setCollectionItemsTerminatedBy(this.expr());
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.MAP)) {
+            lexer.nextToken();
+            acceptIdentifier("KEYS");
+            acceptIdentifier("TERMINATED");
+            accept(Token.BY);
+            format.setMapKeysTerminatedBy(this.expr());
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.SERDE)) {
+            lexer.nextToken();
+            format.setSerde(this.expr());
+        }
+
+        return format;
+    }
+
+    protected SQLExpr parseAliasExpr(String alias) {
+        String chars = alias.substring(1, alias.length() - 1);
+
+        StringBuilder buf = null;
+
+        for (int i = 0; i < chars.length(); ++i) {
+            char ch = chars.charAt(i);
+            if (ch == '\\' && i < chars.length() - 1) {
+                char next = chars.charAt(i + 1);
+                if (next == '\\') {
+                    if (buf == null) {
+                        buf = new StringBuilder();
+                        buf.append(chars.substring(0, i));
+                    }
+                    buf.append('\\');
+                    ++i;
+                } else if (next == '\"') {
+                    if (buf == null) {
+                        buf = new StringBuilder();
+                        buf.append(chars.substring(0, i));
+                    }
+                    buf.append('"');
+                    ++i;
+                } else {
+                    if (buf != null) {
+                        buf.append(ch);
+                    }
+                }
+            } else {
+                if (buf != null) {
+                    buf.append(ch);
+                }
+            }
+        }
+
+        if (buf != null) {
+            chars = buf.toString();
+        }
+        return new SQLCharExpr(chars);
+    }
+
+    public SQLColumnDefinition parseColumnRest(SQLColumnDefinition column) {
+        if (lexer.identifierEquals(FnvHash.Constants.MAPPED)) {
+            lexer.nextToken();
+            accept(Token.BY);
+            this.parseAssignItem(column.getMappedBy(), column);
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.COLPROPERTIES)) {
+            lexer.nextToken();
+            this.parseAssignItem(column.getColProperties(), column);
+        }
+
+
+        return super.parseColumnRest(column);
+    }
+
+    protected SQLExpr parseInterval() {
+        accept(Token.INTERVAL);
+        SQLExpr value = expr();
+
+        if (lexer.token() != Token.IDENTIFIER) {
+            throw new ParserException("Syntax error. " + lexer.info());
+        }
+
+        String unit = lexer.stringVal();
+        lexer.nextToken();
+
+        SQLIntervalExpr intervalExpr = new SQLIntervalExpr();
+        intervalExpr.setValue(value);
+        SQLIntervalUnit intervalUnit = SQLIntervalUnit.valueOf(unit.toUpperCase());
+        if (intervalUnit == SQLIntervalUnit.YEAR
+                && lexer.token() == Token.TO) {
+            lexer.nextToken();
+            acceptIdentifier("MONTH");
+            intervalUnit = SQLIntervalUnit.YEAR_TO_MONTH;
+        }
+        intervalExpr.setUnit(intervalUnit);
+
+        return intervalExpr;
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
@@ -38,6 +38,8 @@ public class ImpalaLexer extends Lexer {
         map.put("STATS",Token.STATS);
         map.put("INCREMENTAL",Token.INCREMENTAL);
         map.put("UPSERT",Token.UPSERT);
+        map.put("HASH",Token.HASH);
+        map.put("RANGE",Token.RANGE);
 
         map.put("OF", Token.OF);
         map.put("CONCAT", Token.CONCAT);

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.parser;
+
+import com.alibaba.druid.sql.parser.Keywords;
+import com.alibaba.druid.sql.parser.Lexer;
+import com.alibaba.druid.sql.parser.SQLParserFeature;
+import com.alibaba.druid.sql.parser.Token;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ImpalaLexer extends Lexer {
+    public final static Keywords DEFAULT_IMPALA_KEYWORDS;
+
+    static {
+        Map<String, Token> map = new HashMap<String, Token>();
+
+        map.putAll(Keywords.DEFAULT_KEYWORDS.getKeywords());
+
+
+        map.put("INVALIDATE",Token.INVALIDATE);
+        map.put("METADATA",Token.METADATA);
+        map.put("REFRESH",Token.REFRESH);
+        map.put("STATS",Token.STATS);
+        map.put("INCREMENTAL",Token.INCREMENTAL);
+        map.put("UPSERT",Token.UPSERT);
+
+        map.put("OF", Token.OF);
+        map.put("CONCAT", Token.CONCAT);
+        map.put("CONTINUE", Token.CONTINUE);
+        map.put("MERGE", Token.MERGE);
+        map.put("MATCHED", Token.MATCHED);
+        map.put("USING", Token.USING);
+
+        map.put("ROW", Token.ROW);
+        map.put("LIMIT", Token.LIMIT);
+        map.put("PARTITIONED", Token.PARTITIONED);
+        map.put("PARTITION", Token.PARTITION);
+        map.put("OVERWRITE", Token.OVERWRITE);
+        map.put("SORT", Token.SORT);
+        map.put("IF", Token.IF);
+        map.put("TRUE", Token.TRUE);
+        map.put("FALSE", Token.FALSE);
+        map.put("RLIKE", Token.RLIKE);
+
+        DEFAULT_IMPALA_KEYWORDS = new Keywords(map);
+    }
+
+    protected final void scanString() {
+        scanString2();
+    }
+
+    public ImpalaLexer(String input){
+        super(input);
+        super.keywods = DEFAULT_IMPALA_KEYWORDS;
+    }
+
+    public ImpalaLexer(String input, SQLParserFeature... features){
+        super(input);
+        super.keywods = DEFAULT_IMPALA_KEYWORDS;
+        for (SQLParserFeature feature : features) {
+            config(feature, true);
+        }
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaLexer.java
@@ -40,6 +40,7 @@ public class ImpalaLexer extends Lexer {
         map.put("UPSERT",Token.UPSERT);
         map.put("HASH",Token.HASH);
         map.put("RANGE",Token.RANGE);
+        map.put("RENAME",Token.RENAME);
 
         map.put("OF", Token.OF);
         map.put("CONCAT", Token.CONCAT);

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaSelectParser.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.parser;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLSizeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLTableSampling;
+import com.alibaba.druid.sql.ast.statement.SQLTableSource;
+import com.alibaba.druid.sql.parser.*;
+import com.alibaba.druid.util.FnvHash;
+
+public class ImpalaSelectParser extends SQLSelectParser {
+
+    public ImpalaSelectParser(SQLExprParser exprParser){
+        super(exprParser);
+    }
+
+    public ImpalaSelectParser(SQLExprParser exprParser, SQLSelectListCache selectListCache){
+        super(exprParser, selectListCache);
+    }
+
+    public ImpalaSelectParser(String sql){
+        this(new ImpalaExprParser(sql));
+    }
+
+    protected SQLExprParser createExprParser() {
+        return new ImpalaExprParser(lexer);
+    }
+
+    protected SQLTableSource parseTableSourceRest(SQLTableSource tableSource) {
+        if (lexer.identifierEquals(FnvHash.Constants.TABLESAMPLE) && tableSource instanceof SQLExprTableSource) {
+            Lexer.SavePoint mark = lexer.mark();
+            lexer.nextToken();
+            if (lexer.token() == Token.LPAREN) {
+                lexer.nextToken();
+
+                SQLTableSampling sampling = new SQLTableSampling();
+
+                if (lexer.identifierEquals(FnvHash.Constants.BUCKET)) {
+                    lexer.nextToken();
+                    SQLExpr bucket = this.exprParser.primary();
+                    sampling.setBucket(bucket);
+
+                    if (lexer.token() == Token.OUT) {
+                        lexer.nextToken();
+                        accept(Token.OF);
+                        SQLExpr outOf = this.exprParser.primary();
+                        sampling.setOutOf(outOf);
+                    }
+
+                    if (lexer.token() == Token.ON) {
+                        lexer.nextToken();
+                        SQLExpr on = this.exprParser.expr();
+                        sampling.setOn(on);
+                    }
+                }
+
+                if (lexer.token() == Token.LITERAL_INT || lexer.token() == Token.LITERAL_FLOAT) {
+                    SQLExpr val = this.exprParser.primary();
+
+                    if (lexer.identifierEquals(FnvHash.Constants.ROWS)) {
+                        lexer.nextToken();
+                        sampling.setRows(val);
+                    } else {
+                        acceptIdentifier("PERCENT");
+                        sampling.setPercent(val);
+                    }
+                }
+
+                if (lexer.token() == Token.IDENTIFIER) {
+                    String strVal = lexer.stringVal();
+                    char first = strVal.charAt(0);
+                    char last = strVal.charAt(strVal.length() - 1);
+                    if (last >= 'a' && last <= 'z') {
+                        last -= 32; // to upper
+                    }
+
+                    boolean match = false;
+                    if ((first == '.' || (first >= '0' && first <= '9'))) {
+                        switch (last) {
+                            case 'B':
+                            case 'K':
+                            case 'M':
+                            case 'G':
+                            case 'T':
+                            case 'P':
+                                match = true;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    SQLSizeExpr size = new SQLSizeExpr(strVal.substring(0, strVal.length() - 2), last);
+                    sampling.setByteLength(size);
+                    lexer.nextToken();
+                }
+
+                final SQLExprTableSource table = (SQLExprTableSource) tableSource;
+                table.setSampling(sampling);
+
+                accept(Token.RPAREN);
+            } else {
+                lexer.reset(mark);
+            }
+        }
+        return super.parseTableSourceRest(tableSource);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/parser/ImpalaStatementParser.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.parser;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.parser.*;
+import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+import com.alibaba.druid.util.FnvHash;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaStatementParser extends SQLStatementParser {
+
+
+
+    public ImpalaStatementParser(String sql) {
+        super (new ImpalaExprParser(sql));
+    }
+
+    public ImpalaStatementParser(String sql, SQLParserFeature... features) {
+        super (new ImpalaExprParser(sql, features));
+    }
+
+    public ImpalaStatementParser(Lexer lexer){
+        super(new ImpalaExprParser(lexer));
+    }
+
+    public ImpalaSelectParser createSQLSelectParser() {
+        return new ImpalaSelectParser(this.exprParser, selectListCache);
+    }
+
+    public SQLStatement parseMeta(){
+        ImpalaMetaStatement stmt = new ImpalaMetaStatement(lexer.token());
+        if (lexer.token() == Token.INVALIDATE){
+            accept(Token.INVALIDATE);
+            accept(Token.METADATA);
+            if (lexer.token() != Token.SEMI) {
+                stmt.setTableSource(this.exprParser.name());
+            }
+        }else{
+            accept(Token.REFRESH);
+            stmt.setTableSource(this.exprParser.name());
+            if (lexer.token() == Token.PARTITION) {
+                lexer.nextToken();
+                accept(Token.LPAREN);
+                for (;;) {
+                    SQLAssignItem ptExpr = new SQLAssignItem();
+                    ptExpr.setTarget(this.exprParser.name());
+                    if (lexer.token() == Token.EQ) {
+                        lexer.nextToken();
+                        SQLExpr ptValue = this.exprParser.expr();
+                        ptExpr.setValue(ptValue);
+                    }
+                    stmt.addPartition(ptExpr);
+                    if (!(lexer.token() == (Token.COMMA))) {
+                        break;
+                    } else {
+                        lexer.nextToken();
+                    }
+                }
+                accept(Token.RPAREN);
+            }
+        }
+        return stmt;
+    }
+
+    public SQLStatement parseMerge() {
+        accept(Token.MERGE);
+        accept(Token.INTO);
+
+        SQLReplaceStatement stmt = new SQLReplaceStatement();
+        stmt.setDbType(JdbcConstants.IMPALA);
+
+        SQLName tableName = exprParser.name();
+        stmt.setTableName(tableName);
+
+        if (lexer.token() == Token.KEY) {
+            lexer.nextToken();
+            accept(Token.LPAREN);
+            this.exprParser.exprList(stmt.getColumns(), stmt);
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.VALUES || lexer.identifierEquals("VALUE")) {
+            lexer.nextToken();
+
+            parseValueClause(stmt.getValuesList(), 0, stmt);
+        } else if (lexer.token() == Token.SELECT) {
+            SQLQueryExpr queryExpr = (SQLQueryExpr) this.exprParser.expr();
+            stmt.setQuery(queryExpr);
+        } else if (lexer.token() == Token.LPAREN) {
+            SQLSelect select = this.createSQLSelectParser().select();
+            SQLQueryExpr queryExpr = new SQLQueryExpr(select);
+            stmt.setQuery(queryExpr);
+        }
+
+        return stmt;
+    }
+
+    public SQLCreateTableParser getSQLCreateTableParser() {
+        return new ImpalaCreateTableParser(this.exprParser);
+    }
+
+    public SQLStatement parseInsert() {
+        ImpalaInsertStatement insert = new ImpalaInsertStatement();
+
+        if (lexer.isKeepComments() && lexer.hasComment()) {
+            insert.addBeforeComment(lexer.readAndResetComments());
+        }
+
+        SQLSelectParser selectParser = createSQLSelectParser();
+
+        accept(Token.INSERT);
+
+        if (lexer.token() == Token.INTO) {
+            lexer.nextToken();
+        } else {
+            accept(Token.OVERWRITE);
+            insert.setOverwrite(true);
+        }
+
+        if (lexer.token() == Token.TABLE) {
+            accept(Token.TABLE);
+        }
+        insert.setTableSource(this.exprParser.name());
+
+        int columnSize = 0;
+
+        if (lexer.token() == Token.LPAREN){
+            lexer.nextToken();
+            List<SQLExpr> columns = insert.getColumns();
+            if (lexer.token() != Token.RPAREN) {
+                for (; ; ) {
+                    String identName;
+                    long hash;
+
+                    Token token = lexer.token();
+                    if (token == Token.IDENTIFIER) {
+                        identName = lexer.stringVal();
+                        hash = lexer.hash_lower();
+                    } else if (token == Token.LITERAL_CHARS) {
+                        identName = '\'' + lexer.stringVal() + '\'';
+                        hash = 0;
+                    } else {
+                        identName = lexer.stringVal();
+                        hash = 0;
+                    }
+                    lexer.nextTokenComma();
+                    SQLExpr expr = new SQLIdentifierExpr(identName, hash);
+                    while (lexer.token() == Token.DOT) {
+                        lexer.nextToken();
+                        String propertyName = lexer.stringVal();
+                        lexer.nextToken();
+                        expr = new SQLPropertyExpr(expr, propertyName);
+                    }
+
+                    expr.setParent(insert);
+                    columns.add(expr);
+                    columnSize++;
+
+                    if (lexer.token() == Token.COMMA) {
+                        lexer.nextTokenIdent();
+                        continue;
+                    }
+
+                    break;
+                }
+                columnSize = insert.getColumns().size();
+            }
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.LINE_COMMENT) {
+            lexer.nextToken();
+        }
+
+        if (lexer.token() == Token.PARTITION) {
+            lexer.nextToken();
+            accept(Token.LPAREN);
+            for (;;) {
+                SQLAssignItem ptExpr = new SQLAssignItem();
+                ptExpr.setTarget(this.exprParser.name());
+                if (lexer.token() == Token.EQ) {
+                    lexer.nextToken();
+                    SQLExpr ptValue = this.exprParser.expr();
+                    ptExpr.setValue(ptValue);
+                }
+                insert.addPartition(ptExpr);
+                if (!(lexer.token() == (Token.COMMA))) {
+                    break;
+                } else {
+                    lexer.nextToken();
+                }
+            }
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.LINE_COMMENT) {
+            lexer.nextToken();
+        }
+
+        if (lexer.token() == Token.VALUES) {
+            lexer.nextTokenLParen();
+            parseValueClause(insert.getValuesList(), columnSize, insert);
+        } else {
+            SQLSelect query = selectParser.select();
+            insert.setQuery(query);
+        }
+
+        return insert;
+    }
+
+    public boolean parseStatementListDialect(List<SQLStatement> statementList) {
+        if (lexer.token() == Token.FROM) {
+            SQLStatement stmt = this.parseInsert();
+            statementList.add(stmt);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaAlterTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaAlterTableStatement.java
@@ -1,0 +1,71 @@
+package com.alibaba.druid.sql.dialect.impala.stmt;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaAlterTableStatement extends SQLAlterTableStatement {
+  private boolean isExists = false;
+
+  public String getAlterType() {
+    return alterType;
+  }
+
+  public void setAlterType(String alterType) {
+    this.alterType = alterType;
+  }
+
+  private String alterType;
+
+  public List<SQLExpr> getPartitions() {
+    return partitions;
+  }
+
+  private List<SQLExpr>  partitions = new ArrayList<SQLExpr>();
+
+
+  public boolean isNotExists() {
+    return isNotExists;
+  }
+
+  public void setNotExists(boolean notExists) {
+    isNotExists = notExists;
+  }
+
+  private boolean isNotExists = false;
+
+  public ImpalaAlterTableStatement(){
+    super(JdbcConstants.IMPALA);
+  }
+
+  public boolean isExists() {
+    return isExists;
+  }
+
+  public void setExists(boolean exists) {
+    isExists = exists;
+  }
+
+  @Override
+  protected void accept0(SQLASTVisitor visitor) {
+    if (visitor instanceof ImpalaASTVisitor) {
+      accept0((ImpalaASTVisitor) visitor);
+    } else {
+      super.accept0(visitor);
+    }
+  }
+
+  protected void accept0(ImpalaASTVisitor visitor) {
+    if (visitor.visit(this)) {
+    }
+    visitor.endVisit(this);
+  }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaCreateTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaCreateTableStatement.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.stmt;
+
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.List;
+
+public class ImpalaCreateTableStatement extends SQLCreateTableStatement {
+
+    public ImpalaCreateTableStatement() {
+        this.dbType = JdbcConstants.IMPALA;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof ImpalaASTVisitor) {
+            accept0((ImpalaASTVisitor) visitor);
+        } else {
+            super.accept0(visitor);
+        }
+    }
+
+    public List<SQLColumnDefinition> getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public void addPartitionColumn(SQLColumnDefinition column) {
+        if (column != null) {
+            column.setParent(this);
+        }
+        this.partitionColumns.add(column);
+    }
+
+    protected void accept0(ImpalaASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            this.acceptChild(visitor, tableSource);
+            this.acceptChild(visitor, tableElementList);
+            this.acceptChild(visitor, inherits);
+            this.acceptChild(visitor, clusteredBy);
+            this.acceptChild(visitor, sortedBy);
+            this.acceptChild(visitor, select);
+        }
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaCreateTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaCreateTableStatement.java
@@ -15,15 +15,23 @@
  */
 package com.alibaba.druid.sql.dialect.impala.stmt;
 
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaKuduPartition;
 import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 import com.alibaba.druid.util.JdbcConstants;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ImpalaCreateTableStatement extends SQLCreateTableStatement {
+
+    protected final List<ImpalaKuduPartition> kuduPartitions =
+        new ArrayList<ImpalaKuduPartition>();
+    private SQLName location;
+    protected final List<String> tblProperties = new ArrayList<String>();
 
     public ImpalaCreateTableStatement() {
         this.dbType = JdbcConstants.IMPALA;
@@ -59,5 +67,19 @@ public class ImpalaCreateTableStatement extends SQLCreateTableStatement {
             this.acceptChild(visitor, select);
         }
         visitor.endVisit(this);
+    }
+    public SQLName getLocation() {
+        return location;
+    }
+
+    public void setLocation(SQLName location) {
+        this.location = location;
+    }
+
+    public List<ImpalaKuduPartition> getKuduPartitions() {
+        return kuduPartitions;
+    }
+    public List<String> getTblProperties() {
+        return tblProperties;
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaMetaStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaMetaStatement.java
@@ -15,18 +15,14 @@
  */
 package com.alibaba.druid.sql.dialect.impala.stmt;
 
-import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
-import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
-import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlSelectIntoStatement;
-import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlStatementImpl;
 import com.alibaba.druid.sql.parser.Token;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 import com.alibaba.druid.util.JdbcConstants;
-import com.mysql.cj.jdbc.StatementImpl;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +34,19 @@ public class ImpalaMetaStatement extends MySqlStatementImpl {
 
     private List<SQLAssignItem>  partitions = new ArrayList<SQLAssignItem>();
 
+
+    private boolean incremental = false;
+    public SQLExpr getComputePartition() {
+        return computePartition;
+    }
+
+    public void setComputePartition(SQLExpr computePartition) {
+        this.computePartition = computePartition;
+    }
+
+    private SQLExpr computePartition = null;
+
+    private List<SQLExpr> columns = new ArrayList<SQLExpr>();
 
     public ImpalaMetaStatement(Token metaType){
         this.dbType = JdbcConstants.IMPALA;
@@ -99,5 +108,16 @@ public class ImpalaMetaStatement extends MySqlStatementImpl {
         return partitions;
     }
 
+    public List<SQLExpr> getColumns() {
+        return columns;
+    }
+
+    public boolean isIncremental() {
+        return incremental;
+    }
+
+    public void setIncremental(boolean incremental) {
+        this.incremental = incremental;
+    }
 
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaMetaStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaMetaStatement.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.stmt;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.dialect.mysql.ast.clause.MySqlSelectIntoStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlStatementImpl;
+import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import com.mysql.cj.jdbc.StatementImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImpalaMetaStatement extends MySqlStatementImpl {
+
+
+    private Token metaType;
+
+    private List<SQLAssignItem>  partitions = new ArrayList<SQLAssignItem>();
+
+
+    public ImpalaMetaStatement(Token metaType){
+        this.dbType = JdbcConstants.IMPALA;
+        this.metaType = metaType;
+    }
+
+    public ImpalaMetaStatement() {
+        this.dbType = JdbcConstants.IMPALA;
+    }
+
+
+
+    public SQLExprTableSource getTableSource() {
+        return tableSource;
+    }
+
+    public void setTableSource(SQLExprTableSource tableSource) {
+        if (tableSource != null) {
+            tableSource.setParent(this);
+        }
+        this.tableSource = tableSource;
+    }
+
+    public void setTableSource(SQLName tableName) {
+        this.setTableSource(new SQLExprTableSource(tableName));
+    }
+
+
+    protected SQLExprTableSource tableSource;
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor instanceof ImpalaASTVisitor) {
+            accept0((ImpalaASTVisitor) visitor);
+        } else {
+            super.accept0(visitor);
+        }
+    }
+
+    protected void accept0(ImpalaASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, tableSource);
+            acceptChild(visitor, partitions);
+        }
+        visitor.endVisit(this);
+    }
+
+    public void addPartition(SQLAssignItem partition) {
+        if (partition != null) {
+            partition.setParent(this);
+        }
+        this.partitions.add(partition);
+    }
+    public Token getMetaType() {
+        return metaType;
+    }
+
+    public List<SQLAssignItem> getPartitions() {
+        return partitions;
+    }
+
+
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaUpdateStatements.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/stmt/ImpalaUpdateStatements.java
@@ -1,0 +1,45 @@
+package com.alibaba.druid.sql.dialect.impala.stmt;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.SQLJoinTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+import com.alibaba.druid.util.JdbcUtils;
+
+public class ImpalaUpdateStatements extends SQLUpdateStatement {
+
+  public SQLJoinTableSource getJoin() {
+    return join;
+  }
+
+  public void setJoin(SQLJoinTableSource join) {
+    this.join = join;
+  }
+
+  private SQLJoinTableSource join;
+
+  public ImpalaUpdateStatements(){
+    super(JdbcUtils.IMPALA);
+  }
+
+  @Override
+  protected void accept0(SQLASTVisitor visitor) {
+    if (visitor instanceof ImpalaASTVisitor) {
+      accept0((ImpalaASTVisitor) visitor);
+    } else {
+      super.accept0(visitor);
+    }
+  }
+
+  protected void accept0(ImpalaASTVisitor visitor) {
+    if (visitor.visit(this)) {
+      acceptChild(visitor, tableSource);
+      acceptChild(visitor, from);
+      acceptChild(visitor, items);
+      acceptChild(visitor, where);
+    }
+    visitor.endVisit(this);
+  }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
@@ -18,6 +18,7 @@ package com.alibaba.druid.sql.dialect.impala.visitor;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaAlterTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
@@ -41,4 +42,7 @@ public interface ImpalaASTVisitor extends SQLASTVisitor {
 
     boolean visit(ImpalaUpdateStatements x);
     void endVisit(ImpalaUpdateStatements x);
+
+    boolean visit(ImpalaAlterTableStatement x);
+    void endVisit(ImpalaAlterTableStatement x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public interface ImpalaASTVisitor extends SQLASTVisitor {
@@ -37,4 +38,7 @@ public interface ImpalaASTVisitor extends SQLASTVisitor {
 
     boolean visit(ImpalaMetaStatement x);
     void endVisit(ImpalaMetaStatement x);
+
+    boolean visit(ImpalaUpdateStatements x);
+    void endVisit(ImpalaUpdateStatements x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.visitor;
+
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public interface ImpalaASTVisitor extends SQLASTVisitor {
+    boolean visit(ImpalaCreateTableStatement x);
+    void endVisit(ImpalaCreateTableStatement x);
+
+    boolean visit(ImpalaMultiInsertStatement x);
+    void endVisit(ImpalaMultiInsertStatement x);
+
+    boolean visit(ImpalaInsertStatement x);
+    void endVisit(ImpalaInsertStatement x);
+
+    boolean visit(ImpalaInsert x);
+    void endVisit(ImpalaInsert x);
+
+    boolean visit(ImpalaMetaStatement x);
+    void endVisit(ImpalaMetaStatement x);
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.visitor;
+
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
+
+public class ImpalaASTVisitorAdapter extends SQLASTVisitorAdapter implements ImpalaASTVisitor {
+    @Override
+    public boolean visit(ImpalaCreateTableStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaCreateTableStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMultiInsertStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaMultiInsertStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaInsertStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsertStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaInsert x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsert x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMetaStatement x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaMetaStatement x) {
+
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
 import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
 
 public class ImpalaASTVisitorAdapter extends SQLASTVisitorAdapter implements ImpalaASTVisitor {
@@ -70,6 +71,16 @@ public class ImpalaASTVisitorAdapter extends SQLASTVisitorAdapter implements Imp
 
     @Override
     public void endVisit(ImpalaMetaStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaUpdateStatements x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaUpdateStatements x) {
 
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaASTVisitorAdapter.java
@@ -18,6 +18,7 @@ package com.alibaba.druid.sql.dialect.impala.visitor;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaAlterTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
@@ -81,6 +82,16 @@ public class ImpalaASTVisitorAdapter extends SQLASTVisitorAdapter implements Imp
 
     @Override
     public void endVisit(ImpalaUpdateStatements x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaAlterTableStatement x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaAlterTableStatement x) {
 
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
@@ -25,6 +25,7 @@ import com.alibaba.druid.sql.dialect.impala.ast.ImpalaKuduPartition;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
 import com.alibaba.druid.sql.parser.Token;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 
@@ -388,6 +389,51 @@ public class ImpalaOutputVisitor extends SQLASTOutputVisitor implements ImpalaAS
 
     @Override
     public void endVisit(ImpalaMetaStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaUpdateStatements x) {
+        print0(ucase ? "UPDATE " : "update ");
+
+        printTableSource(x.getTableSource());
+
+        print0(ucase ? "SET " : "set ");
+        for (int i = 0, size = x.getItems().size(); i < size; ++i) {
+            if (i != 0) {
+                print0(", ");
+            }
+            SQLUpdateSetItem item = x.getItems().get(i);
+            visit(item);
+        }
+
+        if (x.getJoin() != null){
+            indentCount++;
+            println();
+            print0(ucase? "FROM ":"from ");
+            printTableSource(x.getJoin().getLeft());
+            print0(ucase? " JOIN ":" join ");
+            printTableSource(x.getJoin().getRight());
+            println();
+            print(ucase?"ON ":"on ");
+            printExpr(x.getJoin().getCondition());
+            indentCount--;
+        }
+
+        SQLExpr where = x.getWhere();
+        if (where != null) {
+            println();
+            indentCount++;
+            print0(ucase ? "WHERE " : "where ");
+            printExpr(where);
+            indentCount--;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaUpdateStatements x) {
 
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
@@ -24,6 +24,7 @@ import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaKuduPartition;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaAlterTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
@@ -496,6 +497,34 @@ public class ImpalaOutputVisitor extends SQLASTOutputVisitor implements ImpalaAS
 
     @Override
     public void endVisit(ImpalaUpdateStatements x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaAlterTableStatement x){
+        print0(ucase?"ALTER TABLE ":"alter table ");
+        x.getTableSource().accept(this);
+        print0(" " + x.getAlterType());
+        if (x.isExists()){
+            print0(ucase?" IF EXISTS ":" if exists ");
+        }
+        if (x.isNotExists()){
+            print0(ucase?" IF NOT EXISTS ":" if not exists ");
+        }
+        if (x.getPartitions().size() > 0) {
+            print0("(");
+            for (SQLExpr expr : x.getPartitions().subList(0, x.getPartitions().size()-1)) {
+                expr.accept(this);
+                print0(", ");
+            }
+            x.getPartitions().get(x.getPartitions().size()-1).accept(this);
+            print0(")");
+        }
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaAlterTableStatement x){
 
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.visitor;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImpalaOutputVisitor extends SQLASTOutputVisitor implements ImpalaASTVisitor {
+    public ImpalaOutputVisitor(Appendable appender) {
+        super(appender);
+    }
+
+    public ImpalaOutputVisitor(Appendable appender, String dbType) {
+        super(appender, dbType);
+    }
+
+    public ImpalaOutputVisitor(Appendable appender, boolean parameterized) {
+        super(appender, parameterized);
+    }
+
+
+    @Override
+    public boolean visit(ImpalaCreateTableStatement x) {
+        printCreateTable(x, true);
+
+        return false;
+    }
+
+    protected void printCreateTable(ImpalaCreateTableStatement x, boolean printSelect) {
+        print0(ucase ? "CREATE " : "create ");
+
+        final SQLCreateTableStatement.Type tableType = x.getType();
+        if (SQLCreateTableStatement.Type.GLOBAL_TEMPORARY.equals(tableType)) {
+            print0(ucase ? "GLOBAL TEMPORARY " : "global temporary ");
+        } else if (SQLCreateTableStatement.Type.LOCAL_TEMPORARY.equals(tableType)) {
+            print0(ucase ? "LOCAL TEMPORARY " : "local temporary ");
+        }
+        print0(ucase ? "TABLE " : "table ");
+
+        if (x.isIfNotExiists()) {
+            print0(ucase ? "IF NOT EXISTS " : "if not exists ");
+        }
+
+        printTableSourceExpr(x.getName());
+
+        printTableElements(x.getTableElementList());
+
+        SQLExprTableSource inherits = x.getInherits();
+        if (inherits != null) {
+            print0(ucase ? " INHERITS (" : " inherits (");
+            inherits.accept(this);
+            print(')');
+        }
+
+        SQLExpr comment = x.getComment();
+        if (comment != null) {
+            println();
+            print0(ucase ? "COMMENT " : "comment ");
+            comment.accept(this);
+        }
+
+        int partitionSize = x.getPartitionColumns().size();
+        if (partitionSize > 0) {
+            println();
+            print0(ucase ? "PARTITIONED BY (" : "partitioned by (");
+            this.indentCount++;
+            println();
+            for (int i = 0; i < partitionSize; ++i) {
+                SQLColumnDefinition column = x.getPartitionColumns().get(i);
+                column.accept(this);
+
+                if (i != partitionSize - 1) {
+                    print(',');
+                }
+                if (this.isPrettyFormat() && column.hasAfterComment()) {
+                    print(' ');
+                    printlnComment(column.getAfterCommentsDirect());
+                }
+
+                if (i != partitionSize - 1) {
+                    println();
+                }
+            }
+            this.indentCount--;
+            println();
+            print(')');
+        }
+
+        List<SQLSelectOrderByItem> clusteredBy = x.getClusteredBy();
+        if (clusteredBy.size() > 0) {
+            println();
+            print0(ucase ? "CLUSTERED BY (" : "clustered by (");
+            printAndAccept(clusteredBy, ",");
+            print(')');
+        }
+
+        SQLExternalRecordFormat format = x.getRowFormat();
+        if (format != null) {
+            println();
+            print0(ucase ? "ROW FORMAT DELIMITED " : "row format delimited ");
+            visit(format);
+        }
+
+        List<SQLSelectOrderByItem> sortedBy = x.getSortedBy();
+        if (sortedBy.size() > 0) {
+            println();
+            print0(ucase ? "SORTED BY (" : "sorted by (");
+            printAndAccept(sortedBy, ", ");
+            print(')');
+        }
+
+        int buckets = x.getBuckets();
+        if (buckets > 0) {
+            println();
+            print0(ucase ? "INTO " : "into ");
+            print(buckets);
+            print0(ucase ? " BUCKETS" : " buckets");
+        }
+
+        SQLName storedAs = x.getStoredAs();
+        if (storedAs != null) {
+            println();
+            print0(ucase ? "STORE AS " : "store as ");
+            printExpr(storedAs);
+        }
+
+        Map<String, SQLObject> tableOptions = x.getTableOptions();
+        if (tableOptions.size() > 0) {
+            println();
+            print0(ucase ? "TBLPROPERTIES (" : "tblproperties (");
+            int i = 0;
+            for (Map.Entry<String, SQLObject> option : tableOptions.entrySet()) {
+                print0(option.getKey());
+                print0(" = ");
+                option.getValue().accept(this);
+                ++i;
+            }
+            print(')');
+        }
+
+        SQLSelect select = x.getSelect();
+        if (printSelect && select != null) {
+            println();
+            print0(ucase ? "AS" : "as");
+
+            println();
+            visit(select);
+        }
+    }
+
+    @Override
+    public void endVisit(ImpalaCreateTableStatement x) {
+
+    }
+
+    public boolean visit(SQLExternalRecordFormat x) {
+        if (x.getDelimitedBy() != null) {
+            println();
+            print0(ucase ? "LINES TERMINATED BY " : "lines terminated by ");
+            x.getDelimitedBy().accept(this);
+        }
+
+        if (x.getTerminatedBy() != null) {
+            println();
+            print0(ucase ? "FIELDS TERMINATED BY " : "fields terminated by ");
+            x.getTerminatedBy().accept(this);
+        }
+
+        return false;
+    }
+
+
+    @Override
+    public void endVisit(ImpalaMultiInsertStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMultiInsertStatement x) {
+        SQLTableSource from = x.getFrom();
+        if (x.getFrom() != null) {
+            if (from instanceof SQLSubqueryTableSource) {
+                SQLSelect select = ((SQLSubqueryTableSource) from).getSelect();
+                print0(ucase ? "FROM (" : "from (");
+                this.indentCount++;
+                println();
+                select.accept(this);
+                this.indentCount--;
+                println();
+                print0(") ");
+                print0(x.getFrom().getAlias());
+            } else {
+                print0(ucase ? "FROM " : "from ");
+                from.accept(this);
+            }
+            println();
+        }
+
+        for (int i = 0; i < x.getItems().size(); ++i) {
+            ImpalaInsert insert = x.getItems().get(i);
+            if (i != 0) {
+                println();
+            }
+            insert.accept(this);
+        }
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsertStatement x) {
+
+    }
+
+    public boolean visit(ImpalaInsertStatement x) {
+        if (x.hasBeforeComment()) {
+            printlnComments(x.getBeforeCommentsDirect());
+        }
+        if (x.isOverwrite()) {
+            print0(ucase ? "INSERT OVERWRITE TABLE " : "insert overwrite table ");
+        } else {
+            print0(ucase ? "INSERT INTO TABLE " : "insert into table ");
+        }
+        x.getTableSource().accept(this);
+
+        int partitions = x.getPartitions().size();
+        if (partitions > 0) {
+            print0(ucase ? " PARTITION (" : " partition (");
+            for (int i = 0; i < partitions; ++i) {
+                if (i != 0) {
+                    print0(", ");
+                }
+
+                SQLAssignItem assign = x.getPartitions().get(i);
+                assign.getTarget().accept(this);
+
+                if (assign.getValue() != null) {
+                    print('=');
+                    assign.getValue().accept(this);
+                }
+            }
+            print(')');
+        }
+        println();
+
+        SQLSelect select = x.getQuery();
+        List<SQLInsertStatement.ValuesClause> valuesList = x.getValuesList();
+        if (select != null) {
+            select.accept(this);
+        } else if (!valuesList.isEmpty()) {
+            print0(ucase ? "VALUES " : "values ");
+            printAndAccept(valuesList, ", ");
+        }
+
+
+        return false;
+    }
+
+    @Override
+    public boolean visit(ImpalaInsert x) {
+        if (x.hasBeforeComment()) {
+            printlnComments(x.getBeforeCommentsDirect());
+        }
+        if (x.isOverwrite()) {
+            print0(ucase ? "INSERT OVERWRITE TABLE " : "insert overwrite table ");
+        } else {
+            print0(ucase ? "INSERT INTO TABLE " : "insert into table ");
+        }
+        x.getTableSource().accept(this);
+
+        int partitions = x.getPartitions().size();
+        if (partitions > 0) {
+            print0(ucase ? " PARTITION (" : " partition (");
+            for (int i = 0; i < partitions; ++i) {
+                if (i != 0) {
+                    print0(", ");
+                }
+
+                SQLAssignItem assign = x.getPartitions().get(i);
+                assign.getTarget().accept(this);
+
+                if (assign.getValue() != null) {
+                    print('=');
+                    assign.getValue().accept(this);
+                }
+            }
+            print(')');
+        }
+        println();
+
+        SQLSelect select = x.getQuery();
+        List<SQLInsertStatement.ValuesClause> valuesList = x.getValuesList();
+        if (select != null) {
+            select.accept(this);
+        } else if (!valuesList.isEmpty()) {
+            print0(ucase ? "VALUES " : "values ");
+            printAndAccept(valuesList, ", ");
+        }
+
+
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsert x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMetaStatement x) {
+        if (x.getMetaType() == Token.INVALIDATE){
+            print0(ucase? "INVALIDATE METADATA ": "invalidate metadata ");
+            if (x.getTableSource() != null){
+                x.getTableSource().accept(this);
+            }
+        }else{
+            print0(ucase? "REFRESH " : "refresh ");
+            x.getTableSource().accept(this);
+            int partitions = x.getPartitions().size();
+            if (partitions > 0) {
+                print0(ucase ? " PARTITION (" : " partition (");
+                for (int i = 0; i < partitions; ++i) {
+                    if (i != 0) {
+                        print0(", ");
+                    }
+
+                    SQLAssignItem assign = x.getPartitions().get(i);
+                    assign.getTarget().accept(this);
+
+                    if (assign.getValue() != null) {
+                        print('=');
+                        assign.getValue().accept(this);
+                    }
+                }
+                print(')');
+            }
+            println();
+        }
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaMetaStatement x) {
+
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaOutputVisitor.java
@@ -103,7 +103,7 @@ public class ImpalaOutputVisitor extends SQLASTOutputVisitor implements ImpalaAS
             }
             this.indentCount--;
             println();
-            print(')');
+            println(")");
         }
 
         List<ImpalaKuduPartition> kuduPartitions = x.getKuduPartitions();

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
@@ -17,12 +17,14 @@ package com.alibaba.druid.sql.dialect.impala.visitor;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaAlterTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
@@ -90,6 +92,16 @@ public class ImpalaSchemaStatVisitor extends SchemaStatVisitor implements Impala
 
     @Override
     public void endVisit(ImpalaUpdateStatements x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaAlterTableStatement x) {
+        return super.visit((SQLAlterTableStatement)x);
+    }
+
+    @Override
+    public void endVisit(ImpalaAlterTableStatement x) {
 
     }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.impala.visitor;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class ImpalaSchemaStatVisitor extends SchemaStatVisitor implements ImpalaASTVisitor {
+
+    public ImpalaSchemaStatVisitor() {
+        super (JdbcConstants.HIVE);
+    }
+
+    @Override
+    public boolean visit(ImpalaCreateTableStatement x) {
+        return super.visit((SQLCreateTableStatement) x);
+    }
+
+    @Override
+    public void endVisit(ImpalaCreateTableStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaInsert x) {
+        setMode(x, TableStat.Mode.Insert);
+
+        SQLExprTableSource tableSource = x.getTableSource();
+        SQLExpr tableName = tableSource.getExpr();
+
+        if (tableName instanceof SQLName) {
+            TableStat stat = getTableStat((SQLName) tableName);
+            stat.incrementInsertCount();
+
+        }
+
+        for (SQLAssignItem partition : x.getPartitions()) {
+            partition.accept(this);
+        }
+
+        accept(x.getQuery());
+
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsert x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMetaStatement x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaMetaStatement x) {
+
+    }
+
+    @Override
+    public void endVisit(ImpalaMultiInsertStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaMultiInsertStatement x) {
+        if (repository != null
+                && x.getParent() == null) {
+            repository.resolve(x);
+        }
+        return true;
+    }
+
+
+    @Override
+    public void endVisit(ImpalaInsertStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaInsertStatement x) {
+        if (repository != null
+                && x.getParent() == null) {
+            repository.resolve(x);
+        }
+
+        setMode(x, TableStat.Mode.Insert);
+
+        SQLExprTableSource tableSource = x.getTableSource();
+        SQLExpr tableName = tableSource.getExpr();
+
+        if (tableName instanceof SQLName) {
+            TableStat stat = getTableStat((SQLName) tableName);
+            stat.incrementInsertCount();
+
+        }
+
+        for (SQLAssignItem partition : x.getPartitions()) {
+            partition.accept(this);
+        }
+
+        accept(x.getQuery());
+
+        return false;
+    }
+
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
@@ -25,6 +25,7 @@ import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
 import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaMetaStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaUpdateStatements;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.stat.TableStat;
 import com.alibaba.druid.util.JdbcConstants;
@@ -79,6 +80,16 @@ public class ImpalaSchemaStatVisitor extends SchemaStatVisitor implements Impala
 
     @Override
     public void endVisit(ImpalaMetaStatement x) {
+
+    }
+
+    @Override
+    public boolean visit(ImpalaUpdateStatements x) {
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaUpdateStatements x) {
 
     }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/impala/visitor/ImpalaSchemaStatVisitor.java
@@ -33,7 +33,7 @@ import com.alibaba.druid.util.JdbcConstants;
 public class ImpalaSchemaStatVisitor extends SchemaStatVisitor implements ImpalaASTVisitor {
 
     public ImpalaSchemaStatVisitor() {
-        super (JdbcConstants.HIVE);
+        super (JdbcConstants.IMPALA);
     }
 
     @Override

--- a/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsASTVisitor.java
@@ -16,6 +16,7 @@
 package com.alibaba.druid.sql.dialect.odps.visitor;
 
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAddStatisticStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAnalyzeTableStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsCreateTableStatement;
@@ -123,4 +124,8 @@ public interface OdpsASTVisitor extends SQLASTVisitor {
     void endVisit(OdpsValuesTableSource x);
 
     boolean visit(OdpsValuesTableSource x);
+
+    void endVisit(ImpalaInsert x);
+
+    boolean visit(ImpalaInsert x);
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsASTVisitorAdapter.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsASTVisitorAdapter.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAddStatisticStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAnalyzeTableStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsCreateTableStatement;
@@ -88,6 +89,16 @@ public class OdpsASTVisitorAdapter extends SQLASTVisitorAdapter implements OdpsA
     public void endVisit(HiveInsertStatement x) {
 
     }
+
+    @Override
+    public boolean visit(ImpalaInsert x) {
+        return true;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsert x) {
+    }
+
 
     @Override
     public boolean visit(HiveInsert x) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/odps/visitor/OdpsSchemaStatVisitor.java
@@ -23,6 +23,7 @@ import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLGrantStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
+import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAddStatisticStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsAnalyzeTableStatement;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsCreateTableStatement;
@@ -98,6 +99,33 @@ public class OdpsSchemaStatVisitor extends SchemaStatVisitor implements OdpsASTV
         accept(x.getQuery());
 
         return false;
+    }
+
+    @Override
+    public boolean visit(ImpalaInsert x) {
+
+        setMode(x, TableStat.Mode.Insert);
+
+        SQLExprTableSource tableSource = x.getTableSource();
+        SQLExpr tableName = tableSource.getExpr();
+
+        if (tableName instanceof SQLName) {
+            TableStat stat = getTableStat((SQLName) tableName);
+            stat.incrementInsertCount();
+
+        }
+
+        for (SQLAssignItem partition : x.getPartitions()) {
+            partition.accept(this);
+        }
+
+        accept(x.getQuery());
+
+        return false;
+    }
+
+    @Override
+    public void endVisit(ImpalaInsert x) {
     }
 
     @Override

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
@@ -22,6 +22,7 @@ import com.alibaba.druid.sql.dialect.db2.parser.DB2Lexer;
 import com.alibaba.druid.sql.dialect.db2.parser.DB2StatementParser;
 import com.alibaba.druid.sql.dialect.h2.parser.H2StatementParser;
 import com.alibaba.druid.sql.dialect.hive.parser.HiveStatementParser;
+import com.alibaba.druid.sql.dialect.impala.parser.ImpalaStatementParser;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlExprParser;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlLexer;
@@ -112,6 +113,10 @@ public class SQLParserUtils {
 
         if (JdbcUtils.ELASTIC_SEARCH.equals(dbType)) {
             return new MySqlStatementParser(sql);
+        }
+
+        if (JdbcUtils.IMPALA.equals(dbType)){
+            return new ImpalaStatementParser(sql);
         }
 
         return new SQLStatementParser(sql, dbType);

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -2161,7 +2161,7 @@ public class SQLStatementParser extends SQLParser {
 
         Token token = lexer.token;
 
-        if (token == Token.TABLE || lexer.identifierEquals("GLOBAL")) {
+        if (token == Token.TABLE || lexer.identifierEquals("GLOBAL") || lexer.identifierEquals("EXTERNAL")) {
             SQLCreateTableParser createTableParser = getSQLCreateTableParser();
             SQLCreateTableStatement stmt = createTableParser.parseCreateTable(false);
             

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -122,6 +122,7 @@ import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import com.alibaba.druid.sql.ast.statement.SQLUseStatement;
 import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
+import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
 import com.alibaba.druid.sql.dialect.impala.ast.ImpalaInsert;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlExprParser;
@@ -3475,6 +3476,75 @@ public class SQLStatementParser extends SQLParser {
         }
     }
 
+    protected HiveInsertStatement parseHiveInsertStmt() {
+        HiveInsertStatement insert = new HiveInsertStatement();
+
+        if (lexer.isKeepComments() && lexer.hasComment()) {
+            insert.addBeforeComment(lexer.readAndResetComments());
+        }
+
+        SQLSelectParser selectParser = createSQLSelectParser();
+
+        accept(Token.INSERT);
+
+        if (lexer.token() == Token.INTO) {
+            lexer.nextToken();
+        } else {
+            accept(Token.OVERWRITE);
+            insert.setOverwrite(true);
+        }
+
+        accept(Token.TABLE);
+        insert.setTableSource(this.exprParser.name());
+
+        if (lexer.token() == Token.PARTITION) {
+            lexer.nextToken();
+            accept(Token.LPAREN);
+            for (;;) {
+                SQLAssignItem ptExpr = new SQLAssignItem();
+                ptExpr.setTarget(this.exprParser.name());
+                if (lexer.token() == Token.EQ) {
+                    lexer.nextToken();
+                    SQLExpr ptValue = this.exprParser.expr();
+                    ptExpr.setValue(ptValue);
+                }
+                insert.addPartition(ptExpr);
+                if (!(lexer.token() == (Token.COMMA))) {
+                    break;
+                } else {
+                    lexer.nextToken();
+                }
+            }
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.VALUES) {
+            lexer.nextToken();
+
+            for (;;) {
+                if (lexer.token() == Token.LPAREN) {
+                    lexer.nextToken();
+
+                    SQLInsertStatement.ValuesClause values = new SQLInsertStatement.ValuesClause();
+                    this.exprParser.exprList(values.getValues(), values);
+                    insert.addValueCause(values);
+                    accept(Token.RPAREN);
+                }
+
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        } else {
+            SQLSelect query = selectParser.select();
+            insert.setQuery(query);
+        }
+
+        return insert;
+    }
 
     protected HiveInsert parseHiveInsert() {
         HiveInsert insert = new HiveInsert();

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -416,6 +416,7 @@ public class SQLStatementParser extends SQLParser {
                     statementList.add(stmt);
                     continue;
                 }
+                case COMPUTE:
                 case INVALIDATE:
                 case REFRESH:{
                     SQLStatement stmt = parseMeta();

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -354,6 +354,15 @@ public enum Token {
     POUNDGTGT("#>>"),
     MONKEYS_AT_GT("@>"),
     LT_MONKEYS_AT("<@"),
+
+
+    //impala
+    INVALIDATE("INVALIDATE"),
+    METADATA("METADATA"),
+    REFRESH("REFRESH"),
+    STATS("STATS"),
+    INCREMENTAL("INCREMENTAL"),
+
     ;
 
     public final String name;

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -364,7 +364,7 @@ public enum Token {
     INCREMENTAL("INCREMENTAL"),
     HASH("HASH"),
     RANGE("RANGE"),
-
+    RENAME("RENAME"),
     ;
 
     public final String name;

--- a/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -362,6 +362,8 @@ public enum Token {
     REFRESH("REFRESH"),
     STATS("STATS"),
     INCREMENTAL("INCREMENTAL"),
+    HASH("HASH"),
+    RANGE("RANGE"),
 
     ;
 

--- a/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -694,5 +694,7 @@ public final class FnvHash {
         long DIMENSION = fnv1a_64_lower("DIMENSION");
         long KEEP = fnv1a_64_lower("KEEP");
         long PIVOT = fnv1a_64_lower("PIVOT");
+
+        long LOCATION = fnv1a_64_lower("LOCATION");
     }
 }

--- a/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -130,4 +130,6 @@ public interface JdbcConstants {
      */
     String POLARDB                    = "polardb";
     String POLARDB_DRIVER             = "com.aliyun.polardb.Driver";
+
+    String IMPALA                     = "impala";
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaCreateTableTest_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaCreateTableTest_0.java
@@ -1,0 +1,33 @@
+package com.alibaba.druid.bvt.sql.impala;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class ImpalaCreateTableTest_0 extends TestCase {
+    public void test_create() throws Exception {
+        String sql = "CREATE TABLE IF NOT Exists pk(col1 INT, col2 STRING, PRIMARY KEY(col1, col2))";//
+        assertEquals("CREATE TABLE IF NOT EXISTS pk (\n" +
+            "\tcol1 INT,\n" +
+            "\tcol2 STRING,\n" +
+            "\tPRIMARY KEY (col1, col2)\n" +
+            ");", SQLUtils.formatImpala(sql));
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.IMPALA);
+        SQLStatement stmt = statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(JdbcConstants.IMPALA);
+        stmt.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+
+        assertEquals(1, visitor.getTables().size());
+        assertEquals(3, visitor.getColumns().size());
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaCreateTableTest_1.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaCreateTableTest_1.java
@@ -1,0 +1,39 @@
+package com.alibaba.druid.bvt.sql.impala;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.impala.stmt.ImpalaCreateTableStatement;
+import com.alibaba.druid.sql.dialect.impala.visitor.ImpalaSchemaStatVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class ImpalaCreateTableTest_1 extends TestCase {
+    public void test_create() throws Exception {
+        String sql = "CREATE EXTERNAL TABLE external_parquet (c1 INT, c2 STRING, c3 TIMESTAMP) STORED AS PARQUET LOCATION '/user/etl/destination';";
+        assertEquals("CREATE EXTERNAL TABLE external_parquet (\n" +
+            "\tc1 INT,\n" +
+            "\tc2 STRING,\n" +
+            "\tc3 TIMESTAMP\n" +
+            ")\n" +
+            "STORE AS PARQUET\n" +
+            "LOCATION '/user/etl/destination';", SQLUtils.formatImpala(sql));
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.IMPALA);
+        ImpalaCreateTableStatement stmt = (ImpalaCreateTableStatement)statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        ImpalaSchemaStatVisitor visitor =
+            (ImpalaSchemaStatVisitor)SQLUtils.createSchemaStatVisitor(JdbcConstants.IMPALA);
+
+        stmt.accept(visitor);
+        assertEquals(1, visitor.getTables().size());
+
+        assertEquals(3, visitor.getColumns().size());
+
+
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaInsertTest_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaInsertTest_0.java
@@ -1,0 +1,31 @@
+package com.alibaba.druid.bvt.sql.impala;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class ImpalaInsertTest_0 extends TestCase {
+    public void test_create() throws Exception {
+        String sql = "INSERT INTO t1 PARTITION (x=10, y='a') SELECT c1 FROM some_other_table;";//
+        assertEquals("INSERT INTO TABLE t1 PARTITION (x=10, y='a')\n" +
+            "SELECT c1\n" +
+            "FROM some_other_table;", SQLUtils.formatImpala(sql));
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.IMPALA);
+        SQLStatement stmt = statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(JdbcConstants.IMPALA);
+        stmt.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+
+        assertEquals(2, visitor.getTables().size());
+        assertEquals(3, visitor.getColumns().size());
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaInsertTest_1.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/impala/ImpalaInsertTest_1.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.bvt.sql.impala;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class ImpalaInsertTest_1 extends TestCase {
+    public void test_create() throws Exception {
+        String sql = "INSERT INTO TABLE `tt`.`articles`\n" +
+            "VALUES ('a''大1大2-- /**fsdaf**/撒发链接a', 'bb', '大大aa-- /**fsdaf**/撒发链接'), ('a''大1大2-- " +
+            "/**fsdaf**/撒发链接a', 'bb', '大大aa-- /**fsdaf**/撒发链接'), ('a''大1大2-- /**fsdaf**/撒发链接a', " +
+            "'bb', '大大aa-- /**fsdaf**/撒发链接');";//
+        assertEquals("INSERT INTO TABLE `tt`.`articles`\n" +
+            "VALUES ('a''大1大2-- /**fsdaf**/撒发链接a', 'bb', '大大aa-- /**fsdaf**/撒发链接'), ('a''大1大2-- " +
+            "/**fsdaf**/撒发链接a', 'bb', '大大aa-- /**fsdaf**/撒发链接'), ('a''大1大2-- /**fsdaf**/撒发链接a', " +
+            "'bb', '大大aa-- /**fsdaf**/撒发链接');", SQLUtils.formatImpala(sql));
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.IMPALA);
+        SQLStatement stmt = statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(JdbcConstants.IMPALA);
+        stmt.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+
+        assertEquals(1, visitor.getTables().size());
+        assertEquals(0, visitor.getColumns().size());
+    }
+}


### PR DESCRIPTION
增加sql parser中impala相关方言。目前支持简单select，insert、invalidate、refresh等，后续慢慢补充
update at 13 July : add insert, create, update, upsert, compute stats  supported
update at 20 July: add test case of create & insert