### PR TITLE
使用 SQLUtils.toSQLString 生成 SQL 少了一个 ")" 的问题

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -2060,7 +2060,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
         boolean withGroup = x.isWithinGroup();
         if (withGroup) {
-            print0(ucase ? ") WITHIN GROUP (" : " within group (");
+            print0(ucase ? ") WITHIN GROUP (" : ") within group (");
         }
 
         visitAggreateRest(x);


### PR DESCRIPTION
使用 SQLUtils.toSQLString 在带有小写的 within group 的情况下， 生成的 SQL 在 within group 前少了一个 ")" ，