### PR TITLE
support parsing mysql 8 check related DDL statement  #4089

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MysqlAlterTableAlterCheck.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MysqlAlterTableAlterCheck.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.sql.dialect.mysql.ast.statement;
+
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableItem;
+import com.alibaba.druid.sql.dialect.mysql.ast.MySqlObjectImpl;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
+
+public class MysqlAlterTableAlterCheck extends MySqlObjectImpl implements SQLAlterTableItem {
+
+    private SQLName name;
+    private Boolean enforced;
+
+    @Override
+    public void accept0(MySqlASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            if (getName() != null) {
+                getName().accept(visitor);
+            }
+        }
+        visitor.endVisit(this);
+    }
+
+    public SQLName getName() {
+        return name;
+    }
+
+    public void setName(SQLName name) {
+        this.name = name;
+    }
+
+    public Boolean getEnforced() {
+        return enforced;
+    }
+
+    public void setEnforced(Boolean enforced) {
+        this.enforced = enforced;
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -1550,6 +1550,9 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
             check.setExpr(expr);
             constraint = check;
 
+            boolean enforce = true;
+            //should find Token.NOT to recognize "NOT ENFORCED"
+            //but somehow Token.NOT eaten by "this.exprParser.expr()" in above code
             if (lexer.token() == Token.HINT) {
                 String hintText = lexer.stringVal();
                 if (hintText != null) {
@@ -1564,6 +1567,9 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     }
                     lexer.nextToken();
                 }
+            } else if (lexer.stringVal().equalsIgnoreCase("ENFORCED")) {
+                check.setEnforced(enforce);
+                lexer.nextToken();
             }
         }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -1546,13 +1546,19 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
             lexer.nextToken();
             SQLCheck check = new SQLCheck();
             check.setName(name);
-            SQLExpr expr = this.exprParser.expr();
+            SQLExpr expr = this.exprParser.primary();
             check.setExpr(expr);
             constraint = check;
 
             boolean enforce = true;
-            //should find Token.NOT to recognize "NOT ENFORCED"
-            //but somehow Token.NOT eaten by "this.exprParser.expr()" in above code
+            if (Token.NOT.equals(lexer.token())) {
+                enforce = false;
+                lexer.nextToken();
+            }
+            if (lexer.stringVal().equalsIgnoreCase("ENFORCED")) {
+                check.setEnforced(enforce);
+                lexer.nextToken();
+            }
             if (lexer.token() == Token.HINT) {
                 String hintText = lexer.stringVal();
                 if (hintText != null) {
@@ -1567,9 +1573,6 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     }
                     lexer.nextToken();
                 }
-            } else if (lexer.stringVal().equalsIgnoreCase("ENFORCED")) {
-                check.setEnforced(enforce);
-                lexer.nextToken();
             }
         }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
@@ -1443,4 +1443,12 @@ public interface MySqlASTVisitor extends SQLASTVisitor {
     default void endVisit(MySqlJSONTableExpr.Column x) {
 
     }
+
+    default boolean visit(MysqlAlterTableAlterCheck x) {
+        return true;
+    }
+
+    default void endVisit(MysqlAlterTableAlterCheck x) {
+
+    }
 } //

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -5519,4 +5519,27 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
 //        return false;
 //    }
 
+    public boolean visit(MysqlAlterTableAlterCheck x) {
+        print0(ucase ? "ALTER CONSTRAINT " : "alter constraint ");
+
+        SQLName name = x.getName();
+        if (name != null) {
+            name.accept(this);
+            print(' ');
+        }
+
+        Boolean enforced = x.getEnforced();
+        if (enforced != null) {
+            if (enforced) {
+                print0(ucase ? " ENFORCED" : " enforced");
+            } else {
+                print0(ucase ? " NOT ENFORCED" : " not enforced");
+            }
+        }
+        return false;
+    }
+
+    public void endVisit(MysqlAlterTableAlterCheck x) {
+
+    }
 } //

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/MysqlCheckTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/MysqlCheckTest.java
@@ -1,0 +1,184 @@
+package com.alibaba.druid.bvt.sql.mysql;
+
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MysqlAlterTableAlterCheck;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import org.junit.Assert;
+
+import java.util.List;
+
+public class MysqlCheckTest extends MysqlTest {
+
+    public void test_create1()  {
+        String sql = "CREATE TABLE `t12` (\n" +
+                "  `c1` int DEFAULT NULL,\n" +
+                "  `c2` int DEFAULT NULL,\n" +
+                "  `c3` int DEFAULT NULL,\n" +
+                "  CONSTRAINT `c12_positive` CHECK ((`c2` > 0)) /*!80016 NOT ENFORCED */,\n" +
+                "  CONSTRAINT `c21_nonzero` CHECK ((`c1` <> 0)),\n" +
+                "  CONSTRAINT `t12_chk_1` CHECK ((`c1` <> `c2`)),\n" +
+                "  CONSTRAINT `t12_chk_2` CHECK ((`c1` > 10)),\n" +
+                "  CONSTRAINT `t12_chk_3` CHECK ((`c3` < 100)),\n" +
+                "  CONSTRAINT `t12_chk_4` CHECK ((`c1` > `c3`))\n" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+
+        MySqlCreateTableStatement statement = (MySqlCreateTableStatement) statementList.get(0);
+        Assert.assertEquals(9, statement.getTableElementList().size());
+        SQLTableElement element = statement.getTableElementList().get(3);
+        Assert.assertTrue(element instanceof SQLCheck);
+        SQLCheck sqlCheck = (SQLCheck) element;
+        Assert.assertEquals(false, sqlCheck.getEnforced());
+    }
+
+    public void test_create2() {
+        String sql = "CREATE TABLE `t12` (\n" +
+                "\t`c1` int DEFAULT NULL,\n" +
+                "\t`c2` int DEFAULT NULL,\n" +
+                "\t`c3` int DEFAULT NULL,\n" +
+                "\tCONSTRAINT `c12_positive` CHECK (`c2` > 0) NOT ENFORCED,\n" +
+                "\tCONSTRAINT `c21_nonzero` CHECK (`c1` <> 0),\n" +
+                "\tCONSTRAINT `t12_chk_1` CHECK (`c1` <> `c2`),\n" +
+                "\tCONSTRAINT `t12_chk_2` CHECK (`c1` > 10),\n" +
+                "\tCONSTRAINT `t12_chk_3` CHECK (`c3` < 100),\n" +
+                "\tCONSTRAINT `t12_chk_4` CHECK (`c1` > `c3`)\n" +
+                ") ENGINE = InnoDB CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;\n";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+
+        MySqlCreateTableStatement statement = (MySqlCreateTableStatement) statementList.get(0);
+        Assert.assertEquals(9, statement.getTableElementList().size());
+        SQLTableElement element = statement.getTableElementList().get(3);
+        Assert.assertTrue(element instanceof SQLCheck);
+        SQLCheck sqlCheck = (SQLCheck) element;
+        Assert.assertEquals(false, sqlCheck.getEnforced());
+    }
+
+    public void test_alter_add1() {
+        String sql = "ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK((a>1));";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+        Assert.assertTrue(statementList.get(0) instanceof SQLAlterTableStatement);
+        SQLAlterTableStatement statement = (SQLAlterTableStatement) statementList.get(0);
+        Assert.assertEquals(1, statement.getItems().size());
+
+        Assert.assertTrue(statement.getItems().get(0) instanceof SQLAlterTableAddConstraint);
+        SQLAlterTableAddConstraint constraint = (SQLAlterTableAddConstraint) statement.getItems().get(0);
+
+        Assert.assertTrue(constraint.getConstraint() instanceof SQLCheck);
+
+        SQLCheck sqlCheck = (SQLCheck) constraint.getConstraint();
+        Assert.assertNull(sqlCheck.getEnforced());
+        Assert.assertEquals("chk1", sqlCheck.getName().getSimpleName());
+        Assert.assertEquals("a > 1", sqlCheck.getExpr().toString());
+    }
+
+    public void test_alter_add2() {
+        String sql = "ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK((a>1)) NOT ENFORCED; ";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+        Assert.assertTrue(statementList.get(0) instanceof SQLAlterTableStatement);
+        SQLAlterTableStatement statement = (SQLAlterTableStatement) statementList.get(0);
+        Assert.assertEquals(1, statement.getItems().size());
+
+        Assert.assertTrue(statement.getItems().get(0) instanceof SQLAlterTableAddConstraint);
+        SQLAlterTableAddConstraint constraint = (SQLAlterTableAddConstraint) statement.getItems().get(0);
+
+        Assert.assertTrue(constraint.getConstraint() instanceof SQLCheck);
+
+        SQLCheck sqlCheck = (SQLCheck) constraint.getConstraint();
+        Assert.assertEquals(false, sqlCheck.getEnforced());
+        Assert.assertEquals("chk1", sqlCheck.getName().getSimpleName());
+        Assert.assertEquals("a > 1", sqlCheck.getExpr().toString());
+    }
+
+    public void test_alter_drop() throws Exception {
+        String sql = "ALTER TABLE t1 DROP CONSTRAINT t1_check ;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+
+        SQLAlterTableStatement statement = (SQLAlterTableStatement) statementList.get(0);
+        Assert.assertEquals(1, statement.getItems().size());
+
+        Assert.assertTrue(statement.getItems().get(0) instanceof SQLAlterTableDropConstraint);
+        SQLAlterTableDropConstraint constraint = (SQLAlterTableDropConstraint) statement.getItems().get(0);
+
+        Assert.assertEquals("t1_check", constraint.getConstraintName().getSimpleName());
+    }
+
+    public void test_alter_alter1() {
+        String sql = "alter table t1 ALTER CHECK  t1_check  ENFORCED;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+
+        SQLAlterTableStatement statement = (SQLAlterTableStatement) statementList.get(0);
+        Assert.assertEquals(1, statement.getItems().size());
+
+        Assert.assertTrue(statement.getItems().get(0) instanceof MysqlAlterTableAlterCheck);
+        MysqlAlterTableAlterCheck constraint = (MysqlAlterTableAlterCheck) statement.getItems().get(0);
+
+        Assert.assertEquals("t1_check", constraint.getName().getSimpleName());
+        Assert.assertEquals(true, constraint.getEnforced());
+    }
+
+    public void test_alter_alter2() {
+        String sql = "alter table t1 ALTER CHECK  t1_check  NOT ENFORCED;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+
+        System.out.println(stmt);
+
+        Assert.assertEquals(1, statementList.size());
+
+        SQLAlterTableStatement statement = (SQLAlterTableStatement) statementList.get(0);
+        Assert.assertEquals(1, statement.getItems().size());
+
+        Assert.assertTrue(statement.getItems().get(0) instanceof MysqlAlterTableAlterCheck);
+        MysqlAlterTableAlterCheck constraint = (MysqlAlterTableAlterCheck) statement.getItems().get(0);
+
+        Assert.assertEquals("t1_check", constraint.getName().getSimpleName());
+        Assert.assertEquals(false, constraint.getEnforced());
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/MysqlCheckTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/MysqlCheckTest.java
@@ -2,6 +2,8 @@ package com.alibaba.druid.bvt.sql.mysql;
 
 import com.alibaba.druid.sql.MysqlTest;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MysqlAlterTableAlterCheck;
@@ -21,7 +23,7 @@ public class MysqlCheckTest extends MysqlTest {
                 "  CONSTRAINT `c21_nonzero` CHECK ((`c1` <> 0)),\n" +
                 "  CONSTRAINT `t12_chk_1` CHECK ((`c1` <> `c2`)),\n" +
                 "  CONSTRAINT `t12_chk_2` CHECK ((`c1` > 10)),\n" +
-                "  CONSTRAINT `t12_chk_3` CHECK ((`c3` < 100)),\n" +
+                "  CONSTRAINT `t12_chk_3` CHECK (((`c3` < 100) and (`c3` > 0))),\n" +
                 "  CONSTRAINT `t12_chk_4` CHECK ((`c1` > `c3`))\n" +
                 ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
 
@@ -35,10 +37,57 @@ public class MysqlCheckTest extends MysqlTest {
 
         MySqlCreateTableStatement statement = (MySqlCreateTableStatement) statementList.get(0);
         Assert.assertEquals(9, statement.getTableElementList().size());
-        SQLTableElement element = statement.getTableElementList().get(3);
-        Assert.assertTrue(element instanceof SQLCheck);
-        SQLCheck sqlCheck = (SQLCheck) element;
-        Assert.assertEquals(false, sqlCheck.getEnforced());
+        {
+            SQLTableElement element = statement.getTableElementList().get(3);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertEquals(false, sqlCheck.getEnforced());
+            Assert.assertEquals("`c12_positive`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c2` > 0", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(4);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`c21_nonzero`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` <> 0", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(5);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_1`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` <> `c2`", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(6);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_2`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` > 10", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(7);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_3`", sqlCheck.getName().getSimpleName());
+            Assert.assertTrue(sqlCheck.getExpr() instanceof SQLBinaryOpExpr);
+            Assert.assertEquals(SQLBinaryOperator.BooleanAnd, ((SQLBinaryOpExpr) sqlCheck.getExpr()).getOperator());
+            Assert.assertEquals("`c3` < 100", ((SQLBinaryOpExpr) sqlCheck.getExpr()).getLeft().toString());
+            Assert.assertEquals("`c3` > 0", ((SQLBinaryOpExpr) sqlCheck.getExpr()).getRight().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(8);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_4`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` > `c3`", sqlCheck.getExpr().toString());
+        }
     }
 
     public void test_create2() {
@@ -50,7 +99,8 @@ public class MysqlCheckTest extends MysqlTest {
                 "\tCONSTRAINT `c21_nonzero` CHECK (`c1` <> 0),\n" +
                 "\tCONSTRAINT `t12_chk_1` CHECK (`c1` <> `c2`),\n" +
                 "\tCONSTRAINT `t12_chk_2` CHECK (`c1` > 10),\n" +
-                "\tCONSTRAINT `t12_chk_3` CHECK (`c3` < 100),\n" +
+                "\tCONSTRAINT `t12_chk_3` CHECK (`c3` < 100\n" +
+                "\t\tAND `c3` > 0),\n" +
                 "\tCONSTRAINT `t12_chk_4` CHECK (`c1` > `c3`)\n" +
                 ") ENGINE = InnoDB CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;\n";
 
@@ -64,10 +114,57 @@ public class MysqlCheckTest extends MysqlTest {
 
         MySqlCreateTableStatement statement = (MySqlCreateTableStatement) statementList.get(0);
         Assert.assertEquals(9, statement.getTableElementList().size());
-        SQLTableElement element = statement.getTableElementList().get(3);
-        Assert.assertTrue(element instanceof SQLCheck);
-        SQLCheck sqlCheck = (SQLCheck) element;
-        Assert.assertEquals(false, sqlCheck.getEnforced());
+        {
+            SQLTableElement element = statement.getTableElementList().get(3);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertEquals(false, sqlCheck.getEnforced());
+            Assert.assertEquals("`c12_positive`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c2` > 0", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(4);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`c21_nonzero`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` <> 0", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(5);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_1`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` <> `c2`", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(6);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_2`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` > 10", sqlCheck.getExpr().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(7);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_3`", sqlCheck.getName().getSimpleName());
+            Assert.assertTrue(sqlCheck.getExpr() instanceof SQLBinaryOpExpr);
+            Assert.assertEquals(SQLBinaryOperator.BooleanAnd, ((SQLBinaryOpExpr) sqlCheck.getExpr()).getOperator());
+            Assert.assertEquals("`c3` < 100", ((SQLBinaryOpExpr) sqlCheck.getExpr()).getLeft().toString());
+            Assert.assertEquals("`c3` > 0", ((SQLBinaryOpExpr) sqlCheck.getExpr()).getRight().toString());
+        }
+        {
+            SQLTableElement element = statement.getTableElementList().get(8);
+            Assert.assertTrue(element instanceof SQLCheck);
+            SQLCheck sqlCheck = (SQLCheck) element;
+            Assert.assertNull(sqlCheck.getEnforced());
+            Assert.assertEquals("`t12_chk_4`", sqlCheck.getName().getSimpleName());
+            Assert.assertEquals("`c1` > `c3`", sqlCheck.getExpr().toString());
+        }
     }
 
     public void test_alter_add1() {
@@ -120,7 +217,7 @@ public class MysqlCheckTest extends MysqlTest {
         Assert.assertEquals("a > 1", sqlCheck.getExpr().toString());
     }
 
-    public void test_alter_drop() throws Exception {
+    public void test_alter_drop() {
         String sql = "ALTER TABLE t1 DROP CONSTRAINT t1_check ;";
 
         MySqlStatementParser parser = new MySqlStatementParser(sql);


### PR DESCRIPTION
fix issue #4089

增加mysql 8 check语句的支持, 包括下面：

```
CREATE TABLE `t12` (
	`c1` int DEFAULT NULL,
	`c2` int DEFAULT NULL,
	`c3` int DEFAULT NULL,
	CONSTRAINT `c12_positive` CHECK (`c2` > 0) NOT ENFORCED,
	CONSTRAINT `c21_nonzero` CHECK (`c1` <> 0),
	CONSTRAINT `t12_chk_1` CHECK (`c1` <> `c2`),
	CONSTRAINT `t12_chk_2` CHECK (`c1` > 10),
	CONSTRAINT `t12_chk_3` CHECK (`c3` < 100),
	CONSTRAINT `t12_chk_4` CHECK (`c1` > `c3`)
) ENGINE = InnoDB CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;

# 新增check 约束
ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK((a>1));
ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK((a>1)) NOT ENFORCED; 

# 删除check 约束
ALTER TABLE t1 DROP CONSTRAINT t1_check ;

# 让check约束不生效
alter table t1 ALTER CHECK  t1_check  ENFORCED;
alter table t1 ALTER CHECK  t1_check  NOT ENFORCED;
```

修改说明:
1. 修改MySqlCreateTableParser，使得支持create table语句中的  [CONSTRAINT [symbol]] CHECK (expr) [[NOT] ENFORCED]语法

2. 新增MysqlAlterTableAlterCheck 类来识别 ALTER TABLE tbl_name ALTER {CHECK | CONSTRAINT} symbol [NOT] ENFORCED 语句

3. 调整MySqlStatementParser.java代码顺序，使得可以支持 ALTER TABLE tbl_name ADD [CONSTRAINT [symbol]] CHECK (expr) [[NOT] ENFORCED] 语句

4. ALTER TABLE tbl_name DROP {CHECK | CONSTRAINT} symbol 这个不需要修改，已经支持了