### PR TITLE
fix url prefix jdbc:oceanbase:oracle recognize error

### DIFF
--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -534,10 +534,10 @@ public final class JdbcUtils implements JdbcConstants {
             return ORACLE;
         } else if (rawUrl.startsWith("jdbc:alibaba:oracle:")) {
             return ALI_ORACLE;
-        } else if (rawUrl.startsWith("jdbc:oceanbase:")) {
-            return OCEANBASE;
         } else if (rawUrl.startsWith("jdbc:oceanbase:oracle:")) {
             return OCEANBASE_ORACLE;
+        } else if (rawUrl.startsWith("jdbc:oceanbase:")) {
+            return OCEANBASE;
         } else if (rawUrl.startsWith("jdbc:microsoft:") || rawUrl.startsWith("jdbc:log4jdbc:microsoft:")) {
             return SQL_SERVER;
         } else if (rawUrl.startsWith("jdbc:sqlserver:") || rawUrl.startsWith("jdbc:log4jdbc:sqlserver:")) {

--- a/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtils_driver.java
+++ b/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtils_driver.java
@@ -29,6 +29,13 @@ public class JdbcUtils_driver extends TestCase {
         Assert.assertEquals(JdbcConstants.ODPS, JdbcUtils.getDbType(url, className));
     }
 
+    public void test_oceanbase() {
+        assertEquals(JdbcConstants.OCEANBASE
+                , JdbcUtils.getDbType("jdbc:oceanbase://127.1:3306/test?a=b", null));
+        assertEquals(JdbcConstants.OCEANBASE_ORACLE
+                , JdbcUtils.getDbType("jdbc:oceanbase:oracle://127.1:3306/test?a=b", null));
+    }
+
     public void test_log4jdbc_mysql() {
         String jdbcUrl = "jdbc:log4jdbc:mysql://localhost:8066/test";
         String dbType = JdbcUtils.getDbType(jdbcUrl, null);


### PR DESCRIPTION
Signed-off-by: hongwei yi hongweiyi@hotmail.com

workaround: if you need use oceanbase oracle type in Druid previous version, please use DruidDataSource.setDbType("oceanbase_oracle") instead