### PR TITLE
fix url prefix jdbc:oceanbase:oracle recognize error

### DIFF
--- a/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -545,10 +545,10 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.oracle;
         } else if (rawUrl.startsWith("jdbc:alibaba:oracle:")) {
             return DbType.ali_oracle;
-        } else if (rawUrl.startsWith("jdbc:oceanbase:")) {
-            return DbType.oceanbase;
         } else if (rawUrl.startsWith("jdbc:oceanbase:oracle:")) {
             return DbType.oceanbase_oracle;
+        } else if (rawUrl.startsWith("jdbc:oceanbase:")) {
+            return DbType.oceanbase;
         } else if (rawUrl.startsWith("jdbc:microsoft:") || rawUrl.startsWith("jdbc:log4jdbc:microsoft:")) {
             return DbType.sqlserver;
         } else if (rawUrl.startsWith("jdbc:sqlserver:") || rawUrl.startsWith("jdbc:log4jdbc:sqlserver:")) {

--- a/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtils_driver.java
+++ b/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtils_driver.java
@@ -30,6 +30,11 @@ public class JdbcUtils_driver extends TestCase {
         Assert.assertEquals(JdbcConstants.ODPS, JdbcUtils.getDbTypeRaw(url, className));
     }
 
+    public void test_oceanbase() {
+        assertEquals(JdbcConstants.OCEANBASE, DbType.of(JdbcUtils.getDbType("jdbc:oceanbase://127.1:3306/test?a=b", null)));
+        assertEquals(JdbcConstants.OCEANBASE_ORACLE, DbType.of(JdbcUtils.getDbType("jdbc:oceanbase:oracle://127.1:3306/test?a=b", null)));
+    }
+
     public void test_log4jdbc_mysql() {
         String jdbcUrl = "jdbc:log4jdbc:mysql://localhost:8066/test";
         DbType dbType = JdbcUtils.getDbTypeRaw(jdbcUrl, null);


### PR DESCRIPTION
Signed-off-by: hongwei yi hongweiyi@hotmail.com
workaround: if you need use oceanbase oracle type in Druid previous version, please use DruidDataSource.setDbType("oceanbase_oracle") instead