### PR TITLE
JdbcSqlStat.addResultSetHoldTimeNano() should not convert to nanos

### DIFF
--- a/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java
+++ b/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java
@@ -1057,7 +1057,7 @@ public final class JdbcSqlStat implements JdbcSqlStatMBean, Comparable<JdbcSqlSt
     public void addResultSetHoldTimeNano(long statementExecuteNano, long resultHoldTimeNano) {
         resultSetHoldTimeNanoUpdater.addAndGet(this, resultHoldTimeNano);
         executeAndResultSetHoldTimeUpdater.addAndGet(this, statementExecuteNano + resultHoldTimeNano);
-        executeAndResultHoldTimeHistogramRecord((statementExecuteNano + resultHoldTimeNano) / 1000 / 1000);
+        executeAndResultHoldTimeHistogramRecord(statementExecuteNano + resultHoldTimeNano);
         updateCount_0_1_Updater.incrementAndGet(this);
     }
 


### PR DESCRIPTION
For this:

https://github.com/alibaba/druid/blob/584dcb6c69224cc9e31200230d9977c75c67b004/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java#L1057-L1062

When calling `executeAndResultHoldTimeHistogramRecord()`, it should not convert value to nanos by `(statementExecuteNano + resultHoldTimeNano) / 1000 / 1000`. Because `executeAndResultHoldTimeHistogramRecord()` expect nanos:

https://github.com/alibaba/druid/blob/584dcb6c69224cc9e31200230d9977c75c67b004/src/main/java/com/alibaba/druid/stat/JdbcSqlStat.java#L715-L735