### PR TITLE
Fixes #4195 again:  judging closing status at putLast method

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2184,7 +2184,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
     }
 
     boolean putLast(DruidConnectionHolder e, long lastActiveTimeMillis) {
-        if (poolingCount >= maxActive || e.discard || this.closed) {
+        if (poolingCount >= maxActive || e.discard || this.closed || this.closing) {
             return false;
         }
 

--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -3847,16 +3847,22 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                 throw new SQLException("interrupt", e);
             }
 
+            boolean result;
             try {
                 if (!this.isFillable(toCount)) {
                     JdbcUtils.close(holder.getConnection());
                     LOG.info("fill connections skip.");
                     break;
                 }
-                this.putLast(holder, System.currentTimeMillis());
+                result = this.putLast(holder, System.currentTimeMillis());
                 fillCount++;
             } finally {
                 lock.unlock();
+            }
+
+            if (!result) {
+                JdbcUtils.close(holder.getConnection());
+                LOG.info("connection fill failed.");
             }
         }
 


### PR DESCRIPTION
之前提交的PR #4196 只在put方法加了closing状态判断，漏了putLast方法修订，无论put方法还是putLast均需判断closing状态，切换数据库地址关闭DataSource期间，不能将旧DataSource的连接加入connection数组。
See #4195