### PR TITLE
bug: illegal equals implement in DruidPooledPreparedStatement

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidPooledPreparedStatement.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidPooledPreparedStatement.java
@@ -979,7 +979,12 @@ public class DruidPooledPreparedStatement extends DruidPooledStatement implement
             return resultSetHoldability;
         }
 
+        @Override
         public boolean equals(Object object) {
+            if (!(object instanceof PreparedStatementKey)) {
+                return false;
+            }
+
             PreparedStatementKey that = (PreparedStatementKey) object;
 
             if (!this.sql.equals(that.sql)) {


### PR DESCRIPTION
please see javadoc in Object#equals(Object) . your equals implement is disagree with that one.