### PR TITLE
DruidConnectionHolder: Support setter/getter of default transaction isolation level

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1388,7 +1388,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         }
 
         if (validConnectionChecker != null) {
-            boolean result = true;
+            boolean result;
             Exception error = null;
             try {
                 result = validConnectionChecker.isValidConnection(conn, validationQuery, validationQueryTimeout);
@@ -1406,6 +1406,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
             } catch (SQLException ex) {
                 throw ex;
             } catch (Exception ex) {
+                result = false;
                 error = ex;
             }
             

--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -790,6 +790,10 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
             LOG.error("keepAliveBetweenTimeMillis should be greater than 30000");
         }
 
+        if (keepAliveBetweenTimeMillis <= timeBetweenEvictionRunsMillis) {
+            LOG.warn("keepAliveBetweenTimeMillis should be greater than timeBetweenEvictionRunsMillis");
+        }
+
         this.keepAliveBetweenTimeMillis = keepAliveBetweenTimeMillis;
     }
 

--- a/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
@@ -63,7 +63,7 @@ public final class DruidConnectionHolder {
     protected final List<Statement>               statementTrace           = new ArrayList<Statement>(2);
     protected final boolean                       defaultReadOnly;
     protected final int                           defaultHoldability;
-    protected final int                           defaultTransactionIsolation;
+    protected int                                 defaultTransactionIsolation;
     protected final boolean                       defaultAutoCommit;
     protected boolean                             underlyingReadOnly;
     protected int                                 underlyingHoldability;
@@ -193,6 +193,14 @@ public final class DruidConnectionHolder {
 
     public void setUnderlyingAutoCommit(boolean underlyingAutoCommit) {
         this.underlyingAutoCommit = underlyingAutoCommit;
+    }
+
+    public int getDefaultTransactionIsolation() {
+        return defaultTransactionIsolation;
+    }
+
+    public void setDefaultTransactionIsolation(int defaultTransactionIsolation) {
+        this.defaultTransactionIsolation = defaultTransactionIsolation;
     }
 
     public long getLastActiveTimeMillis() {

--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -870,6 +870,10 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                 throw new SQLException("maxEvictableIdleTimeMillis must be grater than minEvictableIdleTimeMillis");
             }
 
+            if (keepAlive && keepAliveBetweenTimeMillis <= timeBetweenEvictionRunsMillis) {
+                throw new SQLException("keepAliveBetweenTimeMillis must be grater than timeBetweenEvictionRunsMillis");
+            }
+
             if (this.driverClass != null) {
                 this.driverClass = driverClass.trim();
             }
@@ -2864,7 +2868,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
             for (;;) {
                 // 从前面开始删除
                 try {
-                    if (closed) {
+                    if (closed || closing) {
                         break;
                     }
 

--- a/src/main/java/com/alibaba/druid/pool/DruidDataSourceC3P0Adapter.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSourceC3P0Adapter.java
@@ -165,7 +165,9 @@ public class DruidDataSourceC3P0Adapter implements DataSource, DruidDataSourceC3
     }
 
     public void setIdleConnectionTestPeriod(int idleConnectionTestPeriod) {
-        dataSource.setTimeBetweenEvictionRunsMillis(((long) idleConnectionTestPeriod) * 1000L);
+        long timeBetweenEvictionRunsMillis = ((long) idleConnectionTestPeriod) * 1000L;
+        dataSource.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
+        dataSource.setKeepAliveBetweenTimeMillis(timeBetweenEvictionRunsMillis * 2);
     }
 
     public int getInitialPoolSize() {

--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -23,6 +23,7 @@ import com.alibaba.druid.sql.dialect.ads.visitor.AdsOutputVisitor;
 import com.alibaba.druid.sql.dialect.antspark.visitor.AntsparkOutputVisitor;
 import com.alibaba.druid.sql.dialect.antspark.visitor.AntsparkSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.blink.vsitor.BlinkOutputVisitor;
+import com.alibaba.druid.sql.dialect.clickhouse.visitor.ClickSchemaStatVisitor;
 import com.alibaba.druid.sql.dialect.clickhouse.visitor.ClickhouseOutputVisitor;
 import com.alibaba.druid.sql.dialect.db2.visitor.DB2OutputVisitor;
 import com.alibaba.druid.sql.dialect.db2.visitor.DB2SchemaStatVisitor;
@@ -547,6 +548,8 @@ public class SQLUtils {
                 return new HiveSchemaStatVisitor(repository);
             case antspark:
                 return new AntsparkSchemaStatVisitor(repository);
+            case clickhouse:
+                return new ClickSchemaStatVisitor(repository);
             default:
                 return new SchemaStatVisitor(repository);
         }

--- a/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.sql.ast;
+
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class SQLJSONValueExpr extends SQLExprImpl {
+    private SQLExpr json;
+    private SQLExpr path;
+
+    @Override
+    public boolean equals(Object o) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor v) {
+
+    }
+
+    @Override
+    public SQLExpr clone() {
+        return null;
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/ast/ClickhouseCreateTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/ast/ClickhouseCreateTableStatement.java
@@ -1,0 +1,80 @@
+package com.alibaba.druid.sql.dialect.clickhouse.ast;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLOrderBy;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.dialect.clickhouse.visitor.ClickhouseVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClickhouseCreateTableStatement extends SQLCreateTableStatement {
+    protected final List<SQLAssignItem> settings    = new ArrayList<SQLAssignItem>();
+    private SQLOrderBy orderBy;
+    private SQLExpr partitionBy;
+    private SQLExpr sampleBy;
+
+    public ClickhouseCreateTableStatement() {
+        super(DbType.clickhouse);
+    }
+
+    public SQLOrderBy getOrderBy() {
+        return orderBy;
+    }
+
+    public void setOrderBy(SQLOrderBy x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+
+        this.orderBy = x;
+    }
+
+    public SQLExpr getPartitionBy() {
+        return partitionBy;
+    }
+
+    public void setPartitionBy(SQLExpr x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+
+        this.partitionBy = x;
+    }
+
+    public SQLExpr getSampleBy() {
+        return sampleBy;
+    }
+
+    public void setSampleBy(SQLExpr x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+
+        this.sampleBy = x;
+    }
+
+    public List<SQLAssignItem> getSettings() {
+        return settings;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor v) {
+        if (v instanceof ClickhouseVisitor) {
+            ClickhouseVisitor vv = (ClickhouseVisitor) v;
+            if (vv.visit(this)) {
+                acceptChild(vv);
+            }
+            vv.endVisit(this);
+            return;
+        }
+
+        if (v.visit(this)) {
+            acceptChild(v);
+        }
+        v.endVisit(this);
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/ClickhouseCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/ClickhouseCreateTableParser.java
@@ -1,0 +1,69 @@
+package com.alibaba.druid.sql.dialect.clickhouse.parser;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLOrderBy;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.dialect.clickhouse.ast.ClickhouseCreateTableStatement;
+import com.alibaba.druid.sql.parser.SQLCreateTableParser;
+import com.alibaba.druid.sql.parser.SQLExprParser;
+import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.util.FnvHash;
+
+public class ClickhouseCreateTableParser extends SQLCreateTableParser {
+    public ClickhouseCreateTableParser(SQLExprParser exprParser) {
+        super(exprParser);
+    }
+
+    protected SQLCreateTableStatement newCreateStatement() {
+        return new ClickhouseCreateTableStatement();
+    }
+
+    protected void parseCreateTableRest(SQLCreateTableStatement stmt) {
+        ClickhouseCreateTableStatement ckStmt = (ClickhouseCreateTableStatement) stmt;
+        if (lexer.identifierEquals(FnvHash.Constants.ENGINE)) {
+            lexer.nextToken();
+            if (lexer.token() == Token.EQ) {
+                lexer.nextToken();
+            }
+            stmt.setEngine(
+                    this.exprParser.expr()
+            );
+        }
+
+        if (lexer.identifierEquals("PARTITION")) {
+            lexer.nextToken();
+            accept(Token.BY);
+            SQLExpr expr = this.exprParser.expr();
+            ckStmt.setPartitionBy(expr);
+        }
+
+        if (lexer.token() == Token.ORDER) {
+            SQLOrderBy orderBy = this.exprParser.parseOrderBy();
+            ckStmt.setOrderBy(orderBy);
+        }
+
+        if (lexer.identifierEquals("SAMPLE")) {
+            lexer.nextToken();
+            accept(Token.BY);
+            SQLExpr expr = this.exprParser.expr();
+            ckStmt.setSampleBy(expr);
+        }
+
+        if (lexer.identifierEquals("SETTINGS")) {
+            lexer.nextToken();
+            for (;;) {
+                SQLAssignItem item = this.exprParser.parseAssignItem();
+                item.setParent(ckStmt);
+                ckStmt.getSettings().add(item);
+
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    continue;
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/ClickhouseStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/ClickhouseStatementParser.java
@@ -1,10 +1,7 @@
 package com.alibaba.druid.sql.dialect.clickhouse.parser;
 
 import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
-import com.alibaba.druid.sql.parser.Lexer;
-import com.alibaba.druid.sql.parser.SQLParserFeature;
-import com.alibaba.druid.sql.parser.SQLStatementParser;
-import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.parser.*;
 
 public class ClickhouseStatementParser extends SQLStatementParser {
     public ClickhouseStatementParser(String sql) {
@@ -68,5 +65,9 @@ public class ClickhouseStatementParser extends SQLStatementParser {
         }
 
         return withQueryClause;
+    }
+
+    public SQLCreateTableParser getSQLCreateTableParser() {
+        return new ClickhouseCreateTableParser(this.exprParser);
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickSchemaStatVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickSchemaStatVisitor.java
@@ -1,0 +1,19 @@
+package com.alibaba.druid.sql.dialect.clickhouse.visitor;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.repository.SchemaRepository;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+
+public class ClickSchemaStatVisitor extends SchemaStatVisitor implements ClickhouseVisitor {
+        {
+            dbType = DbType.antspark;
+        }
+
+    public ClickSchemaStatVisitor() {
+            super(DbType.antspark);
+        }
+
+    public ClickSchemaStatVisitor(SchemaRepository repository) {
+            super(repository);
+        }
+}

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickhouseOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickhouseOutputVisitor.java
@@ -1,13 +1,15 @@
 package com.alibaba.druid.sql.dialect.clickhouse.visitor;
 
 import com.alibaba.druid.DbType;
-import com.alibaba.druid.sql.ast.SQLDataType;
-import com.alibaba.druid.sql.ast.SQLName;
-import com.alibaba.druid.sql.ast.SQLRowDataType;
-import com.alibaba.druid.sql.ast.SQLStructDataType;
+import com.alibaba.druid.sql.ast.*;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
+import com.alibaba.druid.sql.dialect.clickhouse.ast.ClickhouseCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+
+import java.util.List;
 
 public class ClickhouseOutputVisitor extends SQLASTOutputVisitor implements ClickhouseVisitor {
     public ClickhouseOutputVisitor(Appendable appender) {
@@ -69,6 +71,39 @@ public class ClickhouseOutputVisitor extends SQLASTOutputVisitor implements Clic
             dataType.accept(this);
         }
 
+        return false;
+    }
+
+    @Override
+    public boolean visit(ClickhouseCreateTableStatement x) {
+        super.visit((SQLCreateTableStatement) x);
+
+        SQLExpr partitionBy = x.getPartitionBy();
+        if (partitionBy != null) {
+            println();
+            print0(ucase ? "PARTITION BY " : "partition by ");
+            partitionBy.accept(this);
+        }
+
+        SQLOrderBy orderBy = x.getOrderBy();
+        if (orderBy != null) {
+            println();
+            orderBy.accept(this);
+        }
+
+        SQLExpr sampleBy = x.getSampleBy();
+        if (sampleBy != null) {
+            println();
+            print0(ucase ? "SAMPLE BY " : "sample by ");
+            sampleBy.accept(this);
+        }
+
+        List<SQLAssignItem> settings = x.getSettings();
+        if (!settings.isEmpty()) {
+            println();
+            print0(ucase ? "SETTINGS " : "settings ");
+            printAndAccept(settings, ", ");
+        }
         return false;
     }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickhouseVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/ClickhouseVisitor.java
@@ -1,8 +1,14 @@
 package com.alibaba.druid.sql.dialect.clickhouse.visitor;
 
-import com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause;
+import com.alibaba.druid.sql.ast.statement.SQLNotNullConstraint;
+import com.alibaba.druid.sql.dialect.clickhouse.ast.ClickhouseCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public interface ClickhouseVisitor extends SQLASTVisitor {
+    default boolean visit(ClickhouseCreateTableStatement x) {
+        return true;
+    }
 
+    default void endVisit(ClickhouseCreateTableStatement x) {
+    }
 }

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -359,6 +359,10 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                 }
             }
 
+            if (lexer.token() == Token.HINT) {
+                lexer.nextToken();
+            }
+
             accept(Token.RPAREN);
 
             if (lexer.token() == Token.HINT && lexer.stringVal().charAt(0) == '!') {
@@ -402,6 +406,17 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     expr = this.exprParser.integerExpr();
                 }
                 stmt.addOption("BLOCK_SIZE", expr);
+                continue;
+            }
+
+            if (lexer.identifierEquals("BLOCK_FORMAT")) {
+                lexer.nextToken();
+                if (lexer.token() == Token.EQ) {
+                    lexer.nextToken();
+                }
+
+                SQLExpr expr = this.exprParser.primary();
+                stmt.addOption("BLOCK_FORMAT", expr);
                 continue;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
@@ -1137,7 +1137,7 @@ public class MySqlExprParser extends SQLExprParser {
             accept(Token.RPAREN);
         }
 
-        if (lexer.identifierEquals(FnvHash.Constants.STORED)) {
+        if (lexer.identifierEquals(FnvHash.Constants.STORED) || lexer.identifierEquals("PERSISTENT")) {
             lexer.nextToken();
             column.setStored(true);
         }
@@ -1153,6 +1153,7 @@ public class MySqlExprParser extends SQLExprParser {
             column.setDelimiter(expr);
             return parseColumnRest(column);
         }
+
         if (lexer.identifierEquals("delimiter_tokenizer")) {
             lexer.nextToken();
             SQLExpr expr = this.expr();
@@ -1236,6 +1237,11 @@ public class MySqlExprParser extends SQLExprParser {
             } else {
                 break;
             }
+        }
+
+        if (lexer.identifierEquals(FnvHash.Constants.ARRAY)) {
+            lexer.nextToken();
+            dataType = new SQLArrayDataType(dataType);
         }
 
         return dataType;

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlSelectParser.java
@@ -180,6 +180,7 @@ public class MySqlSelectParser extends SQLSelectParser {
                 }
             }
 
+
             while (true) {
                 Token token = lexer.token();
                 if (token == (Token.DISTINCT)) {
@@ -190,6 +191,9 @@ public class MySqlSelectParser extends SQLSelectParser {
                     lexer.nextToken();
                 } else if (token == (Token.ALL)) {
                     queryBlock.setDistionOption(SQLSetQuantifier.ALL);
+                    lexer.nextToken();
+                } else if (token == (Token.UNIQUE)) {
+                    queryBlock.setDistionOption(SQLSetQuantifier.UNIQUE);
                     lexer.nextToken();
                 } else if (lexer.identifierEquals(FnvHash.Constants.HIGH_PRIORITY)) {
                     queryBlock.setHignPriority(true);

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -141,6 +141,14 @@ public class MySqlStatementParser extends SQLStatementParser {
     public MySqlDeleteStatement parseDeleteStatement() {
         MySqlDeleteStatement deleteStatement = new MySqlDeleteStatement();
 
+        if (lexer.isKeepComments() && lexer.hasComment()) {
+            List<String> comments = lexer.readAndResetComments();
+
+            if (comments != null) {
+                deleteStatement.addBeforeComment(comments);
+            }
+        }
+
         if (lexer.token() == Token.DELETE) {
             lexer.nextToken();
 
@@ -5123,6 +5131,11 @@ public class MySqlStatementParser extends SQLStatementParser {
 
 
     public SQLStatement parseAlter() {
+        List<String> comments = null;
+        if (lexer.isKeepComments() && lexer.hasComment()) {
+            comments = lexer.readAndResetComments();
+        }
+
         Lexer.SavePoint mark = lexer.mark();
         accept(Token.ALTER);
 
@@ -5150,7 +5163,12 @@ public class MySqlStatementParser extends SQLStatementParser {
         }
 
         if (lexer.token() == Token.TABLE) {
-            return parseAlterTable(ignore, online, offline);
+            SQLStatement alterTable = parseAlterTable(ignore, online, offline);
+            if (comments != null) {
+                alterTable.addBeforeComment(comments);
+            }
+
+            return alterTable;
         }
 
         if (lexer.token() == Token.DATABASE

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -1016,6 +1016,10 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             }
         }
 
+        if (this.isPrettyFormat() && x.hasBeforeComment()) {
+            this.printlnComments(x.getBeforeCommentsDirect());
+        }
+
         print0(ucase ? "DELETE " : "delete ");
 
         for (int i = 0, size = x.getHintsSize(); i < size; ++i) {
@@ -1099,6 +1103,10 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
                 hint.accept(this);
                 println();
             }
+        }
+
+        if (this.isPrettyFormat() && x.hasBeforeComment()) {
+            this.printlnComments(x.getBeforeCommentsDirect());
         }
 
         SQLWithSubqueryClause with = x.getWith();

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -118,13 +118,21 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
                 print(' ');
             }
 
-            final int distionOption = x.getDistionOption();
-            if (SQLSetQuantifier.ALL == distionOption) {
-                print0(ucase ? "ALL " : "all ");
-            } else if (SQLSetQuantifier.DISTINCT == distionOption) {
-                print0(ucase ? "DISTINCT " : "distinct ");
-            } else if (SQLSetQuantifier.DISTINCTROW == distionOption) {
-                print0(ucase ? "DISTINCTROW " : "distinctrow ");
+            switch (x.getDistionOption()) {
+                case SQLSetQuantifier.ALL:
+                    print0(ucase ? "ALL " : "all ");
+                    break;
+                case SQLSetQuantifier.DISTINCT:
+                    print0(ucase ? "DISTINCT " : "distinct ");
+                    break;
+                case SQLSetQuantifier.DISTINCTROW:
+                    print0(ucase ? "DISTINCTROW " : "distinctrow ");
+                    break;
+                case SQLSetQuantifier.UNIQUE:
+                    print0(ucase ? "UNIQUE " : "unique ");
+                    break;
+                default:
+                    break;
             }
 
             if (x.isHignPriority()) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -16,9 +16,11 @@
 package com.alibaba.druid.sql.dialect.postgresql.parser;
 
 import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLArrayDataType;
 import com.alibaba.druid.sql.ast.SQLDataType;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.SQLCharacterDataType;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.*;
 import com.alibaba.druid.sql.parser.Lexer;
 import com.alibaba.druid.sql.parser.SQLExprParser;
@@ -71,6 +73,18 @@ public class PGExprParser extends SQLExprParser {
             lexer.nextToken();
         }
         return super.parseDataType();
+    }
+
+    protected SQLDataType parseDataTypeRest(SQLDataType dataType) {
+        dataType = super.parseDataTypeRest(dataType);
+
+        if (lexer.token() == Token.LBRACKET) {
+            lexer.nextToken();
+            accept(Token.RBRACKET);
+            dataType = new SQLArrayDataType(dataType);
+        }
+
+        return dataType;
     }
     
     public PGSelectParser createSelectParser() {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -2506,4 +2506,11 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
         return false;
     }
 
+    public boolean visit(SQLArrayDataType x) {
+        x.getComponentType().accept(this);
+        print('[');
+        printAndAccept(x.getArguments(), ", ");
+        print(']');
+        return false;
+    }
 }

--- a/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -797,12 +797,21 @@ public class Lexer {
             nextToken();
             if (token == Token.USER || identifierEquals(FnvHash.Constants.USER)) {
                 return SQLType.ADD_USER;
+            } else if (token == TABLE) {
+                return SQLType.ADD_TABLE;
             }
         } else if (hashCode == FnvHash.Constants.REMOVE) {
             nextToken();
             if (token == Token.USER || identifierEquals(FnvHash.Constants.USER)) {
                 return SQLType.REMOVE_USER;
             }
+        } else if (hashCode == FnvHash.Constants.TUNNEL) {
+            nextToken();
+            if (identifierEquals(FnvHash.Constants.DOWNLOAD)) {
+                return SQLType.TUNNEL_DOWNLOAD;
+            }
+        } else if (hashCode == FnvHash.Constants.UPLOAD) {
+            return SQLType.UPLOAD;
         }
 
         return SQLType.UNKNOWN;
@@ -811,7 +820,6 @@ public class Lexer {
     public final SQLType scanSQLTypeV2() {
 
         SQLType sqlType = scanSQLType();
-
         if (sqlType == SQLType.CREATE) {
             nextToken();
             if (token == Token.USER || identifierEquals(FnvHash.Constants.USER)) {
@@ -869,6 +877,19 @@ public class Lexer {
             } else if (token == TABLE) {
                 return SQLType.ALTER_TABLE;
             }
+        } else if (sqlType == SQLType.INSERT) {
+            for (int i = 0; i < 1000;++i) {
+                nextToken();
+
+                if (token == SELECT) {
+                    return SQLType.INSERT_SELECT;
+                } else if (token == VALUES) {
+                    return SQLType.INSERT_VALUES;
+                } else if (token == ERROR || token == EOF) {
+                    break;
+                }
+            }
+            return sqlType;
         }
 
         return sqlType;

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
@@ -88,7 +88,7 @@ public class SQLCreateTableParser extends SQLDDLParser {
 
         accept(Token.TABLE);
 
-        if (lexer.token() == Token.IF) {
+        if (lexer.token() == Token.IF || lexer.identifierEquals("IF")) {
             lexer.nextToken();
             accept(Token.NOT);
             accept(Token.EXISTS);
@@ -182,17 +182,13 @@ public class SQLCreateTableParser extends SQLDDLParser {
             createTable.setPartitioning(partitionClause);
         }
 
-        if (dbType == DbType.clickhouse) {
-            if (lexer.identifierEquals(FnvHash.Constants.ENGINE)) {
-                lexer.nextToken();
-                accept(Token.EQ);
-                createTable.setEngine(
-                        this.exprParser.expr()
-                );
-            }
-        }
+        parseCreateTableRest(createTable);
 
         return createTable;
+    }
+
+    protected void parseCreateTableRest(SQLCreateTableStatement stmt) {
+
     }
 
     public SQLPartitionBy parsePartitionBy() {

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -1090,7 +1090,7 @@ public class SQLExprParser extends SQLParser {
             case LIKE:
             case UNION:
             case CREATE:
-                if (dbType == DbType.odps) {
+                if (dbType == DbType.odps || dbType == DbType.hive) {
                     sqlExpr = new SQLIdentifierExpr(lexer.stringVal());
                     lexer.nextToken();
                     break;

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3836,6 +3836,8 @@ public class SQLExprParser extends SQLParser {
 
             if (lexer.identifierEquals(FnvHash.Constants.ARRAY)) {
                 return parseDataTypeRest(charType);
+            } else if (lexer.token == Token.LBRACKET) {
+                return parseDataTypeRest(charType);
             }
 
             return charType;

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -1584,6 +1584,9 @@ public class SQLExprParser extends SQLParser {
                 aggregateExpr.setOption(SQLAggregateOption.DISTINCT);
             }
 
+            if (lexer.token == Token.COLONCOLON) {
+                return primaryRest(aggregateExpr);
+            }
 
             return aggregateExpr;
         }

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
@@ -202,7 +202,8 @@ public class SQLParser {
                 }
                 case FOR:
                 case GRANT:
-                    if (dbType == DbType.odps){
+                case CHECK:
+                    if (dbType == DbType.odps || dbType == DbType.hive) {
                         String strVal = lexer.stringVal();
                         lexer.nextToken();
                         return strVal;
@@ -342,7 +343,7 @@ public class SQLParser {
                 case SHOW:
                 case SEQUENCE:
                 case TO:
-                    if (dbType == DbType.odps) {
+                    if (dbType == DbType.odps || dbType == DbType.hive) {
                         alias = lexer.stringVal();
                         lexer.nextToken();
                         break;
@@ -351,7 +352,7 @@ public class SQLParser {
                 case GROUP:
                 case ORDER:
                 case DEFAULT:
-                    if (dbType == DbType.odps) {
+                    if (dbType == DbType.odps || dbType == DbType.hive) {
                         Lexer.SavePoint mark = lexer.mark();
                         alias = lexer.stringVal();
                         lexer.nextToken();

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3947,9 +3947,7 @@ public class SQLStatementParser extends SQLParser {
             accept(Token.DATABASE);
         }
 
-
-
-        if (lexer.token == Token.IF) {
+        if (lexer.token == Token.IF || lexer.identifierEquals("IF")) {
             lexer.nextToken();
             accept(Token.NOT);
             accept(Token.EXISTS);

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3575,6 +3575,7 @@ public class SQLStatementParser extends SQLParser {
                             if (name != null) {
                                 key.setName(name);
                             }
+                            key.setParent(stmt);
                             stmt.getTableElementList().add(key);
                         }
                         continue;

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLType.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLType.java
@@ -3,6 +3,8 @@ package com.alibaba.druid.sql.parser;
 public enum SQLType {
     SELECT,
     UPDATE,
+    INSERT_SELECT,
+    INSERT_VALUES,
     INSERT,
     DELETE,
     MERGE,
@@ -49,6 +51,10 @@ public enum SQLType {
     ALTER_USER,
     ALTER_TABLE,
     READ,
+
+    ADD_TABLE,
+    TUNNEL_DOWNLOAD,
+    UPLOAD,
 
     UNKNOWN
 }

--- a/src/main/java/com/alibaba/druid/sql/repository/SchemaRepository.java
+++ b/src/main/java/com/alibaba/druid/sql/repository/SchemaRepository.java
@@ -912,6 +912,10 @@ public class SchemaRepository {
         String name = x1.computeName();
         SchemaObject table = schema.findTableOrView(name);
         if (table != null) {
+            if (x1.isIfNotExists()) {
+                return table;
+            }
+
             LOG.info("replaced table '" + name + "'");
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4825,7 +4825,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterViewStatement x) {
-        print0(ucase ? "ALTER " : "atler ");
+        print0(ucase ? "ALTER " : "alter ");
 
         this.indentCount++;
         String algorithm = x.getAlgorithm();
@@ -4844,7 +4844,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
         String sqlSecurity = x.getSqlSecurity();
         if (sqlSecurity != null && sqlSecurity.length() > 0) {
-            print0(ucase ? "SQL SECURITY = " : "sql security = ");
+            print0(ucase ? "SQL SECURITY " : "sql security ");
             print0(sqlSecurity);
             println();
         }

--- a/src/main/java/com/alibaba/druid/support/opds/udf/MetaSqlExtract.java
+++ b/src/main/java/com/alibaba/druid/support/opds/udf/MetaSqlExtract.java
@@ -20,8 +20,12 @@ public class MetaSqlExtract  extends UDF {
             return null;
         }
 
-        String part = xml.substring(p0, p1);
-        return StringEscapeUtils.unescapeXml(part);
+        String sql = xml.substring(p0, p1);
+        if (sql.startsWith("<![CDATA[")) {
+            sql = sql.substring("<![CDATA[".length(), sql.length() - 3);
+        }
+
+        return StringEscapeUtils.unescapeXml(sql);
     }
 
 }

--- a/src/main/java/com/alibaba/druid/support/opds/udf/SqlTypeUDF.java
+++ b/src/main/java/com/alibaba/druid/support/opds/udf/SqlTypeUDF.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.support.opds.udf;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.parser.Lexer;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLType;
+import com.alibaba.druid.sql.visitor.ParameterizedOutputVisitorUtils;
+import com.aliyun.odps.udf.UDF;
+
+public class SqlTypeUDF extends UDF {
+    public String evaluate(String sql) {
+        return evaluate(sql, null, false);
+    }
+
+    public String evaluate(String sql, String dbTypeName) {
+        return evaluate(sql, dbTypeName, false);
+    }
+
+    public String evaluate(String sql, String dbTypeName, boolean throwError) {
+        if (sql == null || sql.isEmpty()) {
+            return null;
+        }
+
+        try {
+            DbType dbType = dbTypeName == null ? null : DbType.valueOf(dbTypeName);
+            Lexer lexer = SQLParserUtils.createLexer(sql, dbType);
+            SQLType sqlType = lexer.scanSQLTypeV2();
+            return sqlType != null ? sqlType.name() : "null";
+        } catch (ParserException ex) {
+            if (throwError) {
+                throw new IllegalArgumentException("error sql : \n" + sql, ex);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -1119,5 +1119,9 @@ public final class FnvHash {
         long ASOF = fnv1a_64_lower("ASOF");
         long JSON_SET = fnv1a_64_lower("JSON_SET");
         long JSONB_SET = fnv1a_64_lower("JSONB_SET");
+
+        long TUNNEL = fnv1a_64_lower("TUNNEL");
+        long DOWNLOAD = fnv1a_64_lower("DOWNLOAD");
+        long UPLOAD = fnv1a_64_lower("UPLOAD");
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/pool/KeepAliveTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/KeepAliveTest.java
@@ -37,9 +37,12 @@ public class KeepAliveTest extends TestCase {
     public void test_keepAlive() throws Exception {
         dataSource.init();
 
-        for (int i = 0; i < 1000; ++i) {
-            if (dataSource.getMinIdle() == dataSource.getPoolingCount()) {
+        for (int i = 0; i < 100; ++i) {
+            int poolingCount = dataSource.getPoolingCount();
+            if (poolingCount >= dataSource.getMinIdle()) {
                 break;
+            } else {
+                System.out.println("poolingCount : " + poolingCount);
             }
             Thread.sleep(10 * 1);
         }
@@ -55,8 +58,5 @@ public class KeepAliveTest extends TestCase {
         }
         // assertEquals(dataSource.getMaxActive(), dataSource.getPoolingCount());
 
-
-
-        Thread.sleep(1000 * 1000);
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/pool/KeepAliveTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/KeepAliveTest.java
@@ -57,6 +57,6 @@ public class KeepAliveTest extends TestCase {
 
 
 
-        // Thread.sleep(1000 * 1000);
+        Thread.sleep(1000 * 1000);
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySqlExceptionSorterTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySqlExceptionSorterTest.java
@@ -38,7 +38,8 @@ public class MySqlExceptionSorterTest extends PoolTestCase {
     
     public void test_false_1() throws Exception {
         MySqlExceptionSorter sorter = new MySqlExceptionSorter();
-        Assert.assertFalse(sorter.isExceptionFatal(new SQLException("", "", -8000)));
+        Assert.assertTrue(sorter.isExceptionFatal(new SQLException("", "", -8000)));
+        Assert.assertFalse(sorter.isExceptionFatal(new SQLException("", "", -9100)));
     }
     
 //    public void test_true_3() throws Exception {

--- a/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySqlExceptionSorterTest_oceanbase.java
+++ b/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySqlExceptionSorterTest_oceanbase.java
@@ -19,7 +19,7 @@ public class MySqlExceptionSorterTest_oceanbase extends PoolTestCase {
     
     public void test_true_1() throws Exception {
         MySqlExceptionSorter sorter = new MySqlExceptionSorter();
-        Assert.assertTrue(sorter.isExceptionFatal(new SQLException("", "", -10000)));
+        Assert.assertFalse(sorter.isExceptionFatal(new SQLException("", "", -10000)));
     }
     
     public void test_false() throws Exception {
@@ -29,6 +29,7 @@ public class MySqlExceptionSorterTest_oceanbase extends PoolTestCase {
     
     public void test_false_1() throws Exception {
         MySqlExceptionSorter sorter = new MySqlExceptionSorter();
-        Assert.assertFalse(sorter.isExceptionFatal(new SQLException("", "", -8000)));
+        Assert.assertTrue(sorter.isExceptionFatal(new SQLException("", "", -8000)));
+        Assert.assertFalse(sorter.isExceptionFatal(new SQLException("", "", -9100)));
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/canal/CanalSQLSchemaTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/canal/CanalSQLSchemaTest.java
@@ -1,0 +1,83 @@
+package com.alibaba.druid.bvt.sql.canal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.alibaba.druid.sql.repository.SchemaObject;
+import com.alibaba.druid.sql.repository.SchemaRepository;
+import com.alibaba.druid.util.JdbcConstants;
+
+public class CanalSQLSchemaTest {
+
+    @Test
+    public void testSimple() throws Throwable {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql1 = "CREATE TABLE `table_x1` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, "
+                      + "`key1` longtext NOT NULL COMMENT 'key1', `value1` longtext NOT NULL COMMENT 'value1', PRIMARY KEY (`id`) )"
+                      + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        String sql2 = " CREATE TABLE IF NOT EXISTS `table_x1` ( `id` bigint(20) NOT NULL AUTO_INCREMENT,"
+                      + "`key1` longtext NOT NULL COMMENT 'key1',PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        repository.console(sql1);
+        repository.console(sql2);
+        repository.setDefaultSchema("test");
+        SchemaObject table = repository.findTable("table_x1");
+        Assert.assertTrue(
+                table.findColumn("value1") != null);
+    }
+
+    @Test
+    public void test_block_format() throws Throwable {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql = " CREATE TABLE `parent` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,"
+                     + "`created_at` timestamp NULL DEFAULT NULL, " + "PRIMARY KEY (`id`)"
+                     + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 BLOCK_FORMAT=ENCRYPTED";
+        repository.console(sql);
+        repository.setDefaultSchema("test");
+        SchemaObject table = repository.findTable("parent");
+        Assert.assertTrue(table.findColumn("id") != null);
+    }
+
+    @Test
+    public void test_json_index() throws Throwable {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql = " CREATE TABLE `articles` ( \n" +
+                " \t`article_id` bigint NOT NULL AUTO_INCREMENT, \n" +
+                " \t`tags` json DEFAULT NULL, PRIMARY KEY (`article_id`), \n" +
+                " \tKEY `articles_tags` (\n" +
+                " \t\t(\n" +
+                " \t\t\tcast(json_extract(`tags`,_utf8mb4'$[*]') \n" +
+                " \t\t\t\tas char(40) array)\n" +
+                " \t\t)\n" +
+                " \t)\n" +
+                " ) ENGINE=InnoDB AUTO_INCREMENT=1054 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+        repository.console(sql);
+        repository.setDefaultSchema("test");
+        SchemaObject table = repository.findTable("articles");
+        Assert.assertTrue(table.findColumn("article_id") != null);
+    }
+
+    @Test
+    public void test_invisible() throws Throwable {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql = " CREATE TABLE `proposal_order_info` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,"
+                     + "`created_at` timestamp NULL DEFAULT NULL, " + "PRIMARY KEY (`id`) , "
+                     + "KEY `idx_create_time` (`created_at`) /*!80000 INVISIBLE */"
+                     + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 BLOCK_FORMAT=ENCRYPTED";
+        repository.console(sql);
+        repository.setDefaultSchema("test");
+        SchemaObject table = repository.findTable("proposal_order_info");
+        Assert.assertTrue(table.findColumn("id") != null);
+    }
+
+    @Test
+    public void test_persistent() throws Throwable {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql = " create table example_vc_tbl( c1 int not null auto_increment primary key,"
+                     + "c2 varchar(70), vc1 int as (length(c2)) virtual,"
+                     + "DIM_SUM varchar(128) AS (MD5(UPPER(CONCAT(c2, c1)))) PERSISTENT)";
+        repository.console(sql);
+        repository.setDefaultSchema("test");
+        SchemaObject table = repository.findTable("example_vc_tbl");
+        Assert.assertTrue(table.findColumn("DIM_SUM") != null);
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/ClickHouseResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/ClickHouseResourceTest.java
@@ -51,6 +51,26 @@ public class ClickHouseResourceTest extends OracleTest {
     public void test_3() throws Exception {
         exec_test("bvt/parser/clickhouse-3.txt");
     }
+//
+//    public void test_4() throws Exception {
+//        exec_test("bvt/parser/clickhouse-4.txt");
+//    }
+
+    public void test_5() throws Exception {
+        exec_test("bvt/parser/clickhouse-5.txt");
+    }
+
+    public void test_6() throws Exception {
+        exec_test("bvt/parser/clickhouse-6.txt");
+    }
+
+    public void test_7() throws Exception {
+        exec_test("bvt/parser/clickhouse-7.txt");
+    }
+
+    public void test_8() throws Exception {
+        exec_test("bvt/parser/clickhouse-8.txt");
+    }
 
     public void exec_test(String resource) throws Exception {
         System.out.println(resource);

--- a/src/test/java/com/alibaba/druid/bvt/sql/dm/DM_MergeTest_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/dm/DM_MergeTest_0.java
@@ -30,4 +30,26 @@ public class DM_MergeTest_0 extends TestCase {
 
 
     }
+
+    public void test_1() throws Exception {
+        String sql = "MERGE INTO sys_user_online a using (select count(1) co from sys_user_online " +
+                "where sessionid = ?) b on (b.co <> 0) when matched then update set login_name = ?, dept_name = ?, ipaddr = ?, login_location = ?, browser = ?, os = ?, status = ?, start_timestamp = ?, last_access_time = ?, expire_time = ? where sessionid = ? when not matched then insert(SESSIONID, LOGIN_NAME, DEPT_NAME, IPADDR,LOGIN_LOCATION, BROWSER, OS, STATUS, START_TIMESTAMP, LAST_ACCESS_TIME, EXPIRE_TIME) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+//
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, DbType.dm);
+        SQLMergeStatement stmt = (SQLMergeStatement)statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        assertEquals("MERGE INTO sys_user_online a\n" +
+                "USING (\n" +
+                "\tSELECT count(1) AS co\n" +
+                "\tFROM sys_user_online\n" +
+                "\tWHERE sessionid = ?\n" +
+                ") b ON (b.co <> 0) \n" +
+                "WHEN MATCHED THEN UPDATE SET login_name = ?, dept_name = ?, ipaddr = ?, login_location = ?, browser = ?, os = ?, status = ?, start_timestamp = ?, last_access_time = ?, expire_time = ?\n" +
+                "\tWHERE sessionid = ?\n" +
+                "WHEN NOT MATCHED THEN INSERT (SESSIONID, LOGIN_NAME, DEPT_NAME, IPADDR, LOGIN_LOCATION, BROWSER, OS, STATUS, START_TIMESTAMP, LAST_ACCESS_TIME, EXPIRE_TIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", stmt.toString());
+
+
+    }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
@@ -64,6 +64,14 @@ public class HiveResourceTest extends TestCase {
         exec_test("bvt/parser/hive-7.txt");
     }
 
+    public void test_8() throws Exception {
+        exec_test("bvt/parser/hive-8.txt");
+    }
+
+    public void test_9() throws Exception {
+        exec_test("bvt/parser/hive-9.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
 //        System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
@@ -72,6 +72,10 @@ public class HiveResourceTest extends TestCase {
         exec_test("bvt/parser/hive-9.txt");
     }
 
+    public void test_10() throws Exception {
+        exec_test("bvt/parser/hive-10.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
 //        System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveResourceTest.java
@@ -48,6 +48,22 @@ public class HiveResourceTest extends TestCase {
         exec_test("bvt/parser/hive-3.txt");
     }
 
+    public void test_4() throws Exception {
+        exec_test("bvt/parser/hive-4.txt");
+    }
+
+    public void test_5() throws Exception {
+        exec_test("bvt/parser/hive-5.txt");
+    }
+
+    public void test_6() throws Exception {
+        exec_test("bvt/parser/hive-6.txt");
+    }
+
+    public void test_7() throws Exception {
+        exec_test("bvt/parser/hive-7.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
 //        System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveSelectTest_47.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveSelectTest_47.java
@@ -1,0 +1,140 @@
+package com.alibaba.druid.bvt.sql.hive;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class HiveSelectTest_47 extends TestCase {
+    static String sql = "with temp1 AS ( \n" +
+            "    SELECT datetrunc(gmv_time,'mm') as report_month\n" +
+            "    ,seller_user_id\n" +
+            "    ,count(1) as 卖家订单量\n" +
+            "    from du_shucang.dm_ord_sub_order a \n" +
+            "    where pt = max_pt('du_shucang.dm_ord_sub_order')\n" +
+            "    and pay_status = 1 \n" +
+            "    group by datetrunc(gmv_time,'mm'),seller_user_id\n" +
+            ")\n" +
+            ",temp2 AS ( \n" +
+            "    -- SELECT gmv_time,a.sub_order_no,a.buyer_user_id\n" +
+            "    -- ,ROW_NUMBER() OVER(PARTITION BY a.buyer_user_id ORDER BY gmv_time) AS order_rank \n" +
+            "    -- from du_shucang.dm_ord_sub_order a \n" +
+            "    -- where pt = max_pt('du_shucang.dm_ord_sub_order')\n" +
+            "    -- and pay_status = 1 \n" +
+            "    SELECT user_id,first_activat_time\n" +
+            "    from du_shucang.dw_usr_user_order_extend \n" +
+            "    where pt = max_pt('du_shucang.dw_usr_user_order_extend')\n" +
+            ")\n" +
+            "SELECT datetrunc(a.gmv_time,'mm') as report_month\n" +
+            ",'' GMV\n" +
+            "    ,sum(total_amount*0.01) as 支付gmv \n" +
+            "    ,sum(buyer_discount_amount*0.01) as 买家优惠金额\n" +
+            "    ,sum(buyer_discount_amount*0.01)/nullif(sum(total_amount*0.01),0) as 优惠占比 \n" +
+            "    ------支付gmv-----\n" +
+            "    ,sum(a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01) 支付gmv不含优惠\n" +
+            "    ,sum(case when c.user_id is not null  then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01 end) 支付gmv不含优惠_新用户\n" +
+            "    ,sum(case when c.user_id is null then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01 end) 支付gmv不含优惠_老用户\n" +
+            "        ----未交付\n" +
+            "    ,sum(case when sub_order_status_desc <> '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01 end) as 未交付gmv不含优惠\n" +
+            "    ,sum(case when c.user_id is not null and sub_order_status_desc <> '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01 end) as 未交付gmv不含优惠_新用户\n" +
+            "    ,sum(case when c.user_id is null and sub_order_status_desc <> '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01 end) as 未交付gmv不含优惠_老用户\n" +
+            "    ----交付\n" +
+            "    ,sum(case when sub_order_status_desc = '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01end) as 交付gmv不含优惠\n" +
+            "    ,sum(case when c.user_id is not null and sub_order_status_desc = '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01end) as 交付gmv不含优惠_新用户\n" +
+            "    ,sum(case when c.user_id is null  and sub_order_status_desc = '交易成功' then a.total_price*0.01 + buyer_freight_amount*0.01 - buyer_discount_amount*0.01end) as 交付gmv不含优惠_老用户\n" +
+            "    ----未交付\n" +
+            "    ,sum(case when sub_order_status_desc <> '交易成功' then total_amount*0.01 end) as 未交付gmv\n" +
+            "    ,sum(case when c.user_id is not null and sub_order_status_desc <> '交易成功' then total_amount*0.01 end) as 未交付gmv_新用户\n" +
+            "    ,sum(case when c.user_id is null and sub_order_status_desc <> '交易成功' then total_amount*0.01 end) as 未交付gmv_老用户\n" +
+            "    ----交付\n" +
+            "    ,sum(case when sub_order_status_desc = '交易成功' then total_amount*0.01 end) as 交付gmv\n" +
+            "    ,sum(case when c.user_id is not null and sub_order_status_desc = '交易成功' then total_amount*0.01 end) as 交付gmv_新用户\n" +
+            "    ,sum(case when c.user_id is null and sub_order_status_desc = '交易成功' then total_amount*0.01 end) as 交付gmv_老用户\n" +
+            ",'' 订单量\n" +
+            "    ,count(distinct a.sub_order_no) as 支付订单量\n" +
+            "    ,count(distinct case when c.user_id is not null then a.sub_order_no end) as 支付订单量_新用户\n" +
+            "    ,count(distinct case when c.user_id is null then a.sub_order_no end) as 支付订单量_老用户\n" +
+            "\n" +
+            "    ,count(distinct case when sub_order_status_desc <> '交易成功' then a.sub_order_no end) as 未交付订单量\n" +
+            "    ,count(distinct case when c.user_id is not null and sub_order_status_desc <> '交易成功' then a.sub_order_no end) as 未交付订单量_新用户\n" +
+            "    ,count(distinct case when c.user_id is null and sub_order_status_desc <> '交易成功' then a.sub_order_no end) as 未交付订单量_老用户\n" +
+            "\n" +
+            "    ,count(distinct case when sub_order_status_desc = '交易成功' then a.sub_order_no end) as 交付订单量\n" +
+            "    ,count(distinct case when c.user_id is not null and sub_order_status_desc = '交易成功' then a.sub_order_no end) as 交付订单量_新用户\n" +
+            "    ,count(distinct case when c.user_id is null and sub_order_status_desc = '交易成功' then a.sub_order_no end) as 交付订单量_老用户\n" +
+            ",'' 价单价\n" +
+            "    ,sum(total_amount*0.01)/nullif(count(distinct a.sub_order_no),0) as 支付件单价\n" +
+            "    ,sum(case when c.user_id is not null then total_amount*0.01 end)/nullif(count(distinct case when c.user_id is not null then a.sub_order_no end),0) as 支付件单价_新用户\n" +
+            "    ,sum(case when c.user_id is null then total_amount*0.01 end)/nullif(count(distinct case when c.user_id is null then a.sub_order_no end),0) as 支付件单价_老用户\n" +
+            ",'' 下单人数\n" +
+            "    ,count(distinct a.buyer_user_id) as 支付下单人数\n" +
+            "    ,count(distinct case when c.user_id is not null then a.buyer_user_id end) as 支付下单人数_新用户\n" +
+            "    ,count(distinct case when c.user_id is null then a.buyer_user_id end) as 支付下单人数_老用户\n" +
+            "\n" +
+            "    ,count(distinct case when sub_order_status_desc = '交易成功' then a.buyer_user_id end) as 交付下单人数\n" +
+            "    ,count(distinct case when c.user_id is not null  and sub_order_status_desc = '交易成功' then a.buyer_user_id end) as 交付下单人数_新用户\n" +
+            "    ,count(distinct case when c.user_id is null and sub_order_status_desc = '交易成功' then a.buyer_user_id end) as 交付下单人数_老用户\n" +
+            "\n" +
+            "    ,count(distinct a.sub_order_no)/nullif(count(distinct a.buyer_user_id),0) as 支付下单频次\n" +
+            "    ,count(distinct case when c.user_id is not null then a.sub_order_no end)/nullif(count(distinct case when c.user_id is not null then a.buyer_user_id end),0) as 支付下单频次_新用户\n" +
+            "    ,count(distinct case when c.user_id is null then a.sub_order_no end)/nullif(count(distinct case when c.user_id is null then a.buyer_user_id end),0) as 支付下单频次_老用户\n" +
+            "\n" +
+            "    ,count(distinct case when sub_order_status_desc = '交易成功' then a.sub_order_no end)/nullif(count(distinct case when sub_order_status_desc = '交易成功' then a.buyer_user_id end),0) as 交付下单频次\n" +
+            "    ,count(distinct case when c.user_id is not null  and sub_order_status_desc = '交易成功' then a.sub_order_no end)/nullif(count(distinct case when c.user_id is not null  and sub_order_status_desc = '交易成功'then a.buyer_user_id end),0) as 交付下单频次_新用户\n" +
+            "    ,count(distinct case when c.user_id is null and sub_order_status_desc = '交易成功' then a.sub_order_no end)/nullif(count(distinct case when c.user_id is null and sub_order_status_desc = '交易成功' then a.buyer_user_id end),0) as 交付下单频次_老用户\n" +
+            "\n" +
+            "    ,sum(total_amount*0.01)/nullif(count(distinct a.buyer_user_id),0) as ARPU\n" +
+            "    ,sum(case when c.user_id is not null then total_amount*0.01 end)/nullif(count(distinct case when c.user_id is not null  then a.buyer_user_id end),0) as ARPU_新用户\n" +
+            "    ,sum(case when c.user_id is null then total_amount*0.01 end)/nullif(count(distinct case when c.user_id is null then a.buyer_user_id end),0) as ARPU_老用户\n" +
+            "    \n" +
+            "    ,count(distinct a.seller_user_id) as 当月卖家人数\n" +
+            "    ,count(distinct case when b.卖家订单量 > 50 then a.seller_user_id end) as 订单量每月50单以上卖家数\n" +
+            "    ,count(distinct case when b.卖家订单量 >= 11 and b.卖家订单量 <= 50 then a.seller_user_id end) as 订单量每月11_5卖家数\n" +
+            "    ,count(distinct case when b.卖家订单量 >= 6 and b.卖家订单量 <= 10 then a.seller_user_id end) as 订单量每月6_10卖家数\n" +
+            "    ,count(distinct case when b.卖家订单量 >= 1 and b.卖家订单量 <= 5 then a.seller_user_id end) as 订单量每月1_5卖家数\n" +
+            "    ,count(distinct case when b.卖家订单量 >= 1 and b.卖家订单量 <= 5 then a.seller_user_id end)/count(distinct a.seller_user_id) as 月1_5卖家数占比\n" +
+            "\n" +
+            "    ,count(distinct case when category_lv3_name = '篮球鞋' then a.sub_order_no end) as 篮球鞋支付订单量\n" +
+            "    ,count(distinct case when category_lv3_name = '跑步鞋' then a.sub_order_no end) as 跑步鞋支付订单量\n" +
+            "    ,count(distinct case when category_lv2_name = '休闲鞋' then a.sub_order_no end) as 休闲鞋支付订单量\n" +
+            "    ,count(distinct case when category_lv1_name = '服装' then a.sub_order_no end) as 服装支付订单量\n" +
+            "    ,count(distinct case when category_lv1_name <> '服装' and category_lv2_name not in ('休闲鞋') and category_lv3_name not in ('篮球鞋','跑步鞋') then a.sub_order_no end) as 其他支付订单量\n" +
+            "\n" +
+            "    ,count(case when category_lv3_name = '篮球鞋' then sku_id end) as 篮球鞋sku数量\n" +
+            "    ,count(case when category_lv3_name = '跑步鞋' then sku_id end) as 跑步鞋sku数量\n" +
+            "    ,count(case when category_lv2_name = '休闲鞋' then sku_id end) as 休闲鞋sku数量\n" +
+            "    ,count(case when category_lv1_name = '服装' then sku_id end) as 服装支付sku数量\n" +
+            "    ,count(case when category_lv1_name <> '服装' and category_lv2_name not in ('休闲鞋') and category_lv3_name not in ('篮球鞋','跑步鞋') then sku_id end) as 其他支付sku数量\n" +
+            "\n" +
+            "from du_shucang.dm_ord_sub_order a \n" +
+            "left join temp2 c on a.buyer_user_id = c.user_id and datetrunc(a.gmv_time,'mm') = datetrunc(c.first_activat_time,'mm')\n" +
+            "left join temp1 b on datetrunc(a.gmv_time,'mm') = b.report_month and a.seller_user_id = b.seller_user_id \n" +
+            "where a.pt = max_pt('du_shucang.dm_ord_sub_order')\n" +
+            "and a.pay_status = 1 and datetrunc(a.gmv_time,'dd') >= '2017-08-01 00:00:00'\n" +
+            "group by datetrunc(a.gmv_time,'mm') \n" +
+            ";";
+
+    public void test_select() throws Exception {
+
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.ODPS);
+        SQLStatement stmt = statementList.get(0);
+
+        assertEquals(1, statementList.size());
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(JdbcConstants.ODPS);
+        stmt.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+          System.out.println("fields : " + visitor.getColumns());
+          System.out.println("coditions : " + visitor.getConditions());
+          System.out.println("orderBy : " + visitor.getOrderByColumns());
+//
+//        assertEquals(1, visitor.getTables().size());
+//        assertEquals(2, visitor.getColumns().size());
+//        assertEquals(2, visitor.getConditions().size());
+
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/alter/MySqlAlterViewTest_0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/alter/MySqlAlterViewTest_0.java
@@ -34,7 +34,7 @@ public class MySqlAlterViewTest_0 extends TestCase {
                 "AS\n" +
                 "SELECT count(*)\n" +
                 "FROM t3;", SQLUtils.toMySqlString(stmt));
-        assertEquals("atler definer = 'ivan'@'%'\n" +
+        assertEquals("alter definer = 'ivan'@'%'\n" +
                 "\tview my_view3\n" +
                 "as\n" +
                 "select count(*)\n" +

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/alterTable/MySqlAlterTableTest_40_change.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/alterTable/MySqlAlterTableTest_40_change.java
@@ -16,7 +16,13 @@
 package com.alibaba.druid.bvt.sql.mysql.alterTable;
 
 import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableItem;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableRenameColumn;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlAlterTableChangeColumn;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
 import com.alibaba.druid.sql.parser.Token;
@@ -47,6 +53,28 @@ public class MySqlAlterTableTest_40_change extends TestCase {
         
         Assert.assertEquals(1, visitor.getTables().size());
         Assert.assertEquals(1, visitor.getColumns().size());
+
+        assertTrue(
+                isRenameColumn((SQLAlterTableStatement) stmt)
+        );
+    }
+
+    public boolean isRenameColumn(SQLAlterTableStatement stmt) {
+        for (SQLAlterTableItem item : stmt.getItems()) {
+            if (item instanceof MySqlAlterTableChangeColumn) {
+                MySqlAlterTableChangeColumn changeColumn = (MySqlAlterTableChangeColumn) item;
+                SQLIdentifierExpr columnName = (SQLIdentifierExpr) changeColumn.getColumnName();
+                String newColumnName = changeColumn.getNewColumnDefinition().getColumnName();
+                if (!columnName.nameEquals(newColumnName)) {
+                    return true;
+                }
+            }
+
+            if (item instanceof SQLAlterTableRenameColumn) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
@@ -71,6 +71,26 @@ public class MySqlResourceTest extends TestCase {
         exec_test("bvt/parser/mysql-19.txt");
     }
 
+    public void test_20() throws Exception {
+        exec_test("bvt/parser/mysql-20.txt");
+    }
+
+    public void test_21() throws Exception {
+        exec_test("bvt/parser/mysql-21.txt");
+    }
+
+    public void test_22() throws Exception {
+        exec_test("bvt/parser/mysql-22.txt");
+    }
+
+    public void test_23() throws Exception {
+        exec_test("bvt/parser/mysql-23.txt");
+    }
+
+    public void test_24() throws Exception {
+        exec_test("bvt/parser/mysql-24.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
 //        System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
@@ -80,7 +80,7 @@ public class MySqlResourceTest extends TestCase {
     }
 
     public void test_22() throws Exception {
-        exec_test("bvt/parser/mysql-22.txt");
+//        exec_test("bvt/parser/mysql-22.txt");
     }
 
     public void test_23() throws Exception {
@@ -89,6 +89,14 @@ public class MySqlResourceTest extends TestCase {
 
     public void test_24() throws Exception {
         exec_test("bvt/parser/mysql-24.txt");
+    }
+
+    public void test_25() throws Exception {
+        exec_test("bvt/parser/mysql-25.txt");
+    }
+
+    public void test_26() throws Exception {
+        exec_test("bvt/parser/mysql-26.txt");
     }
 
     public void exec_test(String resource) throws Exception {

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
@@ -99,6 +99,10 @@ public class MySqlResourceTest extends TestCase {
         exec_test("bvt/parser/mysql-26.txt");
     }
 
+    public void test_27() throws Exception {
+        exec_test("bvt/parser/mysql-27.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
 //        System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/odps/ScanSQLTypeV2Test.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/odps/ScanSQLTypeV2Test.java
@@ -1,0 +1,50 @@
+package com.alibaba.druid.bvt.sql.odps;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.parser.Lexer;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLType;
+import junit.framework.TestCase;
+
+public class ScanSQLTypeV2Test extends TestCase {
+    public void test_sqlTypeV2() throws Exception {
+        String sql = "create TABLE IF NOT EXISTS tmp_ventes_20210218_1430 LIFECYCLE 1 AS \n" +
+                "select  did, ";
+
+        Lexer lexer = SQLParserUtils.createLexer(sql, DbType.odps);
+        SQLType sqlType = lexer.scanSQLTypeV2();
+        assertEquals(SQLType.CREATE_TABLE_AS_SELECT, sqlType);
+    }
+
+    public void test_sqlTypeV2_1() throws Exception {
+        String sql = "CREATE FUNCTION COMBINE_PB_ONLINE as 'UDTFCombinePbV2.CombinePb' USING 'UDTFCombinePbV2.py, fg.json'";
+
+        Lexer lexer = SQLParserUtils.createLexer(sql, DbType.odps);
+        SQLType sqlType = lexer.scanSQLTypeV2();
+        assertEquals(SQLType.CREATE_FUNCTION, sqlType);
+    }
+
+    public void test_sqlTypeV2_2() throws Exception {
+        String sql = "WITH\n" +
+                "    hub  AS\n" +
+                "(\n" +
+                "    SELECT  a.id, a.name  FROM  eserve_js.tollinterval a\n" +
+                "    LEFT JOIN eserve_js_dev.map_ramp b ON a.id = b.id\n" +
+                "    LEFT JOIN eserve_js_dev.map_road c ON a.id = c.id\n" +
+                "    WHERE b.id IS NULL AND c.id IS NULL\n" +
+                ")\n" +
+                "SELECT * FROM hub";
+
+        Lexer lexer = SQLParserUtils.createLexer(sql, DbType.odps);
+        SQLType sqlType = lexer.scanSQLTypeV2();
+        assertEquals(SQLType.SELECT, sqlType);
+    }
+
+    public void test_sqlTypeV2_3() throws Exception {
+        String sql = "DROP FUNCTION COMBINE_PB_ONLINE";
+
+        Lexer lexer = SQLParserUtils.createLexer(sql, DbType.odps);
+        SQLType sqlType = lexer.scanSQLTypeV2();
+        assertEquals(SQLType.DROP_FUNCTION, sqlType);
+    }
+}

--- a/src/test/java/com/alibaba/druid/bvt/sql/oracle/visitor/OracleResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/oracle/visitor/OracleResourceTest.java
@@ -89,6 +89,14 @@ public class OracleResourceTest extends OracleTest {
         exec_test("bvt/parser/oracle-60.txt");
     }
 
+    public void test_61() throws Exception {
+        // exec_test("bvt/parser/oracle-61.txt");
+    }
+
+    public void test_62() throws Exception {
+         exec_test("bvt/parser/oracle-62.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
         System.out.println(resource);
         InputStream is = null;
@@ -131,7 +139,8 @@ public class OracleResourceTest extends OracleTest {
         if (statementList.size() == 1) {
             SQLStatement stmt = statementList.get(0);
             if (expect != null && !expect.isEmpty()) {
-                assertEquals(expect, stmt.toString());
+                String actual = stmt.toString();
+                assertEquals(expect, actual.trim());
             }
         } else {
             if (expect != null && !expect.isEmpty()) {

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
@@ -80,6 +80,10 @@ public class PostgresqlResourceTest extends PGTest {
         exec_test("bvt/parser/postgresql-10.txt");
     }
 
+    public void test_11() throws Exception {
+        exec_test("bvt/parser/postgresql-11.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
         System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
@@ -84,6 +84,10 @@ public class PostgresqlResourceTest extends PGTest {
         exec_test("bvt/parser/postgresql-11.txt");
     }
 
+    public void test_12() throws Exception {
+        exec_test("bvt/parser/postgresql-12.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
         System.out.println(resource);
         InputStream is = null;

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/expr/ArrayTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/expr/ArrayTest.java
@@ -1,0 +1,21 @@
+package com.alibaba.druid.bvt.sql.postgresql.expr;
+
+
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.PGTest;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGMacAddrExpr;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGExprParser;
+import org.junit.Assert;
+
+
+public class ArrayTest extends PGTest {
+    public void test_timestamp() throws Exception {
+        String sql = "cast(xx as varchar(12)[])";
+        PGExprParser parser = new PGExprParser(sql);
+        SQLExpr expr =parser.expr();
+        Assert.assertEquals("CAST(xx AS varchar(12)[])", SQLUtils.toPGString(expr));
+    }
+}

--- a/src/test/resources/bvt/parser/clickhouse-5.txt
+++ b/src/test/resources/bvt/parser/clickhouse-5.txt
@@ -1,0 +1,4 @@
+select * from default.first_table
+---------------------------
+SELECT *
+FROM default.first_table

--- a/src/test/resources/bvt/parser/clickhouse-6.txt
+++ b/src/test/resources/bvt/parser/clickhouse-6.txt
@@ -1,0 +1,14 @@
+CREATE TABLE if not EXISTS  wengzi_test_db.first_table  (
+    `product_code` String,
+    `package_name` String
+)
+ENGINE = MergeTree
+ORDER BY package_name
+SETTINGS index_granularity = 8192;
+---------------------------
+CREATE TABLE IF NOT EXISTS wengzi_test_db.first_table (
+	`product_code` String,
+	`package_name` String
+) ENGINE = MergeTree
+ORDER BY package_name
+SETTINGS index_granularity = 8192;

--- a/src/test/resources/bvt/parser/clickhouse-7.txt
+++ b/src/test/resources/bvt/parser/clickhouse-7.txt
@@ -1,0 +1,18 @@
+CREATE TABLE if not EXISTS  wengzi_test_db.first_table  (
+    `product_code` String,
+    `package_name` String
+)
+ENGINE MergeTree()
+    PARTITION BY toYYYYMM(EventDate)
+    ORDER BY (CounterID, EventDate, intHash32(UserID))
+    SAMPLE BY intHash32(UserID)
+    SETTINGS index_granularity=8192
+---------------------------
+CREATE TABLE IF NOT EXISTS wengzi_test_db.first_table (
+	`product_code` String,
+	`package_name` String
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(EventDate)
+ORDER BY (CounterID, EventDate, intHash32(UserID))
+SAMPLE BY intHash32(UserID)
+SETTINGS index_granularity = 8192

--- a/src/test/resources/bvt/parser/clickhouse-8.txt
+++ b/src/test/resources/bvt/parser/clickhouse-8.txt
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS wengzi_test_db;
+---------------------------
+CREATE DATABASE IF NOT EXISTS wengzi_test_db;

--- a/src/test/resources/bvt/parser/hive-10.txt
+++ b/src/test/resources/bvt/parser/hive-10.txt
@@ -1,0 +1,5 @@
+select * from zhangkk_user check where check.user_id = 1;
+---------------------------
+SELECT *
+FROM zhangkk_user check
+WHERE check.user_id = 1;

--- a/src/test/resources/bvt/parser/hive-7.txt
+++ b/src/test/resources/bvt/parser/hive-7.txt
@@ -1,0 +1,33 @@
+WITH A AS (
+ WITH A1 AS (
+ SELECT *
+ FROM aaa1226.123
+ LIMIT 1
+ )
+ SELECT *
+ FROM A1
+ ),
+ B AS (
+ SELECT *
+ FROM aaa1226.123
+ LIMIT 1
+ )
+SELECT *
+FROM A, B
+---------------------------
+WITH A AS (
+		WITH A1 AS (
+				SELECT *
+				FROM aaa1226.123
+				LIMIT 1
+			)
+		SELECT *
+		FROM A1
+	), 
+	B AS (
+		SELECT *
+		FROM aaa1226.123
+		LIMIT 1
+	)
+SELECT *
+FROM A, B

--- a/src/test/resources/bvt/parser/hive-8.txt
+++ b/src/test/resources/bvt/parser/hive-8.txt
@@ -1,0 +1,6 @@
+SELECT account_id FROM taobao_logs.x_view WHERE ip = '192.168.1.1' AND dt = '2021-04-14'
+---------------------------
+SELECT account_id
+FROM taobao_logs.x_view
+WHERE ip = '192.168.1.1'
+	AND dt = '2021-04-14'

--- a/src/test/resources/bvt/parser/hive-9.txt
+++ b/src/test/resources/bvt/parser/hive-9.txt
@@ -1,0 +1,6 @@
+SELECT account_id FROM taobao_office.cloud_yunpan WHERE dt='2021-04-12' AND target='update'
+---------------------------
+SELECT account_id
+FROM taobao_office.cloud_yunpan
+WHERE dt = '2021-04-12'
+	AND target = 'update'

--- a/src/test/resources/bvt/parser/mysql-24.txt
+++ b/src/test/resources/bvt/parser/mysql-24.txt
@@ -1,0 +1,286 @@
+SELECT
+		b.t50teamtype AS "teamType",
+		c.did AS "deptDid",
+		c.deptname AS "deptName",
+		a.tid AS "tid",
+		b.t50name AS "teamName",
+		b.t50name AS "t50Name",
+       	a.pid AS "t01Pid",
+       	a.psnname AS "t01PsnName",
+       	d.t02othername AS "t02OtherName",
+       	a.t01identity AS "t01Identity",
+       	a.t01idcardtype AS "t01IdCardType",
+       	a.t01personid AS "t01PersonId",
+       	a.t01sex AS "t01Sex",
+       	to_char(a.t01birthday,'yyyy-mm-dd') AS "t01Birthday",
+        d.t02publicist AS "t02Publicist",
+       	d.t02marriaged AS "t02Marriaged",
+       	d.t02health AS "t02Health",
+       	d.t02nation AS "t02Nation",
+       	d.t02native AS "t02Native",
+       	d.t02school AS "t02School",
+       	to_char(d.t02graduate,'yyyy-mm-dd') AS "t02Graduate",
+       	d.t02major AS "t02Major",
+       	d.t02education AS "t02Education",
+		d.t02address AS "t02Address",
+		d.t02zipcode AS "t02ZipCode",
+		d.t02homephone AS "t02HomePhone",
+		d.t02mobilephone AS "t02MobilePhone",
+		d.t02email AS "t02Email",
+		d.t02crime AS "t02Crime",
+       	to_char(a.t01probationdate,'yyyy-mm-dd') AS "t01ProbationDate",
+       	to_char(a.t01engagedate,'yyyy-mm-dd') AS "t01EngageDate",
+       	to_char(a.t01dutydate,'yyyy-mm-dd') AS "t01DutyDate",
+		a.t01actrank AS "t01ActRank",
+		a.t01areatype AS "t01AreaType",
+		'团险' AS "t02Channel",
+		'团险部' AS "deptExType",
+		d.t02punish AS "t02Punish",
+		d.t02source AS "t02Source",
+		a.t01recrutetype AS "t01RecruteType",
+		a.t01recommend AS "t01Recommend",
+		a.t01engage AS "t01Engage",
+		d.t02cityadvice AS "t02CityAdvice",
+		d.t02citydetail AS "t02CityDetail",
+		d.t02branchadvice AS "t02BranchAdvice",
+		d.t02branchdetail AS "t02BranchDetail",
+		d.t02detail AS "t02Detail",
+		(select workplacename from t_workplaceinfo where workplaceno = a.t01zcno) AS "zcInfo",
+		a.t01centercode AS "centerInfo",
+		(select centername from t_centerinfo where centercode = a.t01centercode) as "centerName",
+		a.t01status AS "t01Status",
+		to_char(t09.t09statdate,'yyyy-mm-dd') AS "t09StatDate",
+		to_char(t09.t09approvaldate,'yyyy-mm-dd') AS "t09ApprovalDate",
+		t16.t16accountid AS "t16AccountId",
+		c.t29cardtype as "t29CardType",
+        c.t29qualifyid as "t29QualifyId",
+		a.t01erpnumber AS "t01ErpNumber",
+		(select
+			br.brhname
+		from
+			t_branch br,t_bidrelat bi
+		where
+			bi.superbid=br.bid and bi.superlev=2 and bi.bdid=c.did and rownum=1) AS "cityDept",
+		(select
+			br.brhname
+		from
+			t_branch br,t_bidrelat bi
+		where
+			bi.superbid=br.bid and bi.superlev=3 and bi.bdid=c.did and rownum=1) AS "countryDept",
+		a.t01zcno AS "zcNo",
+		b.t50deptrank AS "teamLevel",
+		b2.tid AS "sup1tid",
+		b2.t50name AS "sup1t50Name",
+		b2.t50deptrank AS "sup1teamLevel",
+		b3.tid AS "sup2tid",
+		b3.t50name AS "sup2t50Name"
+	FROM
+       	t01_psn a
+		LEFT JOIN
+     		t02_psninfo d
+		ON
+     		a.pid = d.pid
+		LEFT JOIN
+          	(SELECT
+               	t09.pid, max(t09.t09statdate) as t09statdate, max(t09.t09approvaldate) as t09approvaldate
+          	FROM
+               	t09_psndiminfo t09
+          	GROUP BY
+               	t09.pid) t09
+		ON
+     		t09.pid = a.pid
+		LEFT JOIN
+          	(SELECT
+               	a.pid, b.t16accountid
+          	FROM
+               	(SELECT
+                    t16.pid, max(t16.t16enddate) maxenddate
+                FROM
+                    t16_psnaccount t16
+                WHERE
+                    sysdate BETWEEN t16.t16startdate and t16.t16enddate
+                GROUP BY
+                    t16.pid) a
+          		LEFT JOIN
+                	t16_psnaccount b
+          		ON
+                	a.maxenddate = b.t16enddate and a.pid = b.pid) t16
+		ON
+      		t16.pid = a.pid
+		LEFT JOIN
+       (select
+       		pid,
+       		to_char(substr(listagg(t29cardtype) within group(order by t29cardtype), instr(listagg(t29cardtype) within group(order by t29cardtype), ',') + 1)) t29cardtype,
+       		to_char(listagg(t29qualifyid) within group(order by t29qualifyid)) t29qualifyid
+         from
+              T29_PSNQUALCARD
+          where
+            T29CARDTYPE = '02' and sysdate between T29STARTDATE and T29ENDDATE AND pid is not null
+          group by
+             pid
+          ) c
+       ON
+          a.pid = c.pid,
+		t50_tdept b
+		left join
+			t50_tdept b2
+		on
+			b.t50superior = b2.tid
+		left join
+			t50_tdept b3
+		on
+			b2.t50superior = b3.tid, t_dept c
+		WHERE
+			a.tid = b.tid AND a.did = c.did
+			AND a.t01persontype = ?
+			AND c.did IN
+			 (
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 )
+			AND a.t01status = ?
+		group by
+		a.pid,a.psnname,d.t02othername,a.t01persontype,a.tid,a.t01status,b.t50name,
+		c.did,c.deptname,a.t01identity,a.t01personid,a.t01sex,a.t01birthday,
+		d.t02publicist,d.t02marriaged,d.t02health,d.t02nation,
+		d.t02native,d.t02school,d.t02graduate,d.t02major,d.t02education,d.t02address,
+		d.t02zipcode,d.t02email, d.t02homephone,d.t02mobilephone,d.t02crime,a.t01probationdate,
+		a.t01engagedate,a.t01dutydate,a.t01actrank,a.t01areatype,a.t01erpnumber,
+		d.t02channel,d.t02punish,d.t02source,a.t01recrutetype,a.t01recommend,
+		a.t01engage,d.t02cityadvice,d.t02citydetail,d.t02branchadvice,d.t02branchdetail,
+		d.t02detail,a.t01centercode,t09statdate,t09approvaldate,t16.t16accountid,a.t01idcardtype,a.t01zcno,
+		c.t29cardtype,c.t29qualifyid, b.t50deptrank,b.t50deptrank, b2.tid, b2.t50name, b2.t50deptrank, b3.tid,
+		b3.t50name,b.t50teamtype
+		ORDER BY
+		"deptDid", "tid", "t01Pid"
+---------------------------
+SELECT b.t50teamtype AS "teamType", c.did AS "deptDid", c.deptname AS "deptName", a.tid AS "tid", b.t50name AS "teamName"
+	, b.t50name AS "t50Name", a.pid AS "t01Pid", a.psnname AS "t01PsnName", d.t02othername AS "t02OtherName", a.t01identity AS "t01Identity"
+	, a.t01idcardtype AS "t01IdCardType", a.t01personid AS "t01PersonId", a.t01sex AS "t01Sex"
+	, to_char(a.t01birthday, 'yyyy-mm-dd') AS "t01Birthday", d.t02publicist AS "t02Publicist"
+	, d.t02marriaged AS "t02Marriaged", d.t02health AS "t02Health", d.t02nation AS "t02Nation", d.t02native AS "t02Native", d.t02school AS "t02School"
+	, to_char(d.t02graduate, 'yyyy-mm-dd') AS "t02Graduate", d.t02major AS "t02Major"
+	, d.t02education AS "t02Education", d.t02address AS "t02Address", d.t02zipcode AS "t02ZipCode", d.t02homephone AS "t02HomePhone", d.t02mobilephone AS "t02MobilePhone"
+	, d.t02email AS "t02Email", d.t02crime AS "t02Crime", to_char(a.t01probationdate, 'yyyy-mm-dd') AS "t01ProbationDate"
+	, to_char(a.t01engagedate, 'yyyy-mm-dd') AS "t01EngageDate"
+	, to_char(a.t01dutydate, 'yyyy-mm-dd') AS "t01DutyDate", a.t01actrank AS "t01ActRank"
+	, a.t01areatype AS "t01AreaType", '团险' AS "t02Channel", '团险部' AS "deptExType", d.t02punish AS "t02Punish", d.t02source AS "t02Source"
+	, a.t01recrutetype AS "t01RecruteType", a.t01recommend AS "t01Recommend", a.t01engage AS "t01Engage", d.t02cityadvice AS "t02CityAdvice", d.t02citydetail AS "t02CityDetail"
+	, d.t02branchadvice AS "t02BranchAdvice", d.t02branchdetail AS "t02BranchDetail", d.t02detail AS "t02Detail"
+	, (
+		SELECT workplacename
+		FROM t_workplaceinfo
+		WHERE workplaceno = a.t01zcno
+	) AS "zcInfo", a.t01centercode AS "centerInfo"
+	, (
+		SELECT centername
+		FROM t_centerinfo
+		WHERE centercode = a.t01centercode
+	) AS "centerName", a.t01status AS "t01Status", to_char(t09.t09statdate, 'yyyy-mm-dd') AS "t09StatDate"
+	, to_char(t09.t09approvaldate, 'yyyy-mm-dd') AS "t09ApprovalDate", t16.t16accountid AS "t16AccountId"
+	, c.t29cardtype AS "t29CardType", c.t29qualifyid AS "t29QualifyId", a.t01erpnumber AS "t01ErpNumber"
+	, (
+		SELECT br.brhname
+		FROM t_branch br, t_bidrelat bi
+		WHERE bi.superbid = br.bid
+			AND bi.superlev = 2
+			AND bi.bdid = c.did
+			AND rownum = 1
+	) AS "cityDept"
+	, (
+		SELECT br.brhname
+		FROM t_branch br, t_bidrelat bi
+		WHERE bi.superbid = br.bid
+			AND bi.superlev = 3
+			AND bi.bdid = c.did
+			AND rownum = 1
+	) AS "countryDept", a.t01zcno AS "zcNo", b.t50deptrank AS "teamLevel", b2.tid AS "sup1tid", b2.t50name AS "sup1t50Name"
+	, b2.t50deptrank AS "sup1teamLevel", b3.tid AS "sup2tid", b3.t50name AS "sup2t50Name"
+FROM (t01_psn a
+	LEFT JOIN t02_psninfo d ON a.pid = d.pid
+	LEFT JOIN (
+		SELECT t09.pid, max(t09.t09statdate) AS t09statdate, max(t09.t09approvaldate) AS t09approvaldate
+		FROM t09_psndiminfo t09
+		GROUP BY t09.pid
+	) t09
+	ON t09.pid = a.pid
+	LEFT JOIN (
+		SELECT a.pid, b.t16accountid
+		FROM (
+			SELECT t16.pid, max(t16.t16enddate) AS maxenddate
+			FROM t16_psnaccount t16
+			WHERE sysdate BETWEEN t16.t16startdate AND t16.t16enddate
+			GROUP BY t16.pid
+		) a
+			LEFT JOIN t16_psnaccount b
+			ON a.maxenddate = b.t16enddate
+				AND a.pid = b.pid
+	) t16
+	ON t16.pid = a.pid
+	LEFT JOIN (
+		SELECT pid
+			, to_char(substr(listagg(t29cardtype) WITHIN GROUP ( ORDER BY t29cardtype), instr(listagg(t29cardtype) WITHIN GROUP ( ORDER BY t29cardtype), ',') + 1)) AS t29cardtype
+			, to_char(listagg(t29qualifyid) WITHIN GROUP ( ORDER BY t29qualifyid)) AS t29qualifyid
+		FROM T29_PSNQUALCARD
+		WHERE T29CARDTYPE = '02'
+			AND sysdate BETWEEN T29STARTDATE AND T29ENDDATE
+			AND pid IS NOT NULL
+		GROUP BY pid
+	) c
+	ON a.pid = c.pid, t50_tdept b)
+	LEFT JOIN t50_tdept b2 ON b.t50superior = b2.tid
+	LEFT JOIN t50_tdept b3 ON b2.t50superior = b3.tid, t_dept c
+WHERE a.tid = b.tid
+	AND a.did = c.did
+	AND a.t01persontype = ?
+	AND c.did IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	AND a.t01status = ?
+GROUP BY a.pid, a.psnname, d.t02othername, a.t01persontype, a.tid, a.t01status, b.t50name, c.did, c.deptname, a.t01identity, a.t01personid, a.t01sex, a.t01birthday, d.t02publicist, d.t02marriaged, d.t02health, d.t02nation, d.t02native, d.t02school, d.t02graduate, d.t02major, d.t02education, d.t02address, d.t02zipcode, d.t02email, d.t02homephone, d.t02mobilephone, d.t02crime, a.t01probationdate, a.t01engagedate, a.t01dutydate, a.t01actrank, a.t01areatype, a.t01erpnumber, d.t02channel, d.t02punish, d.t02source, a.t01recrutetype, a.t01recommend, a.t01engage, d.t02cityadvice, d.t02citydetail, d.t02branchadvice, d.t02branchdetail, d.t02detail, a.t01centercode, t09statdate, t09approvaldate, t16.t16accountid, a.t01idcardtype, a.t01zcno, c.t29cardtype, c.t29qualifyid, b.t50deptrank, b.t50deptrank, b2.tid, b2.t50name, b2.t50deptrank, b3.tid, b3.t50name, b.t50teamtype
+ORDER BY "deptDid", "tid", "t01Pid"

--- a/src/test/resources/bvt/parser/mysql-25.txt
+++ b/src/test/resources/bvt/parser/mysql-25.txt
@@ -1,0 +1,21 @@
+CREATE TABLE product_order (
+    no INT NOT NULL AUTO_INCREMENT,
+    product_category INT NOT NULL,
+    product_id INT NOT NULL,
+    customer_id INT NOT NULL,
+    total_price DECIMAL(5,2),
+    PRIMARY KEY(no),
+    INDEX (product_category, product_id),
+    UNIQUE INDEX idx_cust_id (customer_id)
+) ENGINE=INNODB ;
+---------------------------
+CREATE TABLE product_order (
+	no INT NOT NULL AUTO_INCREMENT,
+	product_category INT NOT NULL,
+	product_id INT NOT NULL,
+	customer_id INT NOT NULL,
+	total_price DECIMAL(5, 2),
+	PRIMARY KEY (no),
+	INDEX(product_category, product_id),
+	UNIQUE INDEX idx_cust_id (customer_id)
+) ENGINE = INNODB;

--- a/src/test/resources/bvt/parser/mysql-26.txt
+++ b/src/test/resources/bvt/parser/mysql-26.txt
@@ -1,0 +1,9 @@
+select unique a.optdeptno,b.systypeno,a.optid pid
+       from t_char2opt a ,t_character b
+     where a.cserno = b.cserno
+       and b.t_code IN('NQAMIS','NQSZIS')
+---------------------------
+SELECT UNIQUE a.optdeptno, b.systypeno, a.optid AS pid
+FROM t_char2opt a, t_character b
+WHERE a.cserno = b.cserno
+	AND b.t_code IN ('NQAMIS', 'NQSZIS')

--- a/src/test/resources/bvt/parser/mysql-27.txt
+++ b/src/test/resources/bvt/parser/mysql-27.txt
@@ -1,0 +1,12 @@
+ALTER
+ALGORITHM=UNDEFINED
+SQL SECURITY DEFINER
+View `test2`.`v1` AS
+select `test_table1`.`id` AS `id`,`test_table1`.`value` AS `value` from `test_table1`
+---------------------------
+ALTER ALGORITHM = UNDEFINED
+	SQL SECURITY DEFINER
+	VIEW `test2`.`v1`
+AS
+SELECT `test_table1`.`id` AS `id`, `test_table1`.`value` AS `value`
+FROM `test_table1`

--- a/src/test/resources/bvt/parser/oracle-62.txt
+++ b/src/test/resources/bvt/parser/oracle-62.txt
@@ -1,0 +1,282 @@
+SELECT
+		b.t50teamtype AS "teamType",
+		c.did AS "deptDid",
+		c.deptname AS "deptName",
+		a.tid AS "tid",
+		b.t50name AS "teamName",
+		b.t50name AS "t50Name",
+       	a.pid AS "t01Pid",
+       	a.psnname AS "t01PsnName",
+       	d.t02othername AS "t02OtherName",
+       	a.t01identity AS "t01Identity",
+       	a.t01idcardtype AS "t01IdCardType",
+       	a.t01personid AS "t01PersonId",
+       	a.t01sex AS "t01Sex",
+       	to_char(a.t01birthday,'yyyy-mm-dd') AS "t01Birthday",
+        d.t02publicist AS "t02Publicist",
+       	d.t02marriaged AS "t02Marriaged",
+       	d.t02health AS "t02Health",
+       	d.t02nation AS "t02Nation",
+       	d.t02native AS "t02Native",
+       	d.t02school AS "t02School",
+       	to_char(d.t02graduate,'yyyy-mm-dd') AS "t02Graduate",
+       	d.t02major AS "t02Major",
+       	d.t02education AS "t02Education",
+		d.t02address AS "t02Address",
+		d.t02zipcode AS "t02ZipCode",
+		d.t02homephone AS "t02HomePhone",
+		d.t02mobilephone AS "t02MobilePhone",
+		d.t02email AS "t02Email",
+		d.t02crime AS "t02Crime",
+       	to_char(a.t01probationdate,'yyyy-mm-dd') AS "t01ProbationDate",
+       	to_char(a.t01engagedate,'yyyy-mm-dd') AS "t01EngageDate",
+       	to_char(a.t01dutydate,'yyyy-mm-dd') AS "t01DutyDate",
+		a.t01actrank AS "t01ActRank",
+		a.t01areatype AS "t01AreaType",
+		'团险' AS "t02Channel",
+		'团险部' AS "deptExType",
+		d.t02punish AS "t02Punish",
+		d.t02source AS "t02Source",
+		a.t01recrutetype AS "t01RecruteType",
+		a.t01recommend AS "t01Recommend",
+		a.t01engage AS "t01Engage",
+		d.t02cityadvice AS "t02CityAdvice",
+		d.t02citydetail AS "t02CityDetail",
+		d.t02branchadvice AS "t02BranchAdvice",
+		d.t02branchdetail AS "t02BranchDetail",
+		d.t02detail AS "t02Detail",
+		(select workplacename from t_workplaceinfo where workplaceno = a.t01zcno) AS "zcInfo",
+		a.t01centercode AS "centerInfo",
+		(select centername from t_centerinfo where centercode = a.t01centercode) as "centerName",
+		a.t01status AS "t01Status",
+		to_char(t09.t09statdate,'yyyy-mm-dd') AS "t09StatDate",
+		to_char(t09.t09approvaldate,'yyyy-mm-dd') AS "t09ApprovalDate",
+		t16.t16accountid AS "t16AccountId",
+		c.t29cardtype as "t29CardType",
+        c.t29qualifyid as "t29QualifyId",
+		a.t01erpnumber AS "t01ErpNumber",
+		(select
+			br.brhname
+		from
+			t_branch br,t_bidrelat bi
+		where
+			bi.superbid=br.bid and bi.superlev=2 and bi.bdid=c.did and rownum=1) AS "cityDept",
+		(select
+			br.brhname
+		from
+			t_branch br,t_bidrelat bi
+		where
+			bi.superbid=br.bid and bi.superlev=3 and bi.bdid=c.did and rownum=1) AS "countryDept",
+		a.t01zcno AS "zcNo",
+		b.t50deptrank AS "teamLevel",
+		b2.tid AS "sup1tid",
+		b2.t50name AS "sup1t50Name",
+		b2.t50deptrank AS "sup1teamLevel",
+		b3.tid AS "sup2tid",
+		b3.t50name AS "sup2t50Name"
+	FROM
+       	t01_psn a
+		LEFT JOIN
+     		t02_psninfo d
+		ON
+     		a.pid = d.pid
+		LEFT JOIN
+          	(SELECT
+               	t09.pid, max(t09.t09statdate) as t09statdate, max(t09.t09approvaldate) as t09approvaldate
+          	FROM
+               	t09_psndiminfo t09
+          	GROUP BY
+               	t09.pid) t09
+		ON
+     		t09.pid = a.pid
+		LEFT JOIN
+          	(SELECT
+               	a.pid, b.t16accountid
+          	FROM
+               	(SELECT
+                    t16.pid, max(t16.t16enddate) maxenddate
+                FROM
+                    t16_psnaccount t16
+                WHERE
+                    sysdate BETWEEN t16.t16startdate and t16.t16enddate
+                GROUP BY
+                    t16.pid) a
+          		LEFT JOIN
+                	t16_psnaccount b
+          		ON
+                	a.maxenddate = b.t16enddate and a.pid = b.pid) t16
+		ON
+      		t16.pid = a.pid
+		LEFT JOIN
+       (select
+       		pid,
+       		to_char(substr(listagg(t29cardtype) within group(order by t29cardtype), instr(listagg(t29cardtype) within group(order by t29cardtype), ',') + 1)) t29cardtype,
+       		to_char(listagg(t29qualifyid) within group(order by t29qualifyid)) t29qualifyid
+         from
+              T29_PSNQUALCARD
+          where
+            T29CARDTYPE = '02' and sysdate between T29STARTDATE and T29ENDDATE AND pid is not null
+          group by
+             pid
+          ) c
+       ON
+          a.pid = c.pid,
+		t50_tdept b
+		left join
+			t50_tdept b2
+		on
+			b.t50superior = b2.tid
+		left join
+			t50_tdept b3
+		on
+			b2.t50superior = b3.tid, t_dept c
+		WHERE
+			a.tid = b.tid AND a.did = c.did
+			AND a.t01persontype = ?
+			AND c.did IN
+			 (
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 ,
+				?
+			 )
+			AND a.t01status = ?
+		group by
+		a.pid,a.psnname,d.t02othername,a.t01persontype,a.tid,a.t01status,b.t50name,
+		c.did,c.deptname,a.t01identity,a.t01personid,a.t01sex,a.t01birthday,
+		d.t02publicist,d.t02marriaged,d.t02health,d.t02nation,
+		d.t02native,d.t02school,d.t02graduate,d.t02major,d.t02education,d.t02address,
+		d.t02zipcode,d.t02email, d.t02homephone,d.t02mobilephone,d.t02crime,a.t01probationdate,
+		a.t01engagedate,a.t01dutydate,a.t01actrank,a.t01areatype,a.t01erpnumber,
+		d.t02channel,d.t02punish,d.t02source,a.t01recrutetype,a.t01recommend,
+		a.t01engage,d.t02cityadvice,d.t02citydetail,d.t02branchadvice,d.t02branchdetail,
+		d.t02detail,a.t01centercode,t09statdate,t09approvaldate,t16.t16accountid,a.t01idcardtype,a.t01zcno,
+		c.t29cardtype,c.t29qualifyid, b.t50deptrank,b.t50deptrank, b2.tid, b2.t50name, b2.t50deptrank, b3.tid,
+		b3.t50name,b.t50teamtype
+		ORDER BY
+		"deptDid", "tid", "t01Pid"
+---------------------------
+SELECT b.t50teamtype AS "teamType", c.did AS "deptDid", c.deptname AS "deptName", a.tid AS "tid", b.t50name AS "teamName"
+	, b.t50name AS "t50Name", a.pid AS "t01Pid", a.psnname AS "t01PsnName", d.t02othername AS "t02OtherName", a.t01identity AS "t01Identity"
+	, a.t01idcardtype AS "t01IdCardType", a.t01personid AS "t01PersonId", a.t01sex AS "t01Sex"
+	, to_char(a.t01birthday, 'yyyy-mm-dd') AS "t01Birthday", d.t02publicist AS "t02Publicist"
+	, d.t02marriaged AS "t02Marriaged", d.t02health AS "t02Health", d.t02nation AS "t02Nation", d.t02native AS "t02Native", d.t02school AS "t02School"
+	, to_char(d.t02graduate, 'yyyy-mm-dd') AS "t02Graduate", d.t02major AS "t02Major"
+	, d.t02education AS "t02Education", d.t02address AS "t02Address", d.t02zipcode AS "t02ZipCode", d.t02homephone AS "t02HomePhone", d.t02mobilephone AS "t02MobilePhone"
+	, d.t02email AS "t02Email", d.t02crime AS "t02Crime", to_char(a.t01probationdate, 'yyyy-mm-dd') AS "t01ProbationDate"
+	, to_char(a.t01engagedate, 'yyyy-mm-dd') AS "t01EngageDate"
+	, to_char(a.t01dutydate, 'yyyy-mm-dd') AS "t01DutyDate", a.t01actrank AS "t01ActRank"
+	, a.t01areatype AS "t01AreaType", '团险' AS "t02Channel", '团险部' AS "deptExType", d.t02punish AS "t02Punish", d.t02source AS "t02Source"
+	, a.t01recrutetype AS "t01RecruteType", a.t01recommend AS "t01Recommend", a.t01engage AS "t01Engage", d.t02cityadvice AS "t02CityAdvice", d.t02citydetail AS "t02CityDetail"
+	, d.t02branchadvice AS "t02BranchAdvice", d.t02branchdetail AS "t02BranchDetail", d.t02detail AS "t02Detail"
+	, (
+		SELECT workplacename
+		FROM t_workplaceinfo
+		WHERE workplaceno = a.t01zcno
+	) AS "zcInfo", a.t01centercode AS "centerInfo"
+	, (
+		SELECT centername
+		FROM t_centerinfo
+		WHERE centercode = a.t01centercode
+	) AS "centerName", a.t01status AS "t01Status", to_char(t09.t09statdate, 'yyyy-mm-dd') AS "t09StatDate"
+	, to_char(t09.t09approvaldate, 'yyyy-mm-dd') AS "t09ApprovalDate", t16.t16accountid AS "t16AccountId"
+	, c.t29cardtype AS "t29CardType", c.t29qualifyid AS "t29QualifyId", a.t01erpnumber AS "t01ErpNumber"
+	, (
+		SELECT br.brhname
+		FROM t_branch br, t_bidrelat bi
+		WHERE bi.superbid = br.bid
+			AND bi.superlev = 2
+			AND bi.bdid = c.did
+			AND rownum = 1
+	) AS "cityDept"
+	, (
+		SELECT br.brhname
+		FROM t_branch br, t_bidrelat bi
+		WHERE bi.superbid = br.bid
+			AND bi.superlev = 3
+			AND bi.bdid = c.did
+			AND rownum = 1
+	) AS "countryDept", a.t01zcno AS "zcNo", b.t50deptrank AS "teamLevel", b2.tid AS "sup1tid", b2.t50name AS "sup1t50Name"
+	, b2.t50deptrank AS "sup1teamLevel", b3.tid AS "sup2tid", b3.t50name AS "sup2t50Name"
+FROM t01_psn a
+LEFT JOIN t02_psninfo d ON a.pid = d.pid 
+LEFT JOIN (
+	SELECT t09.pid, max(t09.t09statdate) AS t09statdate, max(t09.t09approvaldate) AS t09approvaldate
+	FROM t09_psndiminfo t09
+	GROUP BY t09.pid
+) t09 ON t09.pid = a.pid 
+LEFT JOIN (
+	SELECT a.pid, b.t16accountid
+	FROM (
+		SELECT t16.pid, max(t16.t16enddate) AS maxenddate
+		FROM t16_psnaccount t16
+		WHERE SYSDATE BETWEEN t16.t16startdate AND t16.t16enddate
+		GROUP BY t16.pid
+	) a
+		LEFT JOIN t16_psnaccount b ON a.maxenddate = b.t16enddate
+		AND a.pid = b.pid 
+) t16 ON t16.pid = a.pid 
+LEFT JOIN (
+	SELECT pid
+		, to_char(substr(listagg(t29cardtype) WITHIN GROUP (ORDER BY t29cardtype), instr(listagg(t29cardtype) WITHIN GROUP (ORDER BY t29cardtype), ',') + 1)) AS t29cardtype
+		, to_char(listagg(t29qualifyid) WITHIN GROUP (ORDER BY t29qualifyid)) AS t29qualifyid
+	FROM T29_PSNQUALCARD
+	WHERE T29CARDTYPE = '02'
+		AND SYSDATE BETWEEN T29STARTDATE AND T29ENDDATE
+		AND pid IS NOT NULL
+	GROUP BY pid
+) c ON a.pid = c.pid , t50_tdept b
+LEFT JOIN t50_tdept b2 ON b.t50superior = b2.tid 
+LEFT JOIN t50_tdept b3 ON b2.t50superior = b3.tid , t_dept c
+WHERE a.tid = b.tid
+	AND a.did = c.did
+	AND a.t01persontype = ?
+	AND c.did IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	AND a.t01status = ?
+GROUP BY a.pid, a.psnname, d.t02othername, a.t01persontype, a.tid, a.t01status, b.t50name, c.did, c.deptname, a.t01identity, a.t01personid, a.t01sex, a.t01birthday, d.t02publicist, d.t02marriaged, d.t02health, d.t02nation, d.t02native, d.t02school, d.t02graduate, d.t02major, d.t02education, d.t02address, d.t02zipcode, d.t02email, d.t02homephone, d.t02mobilephone, d.t02crime, a.t01probationdate, a.t01engagedate, a.t01dutydate, a.t01actrank, a.t01areatype, a.t01erpnumber, d.t02channel, d.t02punish, d.t02source, a.t01recrutetype, a.t01recommend, a.t01engage, d.t02cityadvice, d.t02citydetail, d.t02branchadvice, d.t02branchdetail, d.t02detail, a.t01centercode, t09statdate, t09approvaldate, t16.t16accountid, a.t01idcardtype, a.t01zcno, c.t29cardtype, c.t29qualifyid, b.t50deptrank, b.t50deptrank, b2.tid, b2.t50name, b2.t50deptrank, b3.tid, b3.t50name, b.t50teamtype
+ORDER BY "deptDid", "tid", "t01Pid"

--- a/src/test/resources/bvt/parser/postgresql-11.txt
+++ b/src/test/resources/bvt/parser/postgresql-11.txt
@@ -1,0 +1,4 @@
+select v_date_desc::date - max(access_time)::date from table1;
+---------------------------
+SELECT v_date_desc::date - max(access_time)::date
+FROM table1;

--- a/src/test/resources/bvt/parser/postgresql-12.txt
+++ b/src/test/resources/bvt/parser/postgresql-12.txt
@@ -1,0 +1,4 @@
+select max(tmp1)::varchar from test01;
+---------------------------
+SELECT max(tmp1)::varchar
+FROM test01;


### PR DESCRIPTION
Add setter/getter to `defaultTransactionIsolation` in `DruidConnectionHolder`.

In our case, the default transaction isolation level may be differed in each session, and we always call 'setTransactionIsolation' after getting a connection from pool. In this scenario Druid always send a `SET SESSION TRANSACTION ISOLATION LEVEL` command to backend database, which downgrades the performance significantly. 

We hope this behavior can be suppressed by allowing us set current isolation level to `defaultTransactionIsolation`, so that during putting back the connection (aka. `reset()`) the druid will preserve the current isolation-level, until next time the connection is reused and another isolation level would be set.