### PR TITLE
fix flaky test in MySqlCreateExternalCatalogTest2

### DIFF
--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySqlCreateExternalCatalogTest2.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySqlCreateExternalCatalogTest2.java
@@ -19,7 +19,13 @@ import com.alibaba.druid.sql.MysqlTest;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import static org.apache.commons.lang3.ArrayUtils.*;
 
 public class MySqlCreateExternalCatalogTest2 extends MysqlTest {
 
@@ -41,16 +47,60 @@ public class MySqlCreateExternalCatalogTest2 extends MysqlTest {
         assertEquals(1, stmtList.size());
 
         SQLStatement stmt = stmtList.get(0);
-
-        assertEquals("CREATE EXTERNAL CATALOG shanghao_test.oss_catalog_0 PROPERTIES (\n" +
-                "connector.name='oss'\n" +
-                "'bucket-name'='oss_test'\n" +
-                "'connection-url'='http://oss-cn-hangzhou-zmf.aliyuncs.com'\n" +
-                "'connection-user'='access_id'\n" +
-                "'connection-password'='access_key')\n" +
-                "COMMENT 'This is a sample to create an oss connector catalog';", stmt.toString());
+        Set<String> allPossibleRes = generateAllPossibleRes();
+        assertTrue(allPossibleRes.contains(stmt.toString()));
     }
 
+    private Set<String> generateAllPossibleRes() {
+        Set<String> res = new HashSet<>();
+        List<String> list = new ArrayList<>();
+        list.add("connector.name='oss'");
+        list.add("'bucket-name'='oss_test'");
+        list.add("'connection-url'='http://oss-cn-hangzhou-zmf.aliyuncs.com'");
+        list.add("'connection-user'='access_id'");
+        list.add("'connection-password'='access_key'");
+        List<int[]> allPermutation = getAllPermutation(list.size());
+        for (int[] cur : allPermutation) {
+            res.add("CREATE EXTERNAL CATALOG shanghao_test.oss_catalog_0 PROPERTIES (\n"
+                    + list.get(cur[0]) + "\n" + list.get(cur[1]) + "\n" + list.get(cur[2])
+                    + "\n" + list.get(cur[3]) + "\n" + list.get(cur[4]) + ")\n"
+                    + "COMMENT 'This is a sample to create an oss connector catalog';");
+        }
+        return res;
+    }
+
+    private List<int[]> getAllPermutation(int n) {
+        List<int[]> res = new ArrayList<>();
+        int total = 1;
+        int[] permutation = new int[n];
+        for (int i = 1; i <= n; ++i) {
+            permutation[i - 1] = i - 1;
+            total *= i;
+        }
+
+        for (int i = 0; i < total; ++i) {
+            res.add(Arrays.copyOf(permutation,n));
+            nexPermutation(permutation);
+        }
+        return res;
+    }
+
+    private void nexPermutation(int[] nums) {
+        if (nums == null || nums.length == 0) return;
+        int i = nums.length - 2;
+        while (i >= 0 && nums[i] >= nums[i + 1]) {
+            --i;
+        }
+        if (i == -1) {
+            return;
+        }
+        int j = i + 1;
+        while (j < nums.length && nums[j] > nums[i]) {
+            ++j;
+        }
+        swap(nums, i, j - 1);
+        reverse(nums, i + 1, nums.length);
+    }
 
 
 }


### PR DESCRIPTION
In com/alibaba/druid/bvt/sql/mysql/create/MySqlCreateExternalCatalogTest2.java, test_0() is flaky due to the non-deterministic property of HashMap, proved in proved in [document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), it is used by SQLStatement.toString(). This function called com.alibaba.druid.sql.dialect.mysql.visitor.MySqlOutputVisitor.visit(), which used the iterator of HashMap. I fixed it by generating all possible combinations of strings that could be output by toString() function. The method is similar to [pull4574](https://github.com/alibaba/druid/pull/4574).