### PR TITLE
回收PreparedStatement时，不仅clearParameters，还要clearBatch，因为Query对象的batchedArgs里的批量数据需要清除

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
@@ -167,6 +167,17 @@ public class DruidPooledConnection extends PoolableWrapper implements javax.sql.
 
                 LOG.error("clear parameter error", ex);
             }
+
+            try {
+                rawStatement.clearBatch();
+            } catch (SQLException ex) {
+                this.handleException(ex, null);
+                if (rawStatement.getConnection().isClosed()) {
+                    return;
+                }
+
+                LOG.error("clear batch error", ex);
+            }
         }
 
         PreparedStatementHolder stmtHolder = stmt.getPreparedStatementHolder();


### PR DESCRIPTION
回收PreparedStatement时，不仅clearParameters，还要clearBatch，因为Query对象的batchedArgs里的批量数据需要清除。