### PR TITLE
适配actuator，解决DataSource health check failed：bad SQL grammar [SELECT 1…

### DIFF
--- a/druid-spring-boot-starter/pom.xml
+++ b/druid-spring-boot-starter/pom.xml
@@ -64,11 +64,17 @@
         </dependency>
 
         <dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/support/actuator/DruidDataSourcePoolMetadata.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/support/actuator/DruidDataSourcePoolMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Created on 2022年1月14日
+// $Id$
+package com.alibaba.druid.spring.boot.autoconfigure.support.actuator;
+
+import org.springframework.boot.autoconfigure.jdbc.metadata.AbstractDataSourcePoolMetadata;
+
+import com.alibaba.druid.pool.DruidDataSource;
+
+/**
+ * @author zero3h
+ */
+public class DruidDataSourcePoolMetadata extends AbstractDataSourcePoolMetadata<DruidDataSource> {
+
+    /**
+     * @param dataSource
+     */
+    public DruidDataSourcePoolMetadata(DruidDataSource dataSource){
+        super(dataSource);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadata#getActive()
+     */
+    @Override
+    public Integer getActive() {
+        return getDataSource().getActiveCount();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadata#getMax()
+     */
+    @Override
+    public Integer getMax() {
+        return getDataSource().getMaxActive();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadata#getMin()
+     */
+    @Override
+    public Integer getMin() {
+        return getDataSource().getMinIdle();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadata#getValidationQuery()
+     */
+    @Override
+    public String getValidationQuery() {
+        return getDataSource().getValidationQuery();
+    }
+
+    /**
+     * 兼容spring boot 2.0后新增的方法
+     * 
+     * @return
+     */
+    public Boolean getDefaultAutoCommit() {
+        return getDataSource().isDefaultAutoCommit();
+    }
+
+}

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/support/actuator/DruidDataSourcePoolMetadataProvider.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/support/actuator/DruidDataSourcePoolMetadataProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Created on 2022年1月14日
+// $Id$
+
+package com.alibaba.druid.spring.boot.autoconfigure.support.actuator;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadata;
+import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.alibaba.druid.pool.DruidDataSource;
+
+/**
+ * @author zero3h
+ */
+@Configuration
+@ConditionalOnClass({ Health.class, DruidDataSource.class })
+public class DruidDataSourcePoolMetadataProvider {
+
+    /**
+     * @return
+     */
+    @Bean
+    public DataSourcePoolMetadataProvider druidPoolDataSourceMetadataProvider() {
+        return new DataSourcePoolMetadataProvider() {
+
+            /*
+             * (non-Javadoc)
+             * @see org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvider#
+             * getDataSourcePoolMetadata(javax.sql.DataSource)
+             */
+            @Override
+            public DataSourcePoolMetadata getDataSourcePoolMetadata(DataSource dataSource) {
+                if (dataSource instanceof DruidDataSource) {
+                    return new DruidDataSourcePoolMetadata((DruidDataSource) dataSource);
+                }
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
新增支持读取配置spring.datasource.druid.validation-query来变更actuator中数据库健康检查默认存活检查语句