### PR TITLE
修复DruidDataSource close后CreateConnectionThread没有退出的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2809,7 +2809,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                     break;
                 }
                 
-                if (Thread.interrupted()) {
+                if (closing || closed) {
                     break;
                 }
 

--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2808,6 +2808,10 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                     setFailContinuous(true);
                     break;
                 }
+                
+                if (Thread.interrupted()) {
+                    break;
+                }
 
                 if (connection == null) {
                     continue;


### PR DESCRIPTION
问题描述：
mysql主从，当主库hang住以后获取链接超时，此时进行主从切换，调用DruidDataSource的close方法并重新创建新的DruidDataSource。新的DruidDataSource正确链接了正确的数据库，但是原来的DruidDataSource中CreateConnectionThread并没有退出，还在持续尝试创建链接，进而报错。

分析：
DruidDataSource中的CreateConnectionThread和DestroyConnectionThread是成对出现的，调用close方法会采用中断方式关闭它们。而目前观测到的情况是DestroyConnectionThread退出，但是CreateConnectionThread没有。对比二者逻辑，DestroyConnectionThread包含Thread.isInterrupted检测，但是CreateConnectionThread中调用createPhysicalConnection方法时没有处理interruptedException。mysql hang住时，超时时间一般都是秒级别的，导致close时基本100%停留在此处，故catch了SQLException后没有退出。

变更：
CreateConnectionThread中增加closed closing判断，如果觉得不妥，也可以使用Thread.isInterrupted

类似问题 https://github.com/alibaba/druid/issues/2291
