### PR TITLE
修复print0打印，ALTER关键字笔误

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -5256,7 +5256,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
 
     @Override
     public boolean visit(MySqlAlterServerStatement x) {
-        print0(ucase ? "ATLER SERVER " : "alter server ");
+        print0(ucase ? "ALTER SERVER " : "alter server ");
         x.getName().accept(this);
 
         print(" OPTIONS(");

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4808,7 +4808,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterSystemGetConfigStatement x) {
-        print0(ucase ? "ALTER SYSTEM GET CONFIG " : "atler system get config ");
+        print0(ucase ? "ALTER SYSTEM GET CONFIG " : "alter system get config ");
         x.getName().accept(this);
 
         return false;
@@ -4816,7 +4816,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterSystemSetConfigStatement x) {
-        print0(ucase ? "ALTER SYSTEM SET COFNIG " : "atler system set config ");
+        print0(ucase ? "ALTER SYSTEM SET COFNIG " : "alter system set config ");
 
         printAndAccept(x.getOptions(), " ");
 
@@ -4825,7 +4825,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterViewStatement x) {
-        print0(ucase ? "ALTER " : "atler ");
+        print0(ucase ? "ALTER " : "alter ");
 
         this.indentCount++;
         String algorithm = x.getAlgorithm();

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/alter/MySqlAlterViewTest_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/alter/MySqlAlterViewTest_0.java
@@ -34,7 +34,7 @@ public class MySqlAlterViewTest_0 extends TestCase {
                 "AS\n" +
                 "SELECT count(*)\n" +
                 "FROM t3;", SQLUtils.toMySqlString(stmt));
-        assertEquals("atler definer = 'ivan'@'%'\n" +
+        assertEquals("alter definer = 'ivan'@'%'\n" +
                 "\tview my_view3\n" +
                 "as\n" +
                 "select count(*)\n" +

--- a/vtune.sh
+++ b/vtune.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 export AMPLXE_EXPERIMENTAL=1
 /opt/intel/vtune_amplifier_xe/bin64/amplxe-cl -collect hotspots java -classpath target/classes/:target/test-classes/ com.alibaba.druid.benckmark.sql.MySqlPerfMain_visitor


### PR DESCRIPTION
全局排查共3个类，已修复