### PR TITLE
Support build on java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
 		<profile>
 			<id>default-profile</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<!--<activeByDefault>true</activeByDefault>-->
 				<file>
 					<exists>${env.JAVA_HOME}/lib/jconsole.jar</exists>
 				</file>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 
 	<profiles>
 		<profile>
-			<id>default-profile</id>
+			<id>jconsole</id>
 			<activation>
 				<!--<activeByDefault>true</activeByDefault>-->
 				<file>
@@ -229,6 +229,19 @@
 					<scope>system</scope>
 					<systemPath>${toolsjar}</systemPath>
 					<optional>true</optional>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>java11plus</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+					<version>1.3.2</version>
 				</dependency>
 			</dependencies>
 		</profile>


### PR DESCRIPTION
此PR包含两个功能：
1. 不存在${env.JAVA_HOME}/lib/jconsole.jar也可进行maven编译
2. 支持java 11+下的编译依赖
```
   <dependency>
            <groupId>javax.annotation</groupId>
            <artifactId>javax.annotation-api</artifactId>
            <version>1.3.2</version>
        </dependency>
```
from: https://stackoverflow.com/questions/56855335/javax-annotation-classes-and-java-11-jdk
