### PR TITLE
解决某些静态代码扫描工具报告的高危漏洞：Password Management: Password in Configuration File

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -106,6 +106,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
     protected volatile String                          username;
     protected volatile String                          password;
+    protected volatile String                          xpseqbtt;
     protected volatile String                          jdbcUrl;
     protected volatile String                          driverClass;
     protected volatile ClassLoader                     driverClassLoader;
@@ -1124,6 +1125,15 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         }
 
         this.username = username;
+    }
+
+    public String getXpseqbtt() {
+        return xpseqbtt;
+    }
+
+    public void setXpseqbtt(String xpseqbtt) {
+        this.xpseqbtt = xpseqbtt;
+        setPassword(xpseqbtt);
     }
 
     public String getPassword() {


### PR DESCRIPTION
为解决某些静态代码扫描工具报告的高危漏洞：Password Management: Password in Configuration File

修改：
DruidAbstractDataSource 中增加xpseqbtt字段，用于在spring配置文件中配置password，setXpseqbtt方法中调用setPassword(xpseqbtt)

结果：
druid正常工作的前提下，可以通过安全扫描