### PR TITLE
bug-oracle charType miss type name character

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -126,6 +126,7 @@ public class OracleExprParser extends SQLExprParser {
                 || hash == FnvHash.Constants.VARCHAR2
                 || hash == FnvHash.Constants.NVARCHAR
                 || hash == FnvHash.Constants.NVARCHAR2
+                || hash == FnvHash.Constants.CHARACTER
                 ;
     }
 


### PR DESCRIPTION
sql:
CREATE TABLE test_char_2(
 test_char_2_1 character,
 test_char_2_2 character(10),
 test_char_2_3 character(10 BYTE),
 test_char_2_4 character(10 CHAR)
)

error:
parse fail com.alibaba.druid.sql.parser.ParserException: syntax error, expect ), actual IDENTIFIER pos 114, line 4, column 30, token IDENTIFIER BYTE
	at com.alibaba.druid.sql.parser.SQLExprParser.accept(SQLExprParser.java:3980) ~[druid-1.2.3.jar:1.2.3]
	at com.alibaba.druid.sql.parser.SQLExprParser.parseDataTypeRest(SQLExprParser.java:3865) ~[druid-1.2.3.jar:1.2.3]
	at com.alibaba.druid.sql.dialect.oracle.parser.OracleExprParser.parseDataType(OracleExprParser.java:267) ~[druid-1.2.3.jar:1.2.3]
	at com.alibaba.druid.sql.parser.SQLExprParser.parseDataType(SQLExprParser.java:3557) ~[druid-1.2.3.jar:1.2.3]
	at com.alibaba.druid.sql.parser.SQLExprParser.parseColumn(SQLExprParser.java:3999) ~[druid-1.2.3.jar:1.2.3]
	at com.alibaba.druid.sql.parser.SQLCreateTableParser.parseCreateTable(SQLCreateTableParser.java:113) ~[druid-1.2.3.jar:1.2.3]
