### PR TITLE
BugFix: Use columnName for hash

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLTableSourceImpl.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLTableSourceImpl.java
@@ -129,7 +129,7 @@ public abstract class SQLTableSourceImpl extends SQLObjectImpl implements SQLTab
             return null;
         }
 
-        long hash = FnvHash.hashCode64(alias);
+        long hash = FnvHash.hashCode64(columnName);
         return findColumn(hash);
     }
 
@@ -146,7 +146,7 @@ public abstract class SQLTableSourceImpl extends SQLObjectImpl implements SQLTab
             return null;
         }
 
-        long hash = FnvHash.hashCode64(alias);
+        long hash = FnvHash.hashCode64(columnName);
         return findTableSourceWithColumn(hash, columnName, 0);
     }
 


### PR DESCRIPTION
Use columnName for hash when findColumn and findTableSourceWithColumn