### PR TITLE
fix #4167,ignore the serviceId's case

### DIFF
--- a/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
+++ b/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
@@ -117,7 +117,7 @@ public class MonitorStatService implements DruidStatServiceMBean {
                 int port = instance.getPort();
                 String serviceId = instance.getServiceId();
                 // 根据前端参数采集指定的服务
-                if (serviceId.equals(requestServiceName)) {
+                if (serviceId.equalsIgnoreCase(requestServiceName)) {
                     ServiceNode serviceNode = new ServiceNode();
                     serviceNode.setId(instanceId);
                     serviceNode.setPort(port);


### PR DESCRIPTION
eureka实现DiscoveryClient的时候，serviceId为大写，这里忽略大小写即可正确获取其他节点信息