### PR TITLE
add parseStatement not check SQL end

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -131,6 +131,14 @@ import com.alibaba.druid.util.JdbcConstants;
 
 public class SQLStatementParser extends SQLParser {
 
+    /**
+     * 标识变量，默认SQL解析结束后核对输入SQL是否解析结束了，预防程序BUG导致SQL被意外截断，
+     * 造成如数据库表被全删除了此类严重安全事故.默认启用此特，如要禁用则需要设置jvm参数:
+     * `-Ddruid_sql_parser_end_assert_off=true`
+     */
+    private static final boolean PARSER_END_ASSERT = 
+        !Boolean.getBoolean("druid_sql_parser_end_assert_off");
+
     protected SQLExprParser      exprParser;
     protected boolean            parseCompleteValues = true;
     protected int                parseValuesSize     = 3;
@@ -2832,42 +2840,48 @@ public class SQLStatementParser extends SQLParser {
     }
     
     public SQLStatement parseStatement() {
+        SQLStatement ret;
         if (lexer.token == Token.SELECT) {
-            return this.parseSelect();
+            ret = this.parseSelect();
         }
-
-        if (lexer.token == Token.INSERT) {
-            return this.parseInsert();
+        else if (lexer.token == Token.INSERT) {
+            ret = this.parseInsert();
         }
-
-
-        if (lexer.token == Token.UPDATE) {
-            return this.parseUpdateStatement();
+        else if (lexer.token == Token.UPDATE) {
+            ret = this.parseUpdateStatement();
         }
-
-        if (lexer.token == Token.DELETE) {
-            return this.parseDeleteStatement();
+        else if (lexer.token == Token.DELETE) {
+            ret = this.parseDeleteStatement();
         }
-
-        List<SQLStatement> list = new ArrayList<SQLStatement>(1);
-        this.parseStatementList(list, 1, null);
-        return list.get(0);
+        else {
+            ret =  parseStatement(false);
+        }
+        if (PARSER_END_ASSERT && lexer.token != Token.EOF) {
+            throw createParseNotEndException();
+        }
+        return ret;
     }
-    
+
     /**
-    * @param tryBest  - 为true去解析并忽略之后的错误
-    *  强制建议除非明确知道可以忽略才传tryBest=true,
+     * 强制建议除非明确知道可以忽略才传failIfSyntaxError=false.
     *  不然会忽略语法错误，且截断sql,导致update和delete无where条件下执行！！！
+    *
+    * @param failIfSyntaxError  - 为false去解析并忽略之后的错误
     */
-    public SQLStatement parseStatement( final boolean tryBest) {
-        List<SQLStatement> list = new ArrayList<SQLStatement>();
-        this.parseStatementList(list, 1, null);
-        if (tryBest) {
+    public SQLStatement parseStatement(final boolean failIfSyntaxError) {
+        final List<SQLStatement> list = new ArrayList<SQLStatement>();
+        parseStatementList(list, 1, null);
+        if (failIfSyntaxError) {
             if (lexer.token != Token.EOF) {
-                throw new ParserException("sql syntax error, no terminated. " + lexer.token);
+                throw createParseNotEndException();
             }
         }
         return list.get(0);
+    }
+ 
+     private ParserException createParseNotEndException() {
+        return new ParserException("parse not end, sql syntax may error!lexer.token: "
+            + lexer.token + " pos: " + lexer.pos + " sql: " + lexer.text);
     }
 
     public SQLExplainStatement parseExplain() {

--- a/src/test/java/com/alibaba/druid/bvt/bug/BugSqlParserIllegalWhere.java
+++ b/src/test/java/com/alibaba/druid/bvt/bug/BugSqlParserIllegalWhere.java
@@ -1,0 +1,65 @@
+
+package com.alibaba.druid.bvt.bug;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleExportParameterVisitor;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.ExportParameterVisitor;
+import com.alibaba.fastjson.JSON;
+
+import junit.framework.TestCase;
+
+/**
+ * 此测试类用于检测试sql中where拼错导致SQL无效，
+ * 但经SQLStatementParser解析却丢失where的严复问题.
+ * 
+ * @author qxo
+ */
+public class BugSqlParserIllegalWhere extends TestCase {
+
+    public void test4deleteWhere() throws Exception {
+        // @formatter:off
+        Object[][] samples =  {
+            { "update test_tab1 set b= 1 swhere a=1", false},
+            { "select * from test_tab1 swhere  a=1", false},
+            { "delete from test_tab1 \n swhere  a=1", false},
+            { "delete from test_tab1 where a=1", true},
+            { "delete from test_tab1 \n where a='a'     \n", true}
+            
+        };
+        // @formatter:off
+        for (final Object[] arr : samples) {
+            String sql = (String)arr[0];
+            final boolean ok = Boolean.TRUE.equals(arr[1]);
+            try {
+                System.out.println("before sql:" + sql);
+                final StringBuilder out = new StringBuilder();
+                final ExportParameterVisitor visitor = new OracleExportParameterVisitor(out);
+                visitor.setParameterizedMergeInList(true);
+                SQLStatementParser parser = new OracleStatementParser(sql);
+                final SQLStatement parseStatement = parser.parseStatement();
+                parseStatement.accept(visitor);
+                final List<Object> plist = visitor.getParameters();
+                sql = out.toString();
+                System.out.println("after sql:" + sql);
+                System.out.println("params: " + JSON.toJSONString(plist));
+                assertTrue(Pattern.compile("(?i)(^|\\s+)where(\\s+|$)").matcher(sql).find());
+            //assertEquals("[\"name\",[\"A\",\"B\"]]", JSON.toJSONString(plist));
+                if(!ok) {
+                    fail();
+                }
+            } catch (ParserException ex) {
+                if(ok) {
+                    fail();
+                } else {
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
where拼写错误导致where之后条件被忽略！

之前PR #1577 虽然被合并到了主分支，但实际上执行点从来没生效过:(
而且本PR也只是处理parseStatement：加了后置断言，其它parseStatementList这一组方法依然存在此问题。


最好能在发现SQL有语法问题时直接中止处理，而不是忽略过去


@wenshao 