### PR TITLE
fix VERSION to 1.2.6

### DIFF
--- a/src/main/java/com/alibaba/druid/VERSION.java
+++ b/src/main/java/com/alibaba/druid/VERSION.java
@@ -19,7 +19,7 @@ public final class VERSION {
 
     public final static int MajorVersion    = 1;
     public final static int MinorVersion    = 2;
-    public final static int RevisionVersion = 5;
+    public final static int RevisionVersion = 6;
 
     public static String getVersionNumber() {
         return VERSION.MajorVersion + "." + VERSION.MinorVersion + "." + VERSION.RevisionVersion;


### PR DESCRIPTION
When I use druid-1.2.6, there is 1.2.5 in StatViewServlet
By the way, I think its better to get VERSION automatically, such as `VERSION.class.getPackage().getImplementationVersion()`
But it only works for druid jar