### PR TITLE
bug: limit ? offset ?和limit ?,?的参数顺序是相反的，应该区别对待

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/SQLLimit.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/SQLLimit.java
@@ -39,6 +39,8 @@ public final class SQLLimit extends SQLObjectImpl {
     private SQLExpr rowCount;
     private SQLExpr offset;
 
+    private boolean withOffsetCause;
+
     public SQLExpr getRowCount() {
         return rowCount;
     }
@@ -67,6 +69,14 @@ public final class SQLLimit extends SQLObjectImpl {
             offset.setParent(this);
         }
         this.offset = offset;
+    }
+
+    public boolean isWithOffsetCause(){
+        return withOffsetCause;
+    }
+
+    public void setWithOffsetCause(boolean withOffsetCause) {
+        this.withOffsetCause = withOffsetCause;
     }
 
     @Override

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3621,6 +3621,7 @@ public class SQLExprParser extends SQLParser {
                 limit.setRowCount(temp);
                 lexer.nextToken();
                 limit.setOffset(this.expr());
+                limit.setWithOffsetCause(true);
             } else {
                 limit.setRowCount(temp);
             }

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -5947,15 +5947,25 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     public boolean visit(SQLLimit x) {
         print0(ucase ? "LIMIT " : "limit ");
-        SQLExpr offset = x.getOffset();
-        if (offset != null) {
-            printExpr(offset);
-            print0(", ");
+        if (x.isWithOffsetCause()) {
+            SQLExpr rowCount = x.getRowCount();
+            printExpr(rowCount);
+
+            SQLExpr offset = x.getOffset();
+            if (offset != null) {
+                print0(ucase ? " OFFSET " : " offset ");
+                printExpr(offset);
+            }
+        } else {
+            SQLExpr offset = x.getOffset();
+            if (offset != null) {
+                printExpr(offset);
+                print0(", ");
+            }
+
+            SQLExpr rowCount = x.getRowCount();
+            printExpr(rowCount);
         }
-
-        SQLExpr rowCount = x.getRowCount();
-        printExpr(rowCount);
-
         return false;
     }
 

--- a/src/test/java/com/alibaba/druid/mysql/MysqlLimitTest.java
+++ b/src/test/java/com/alibaba/druid/mysql/MysqlLimitTest.java
@@ -1,5 +1,6 @@
 package com.alibaba.druid.mysql;
 
+import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.parser.SQLParserUtils;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
@@ -22,7 +23,12 @@ public class MysqlLimitTest extends TestCase{
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("is not a number!"));
         }
+    }
 
-
+    public void testLimitWithOffset() {
+        String sql = "select * from aaa limit ? offset ?";
+        SQLStatementParser statementParser = SQLParserUtils.createSQLStatementParser(sql, "mysql");
+        SQLStatement sqlStatement = statementParser.parseStatement();
+        assertEquals("select * from aaa limit 10 offset 0", SQLUtils.toSQLString(sqlStatement, "mysql", new SQLUtils.FormatOption(false, false)));
     }
 }


### PR DESCRIPTION
fix bug: 当sql是limit ? offset ? 的时候，原来的版本会输出为 limit ?,?。这样就调整了参数顺序，这个时候如果Statement上的参数顺序没有改变的话则会导致错误