### PR TITLE
日志相关过滤器与HA的ZooKeeper逻辑优化

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
@@ -122,11 +122,37 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
                 statementExecutableSqlLogEnable = false;
             }
         }
+        {
+            String prop = properties.getProperty("druid.log.conn.logError");
+            if ("false".equals(prop)) {
+                connectionLogErrorEnabled = false;
+            } else if ("true".equals(prop)) {
+                connectionLogErrorEnabled = true;
+            }
+        }
+        {
+            String prop = properties.getProperty("druid.log.stmt.logError");
+            if ("false".equals(prop)) {
+                statementLogErrorEnabled = false;
+            } else if ("true".equals(prop)) {
+                statementLogErrorEnabled = true;
+            }
+        }
+        {
+            String prop = properties.getProperty("druid.log.rs.logError");
+            if ("false".equals(prop)) {
+                resultSetLogErrorEnabled = false;
+            } else if ("true".equals(prop)) {
+                resultSetLogErrorEnabled = true;
+            }
+        }
     }
 
     @Override
     public void init(DataSourceProxy dataSource) {
         this.dataSource = dataSource;
+        configFromProperties(dataSource.getConnectProperties());
+        configFromProperties(System.getProperties());
     }
 
     public boolean isConnectionLogErrorEnabled() {

--- a/src/main/java/com/alibaba/druid/pool/ha/node/ZookeeperNodeListener.java
+++ b/src/main/java/com/alibaba/druid/pool/ha/node/ZookeeperNodeListener.java
@@ -26,7 +26,7 @@ import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
-import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryForever;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -88,9 +88,9 @@ public class ZookeeperNodeListener extends NodeListener {
         if (client == null) {
             client = CuratorFrameworkFactory.builder()
                     .canBeReadOnly(true)
-                    .connectionTimeoutMs(3000)
+                    .connectionTimeoutMs(5000)
                     .connectString(zkConnectString)
-                    .retryPolicy(new ExponentialBackoffRetry(5000, 3, 30000))
+                    .retryPolicy(new RetryForever(10000))
                     .sessionTimeoutMs(30000)
                     .build();
             client.start();

--- a/src/main/java/com/alibaba/druid/pool/ha/node/ZookeeperNodeRegister.java
+++ b/src/main/java/com/alibaba/druid/pool/ha/node/ZookeeperNodeRegister.java
@@ -20,7 +20,7 @@ import com.alibaba.druid.support.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.nodes.GroupMember;
-import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryForever;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -49,9 +49,9 @@ public class ZookeeperNodeRegister {
     public void init() {
         if (client == null) {
             client = CuratorFrameworkFactory.builder()
-                    .connectionTimeoutMs(3000)
+                    .connectionTimeoutMs(5000)
                     .connectString(zkConnectString)
-                    .retryPolicy(new ExponentialBackoffRetry(5000, 3, 30000))
+                    .retryPolicy(new RetryForever(10000))
                     .sessionTimeoutMs(30000)
                     .build();
             client.start();


### PR DESCRIPTION
1. 针对`LogFilter`中的`connectionLogErrorEnabled`、`statementLogErrorEnabled`和`resultSetLogErrorEnabled`增加了3个配置属性
2. `LogFilter`的`init()`方法中重新设置属性
3. `StatFilter`中的慢SQL日志级别可调整
4. 将Curator的`ExponentialBackoffRetry`替换为`RetryForever`，解决了ZK断开后可能出现的无法重新连接问题
5. 调整了ZK的默认连接超时时间