### PR TITLE
Pg patch

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
@@ -109,6 +109,9 @@ public class PGSelectQueryBlock extends SQLSelectQueryBlock implements PGSQLObje
     }
 
     public void setOrderBy(SQLOrderBy orderBy) {
+        if (orderBy != null) {
+            orderBy.setParent(this);
+        }
         this.orderBy = orderBy;
     }
 


### PR DESCRIPTION
druid中`PGSelectQueryBlock`中的setOderby没有为orderby设置parent.
```
    public void setOrderBy(SQLOrderBy orderBy) {
        this.orderBy = orderBy;
    }
```
mysql就没有这个问题，因为它的实现是这样的。
```
    public void setOrderBy(SQLOrderBy orderBy) {
        if (orderBy != null) {
            orderBy.setParent(this);
        }

        this.orderBy = orderBy;
    }
```