### PR TITLE
springboot actuator dataSource metrics support durid

### DIFF
--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -56,4 +56,18 @@ public class DruidDataSourceAutoConfigure {
         LOGGER.info("Init DruidDataSource");
         return new DruidDataSourceWrapper();
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({MeterRegistry.class, DruidDataSource.class})
+    public DataSourcePoolMetadataProvider druidPoolDataSourceMetadataProvider() {
+        return (dataSource) -> {
+            DruidDataSource ds = DataSourceUnwrapper.unwrap(dataSource,
+                DruidDataSource.class);
+            if (ds != null) {
+                return new DruidDataSourcePoolMetadata(ds);
+            }
+            return null;
+        };
+    }
 }

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/metrics/DruidDataSourcePoolMetadata.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/metrics/DruidDataSourcePoolMetadata.java
@@ -1,0 +1,47 @@
+package com.alibaba.druid.spring.boot.autoconfigure.metrics;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import org.springframework.boot.jdbc.metadata.AbstractDataSourcePoolMetadata;
+
+/**
+ * @author hai
+ * @version 1.0
+ * Created on 2021/11/16 下午7:15
+ * @description
+ */
+public class DruidDataSourcePoolMetadata extends AbstractDataSourcePoolMetadata<DruidDataSource> {
+
+  /**
+   * Create an instance with the data source to use.
+   *
+   * @param dataSource the data source
+   */
+  public DruidDataSourcePoolMetadata(DruidDataSource dataSource) {
+    super(dataSource);
+  }
+
+  @Override
+  public Integer getActive() {
+    return getDataSource().getActiveCount();
+  }
+
+  @Override
+  public Integer getMax() {
+    return getDataSource().getMaxActive();
+  }
+
+  @Override
+  public Integer getMin() {
+    return getDataSource().getMinIdle();
+  }
+
+  @Override
+  public String getValidationQuery() {
+    return getDataSource().getValidationQuery();
+  }
+
+  @Override
+  public Boolean getDefaultAutoCommit() {
+    return getDataSource().isDefaultAutoCommit();
+  }
+}


### PR DESCRIPTION
Current spring boot actuator dataSource do not support durid, I add some file to support this.  when you use spring boot actuator and durid and prometheus , you can get durid info from endpoint "actuator/prometheus"!