### PR TITLE
bug：mysql解析引擎对while...end while后丢失";", 导致执行时报错

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# 请参与投票
-* 2019最受欢迎中国开源软件评选投票 https://www.oschina.net/project/top_cn_2019 请参与投票
-
 # druid
 
 [![Build Status](https://travis-ci.org/alibaba/druid.svg?branch=master)](https://travis-ci.org/alibaba/druid)

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -3935,7 +3935,7 @@ public class MySqlStatementParser extends SQLStatementParser {
                     renameStmt.addItem(item);
 
                     return renameStmt;
-                }   
+                }
             } else if (lexer.token() == Token.ORDER) {
                 throw new ParserException("TODO " + lexer.info());
             } else if (lexer.identifierEquals("CONVERT")) {
@@ -5055,6 +5055,7 @@ public class MySqlStatementParser extends SQLStatementParser {
         accept(Token.WHILE);
 
         accept(Token.SEMI);
+        stmt.setAfterSemi(true);
 
         return stmt;
 
@@ -5085,6 +5086,7 @@ public class MySqlStatementParser extends SQLStatementParser {
         acceptIdentifier(label);
 
         accept(Token.SEMI);
+        stmt.setAfterSemi(true);
 
         return stmt;
 
@@ -5543,7 +5545,7 @@ public class MySqlStatementParser extends SQLStatementParser {
 
         return stmt;
     }
-    
+
     /**
      * FETCH [[NEXT] FROM] cursor_name INTO var_name [, var_name] ...
      */

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -2474,11 +2474,11 @@ public class SQLStatementParser extends SQLParser {
             stmt.setWhen(condition);
         }
 
-        List<SQLStatement> body = this.parseStatementList();
-        if (body == null || body.isEmpty()) {
+        SQLStatement body = this.parseBlock();
+        if (body == null) {
             throw new ParserException("syntax error");
         }
-        stmt.setBody(body.get(0));
+        stmt.setBody(body);
         return stmt;
     }
 


### PR DESCRIPTION
创建 函数语句中，存在while... end while表达式时，经过MysqlStatementParser解析时，在end while后没有处理“;”，导致不能正确执行。