### PR TITLE
#3872  解析创建数据库sql出错

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -4413,6 +4413,14 @@ public class MySqlStatementParser extends SQLStatementParser {
             accept(Token.EXISTS);
             stmt.setIfNotExists(true);
         }
+        if (lexer.token() == Token.HINT) {
+            List<SQLCommentHint> hints = stmt.getHints();
+            if (hints == null){
+                hints = new ArrayList<SQLCommentHint>();
+                stmt.setHints(hints);
+            }
+            this.exprParser.parseHints(hints);
+        }
 
         stmt.setName(this.exprParser.name());
 
@@ -4421,7 +4429,12 @@ public class MySqlStatementParser extends SQLStatementParser {
         }
 
         if (lexer.token() == Token.HINT) {
-            stmt.setHints(this.exprParser.parseHints());
+            List<SQLCommentHint> hints = stmt.getHints();
+            if (hints == null){
+                hints = new ArrayList<SQLCommentHint>();
+                stmt.setHints(hints);
+            }
+            this.exprParser.parseHints(hints);
         }
 
         if (lexer.token() == Token.DEFAULT) {


### PR DESCRIPTION
CREATE DATABASE /*!32312 IF NOT EXISTS /xwiki /!40100 DEFAULT CHARACTER SET utf8 */;
此sql在navicat可以正常执行，但在druid-1.1.23通过以下代码解析出错：
List sqlStatements = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);

com.alibaba.druid.sql.parser.ParserException: error pos 41, line 1, column 16, token HINT

	at com.alibaba.druid.sql.parser.SQLExprParser.name(SQLExprParser.java:1562)
	at com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser.parseCreateDatabase(MySqlStatementParser.java:4417)
	at com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser.parseCreate(MySqlStatementParser.java:430)
	at com.alibaba.druid.sql.parser.SQLStatementParser.parseStatementList(SQLStatementParser.java:260)
	at com.alibaba.druid.sql.parser.SQLStatementParser.parseStatementList(SQLStatementParser.java:171)
	at com.alibaba.druid.sql.SQLUtils.parseStatements(SQLUtils.java:492)
	at com.alibaba.druid.sql.SQLUtils.parseStatements(SQLUtils.java:487)
	at org.exam.ConverterTest.fromText(ConverterTest.java:121)
	at org.exam.ConverterTest.test(ConverterTest.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)