### PR TITLE
Fix a flaky test

### DIFF
--- a/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtilsTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/utils/JdbcUtilsTest.java
@@ -17,7 +17,7 @@ package com.alibaba.druid.bvt.utils;
 
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +54,7 @@ public class JdbcUtilsTest extends TestCase {
             Assert.assertEquals(0, list.size());
         }
         {
-            Map<String, Object> data = new HashMap<String, Object>();
+            Map<String, Object> data = new LinkedHashMap<String, Object>();
             data.put("id", 123);
             data.put("name", "高傲的羊");
             JdbcUtils.insertToTable(dataSource, "user", data);


### PR DESCRIPTION
**Problem Description:**

The function `insertToTable()` called in `JdbcUtilsTest.java:60 ` will iterate a `HashMap` by calling `toArray()`, but the iteration is non-deterministic thus causing different output. Therefore, this test is flaky since following assertions may fail unexpectedly. 

**Reproduce the failure**
One can check it using the [Nondex](https://github.com/TestingResearchIllinois/nondex):

```
mvn install -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.alibaba.druid.bvt.utils.JdbcUtilsTest#test_curd
```

**Solution:** 

Use `LinkedHashMap` instead of `HashMap`  so that the order of iteration will be preserved as that of elements being added.