### PR TITLE
修复oracle搭配非内置的log4jdbc获取驱动版本不对的问题 fix #1717

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1207,6 +1207,9 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                 this.driverClass = driver.getClass().getName();
             }
         }
+        if(!driver.acceptsURL(getUrl())) {
+            throw new SQLException(String.format("driver not support this url:\"%s\"",this.jdbcUrl));
+        }
     }
 
     protected void initCheck() throws SQLException {


### PR DESCRIPTION
解决oracle 搭配 log4jdbc（非内置的）时候报错：not support oracle driver 1.0的问题 fix #1717