### PR TITLE
refactor: Use `Collections#isEmpty()` instead of comparing `size()`

### DIFF
--- a/src/main/java/com/alibaba/druid/mock/handler/MySqlMockExecuteHandlerImpl.java
+++ b/src/main/java/com/alibaba/druid/mock/handler/MySqlMockExecuteHandlerImpl.java
@@ -60,7 +60,7 @@ public class MySqlMockExecuteHandlerImpl implements MockExecuteHandler {
             throw new SQLException("not support multi-statment. " + sql);
         }
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new SQLException("executeQueryError : " + sql);
         }
 

--- a/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1663,7 +1663,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
     public Connection createPhysicalConnection(String url, Properties info) throws SQLException {
         Connection conn;
-        if (getProxyFilters().size() == 0) {
+        if (getProxyFilters().isEmpty()) {
             conn = getDriver().connect(url, info);
         } else {
             conn = new FilterChainImpl(this).connection_connect(info);
@@ -1847,7 +1847,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         }
 
         Collection<String> initSqls = getConnectionInitSqls();
-        if (initSqls.size() == 0
+        if (initSqls.isEmpty()
                 && variables == null
                 && globalVariables == null) {
             return;

--- a/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -675,7 +675,7 @@ public class PagerUtils {
             SQLOrderBy orderBy = x.getOrderBy();
             SQLLimit limit = x.getLimit();
 
-            if (limit != null && (orderBy == null || orderBy.getItems().size() == 0)) {
+            if (limit != null && (orderBy == null || orderBy.getItems().isEmpty())) {
                 boolean subQueryHasOrderBy = false;
                 SQLTableSource from = x.getFrom();
                 if (from instanceof SQLSubqueryTableSource) {
@@ -747,7 +747,7 @@ public class PagerUtils {
                     orderBy = select.getOrderBy();
                 }
 
-                if (orderBy == null || orderBy.getItems().size() == 0) {
+                if (orderBy == null || orderBy.getItems().isEmpty()) {
                     unorderedLimitCount++;
                 }
             }
@@ -785,7 +785,7 @@ public class PagerUtils {
 
             SQLSelect select = (SQLSelect) parent;
 
-            if (select.getOrderBy() == null || select.getOrderBy().getItems().size() == 0) {
+            if (select.getOrderBy() == null || select.getOrderBy().getItems().isEmpty()) {
                 unorderedLimitCount++;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/SQLTransformUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLTransformUtils.java
@@ -158,7 +158,7 @@ public class SQLTransformUtils {
             dataType = new SQLDataTypeImpl("double");
 
         } else if (nameHash == FnvHash.Constants.NUMBER) {
-            if (argumentns.size() == 0) {
+            if (argumentns.isEmpty()) {
                 dataType = new SQLDataTypeImpl("decimal", 38);
             } else {
                 SQLExpr arg0 = argumentns.get(0);
@@ -230,7 +230,7 @@ public class SQLTransformUtils {
         } else if (nameHash == FnvHash.Constants.RAW) {
             int len;
 
-            if (argumentns.size() == 0) {
+            if (argumentns.isEmpty()) {
                 len = -1;
             } else if (argumentns.size() == 1) {
                 SQLExpr arg0 = argumentns.get(0);
@@ -267,7 +267,7 @@ public class SQLTransformUtils {
                 } else {
                     dataType = new SQLCharacterDataType("varchar", len);
                 }
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType("char");
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
@@ -289,7 +289,7 @@ public class SQLTransformUtils {
                 } else {
                     dataType = new SQLCharacterDataType("nvarchar", len);
                 }
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType("nchar");
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
@@ -462,7 +462,7 @@ public class SQLTransformUtils {
             dataType = new SQLDataTypeImpl(SQLDataType.Constants.DOUBLE_PRECISION);
 
         } else if (nameHash == FnvHash.Constants.NUMBER) {
-            if (argumentns.size() == 0) {
+            if (argumentns.isEmpty()) {
                 dataType = new SQLDataTypeImpl(SQLDataType.Constants.DECIMAL, 38);
             } else {
                 SQLExpr arg0 = argumentns.get(0);
@@ -536,7 +536,7 @@ public class SQLTransformUtils {
                     throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
                 }
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR, len);
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR);
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
@@ -558,7 +558,7 @@ public class SQLTransformUtils {
                 } else {
                     dataType = new SQLCharacterDataType(SQLDataType.Constants.TEXT);
                 }
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR);
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
@@ -684,7 +684,7 @@ public class SQLTransformUtils {
         }
 
         if (nameHashCode64 == FnvHash.Constants.CURRENT_TIMESTAMP) {
-            if (parameters.size() == 0 && x.getParent() instanceof SQLColumnDefinition) {
+            if (parameters.isEmpty() && x.getParent() instanceof SQLColumnDefinition) {
                 SQLDataType dataType = ((SQLColumnDefinition) x.getParent()).getDataType();
                 if (dataType.nameHashCode64() == FnvHash.Constants.TIMESTAMP
                         && dataType.getArguments().size() == 1) {
@@ -895,7 +895,7 @@ public class SQLTransformUtils {
                     throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
                 }
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR, len);
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR);
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));
@@ -917,7 +917,7 @@ public class SQLTransformUtils {
                 } else {
                     dataType = new SQLCharacterDataType(SQLDataType.Constants.TEXT);
                 }
-            } else if (argumentns.size() == 0) {
+            } else if (argumentns.isEmpty()) {
                 dataType = new SQLCharacterDataType(SQLDataType.Constants.CHAR);
             } else {
                 throw new UnsupportedOperationException(SQLUtils.toOracleString(x));

--- a/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -706,7 +706,7 @@ public class SQLUtils {
 
         List<SQLStatement> stmtList = parseStatements(sql, dbType);
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new IllegalArgumentException("not support empty-statement :" + sql);
         }
 
@@ -779,7 +779,7 @@ public class SQLUtils {
     public static String addSelectItem(String selectSql, String expr, String alias, boolean first, DbType dbType) {
         List<SQLStatement> stmtList = parseStatements(selectSql, dbType);
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new IllegalArgumentException("not support empty-statement :" + selectSql);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExpr.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExpr.java
@@ -462,7 +462,7 @@ public class SQLBinaryOpExpr extends SQLExprImpl implements SQLReplaceable, Seri
     }
 
     public static SQLExpr or(List<? extends SQLExpr> list) {
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             return null;
         }
         SQLExpr first = list.get(0);

--- a/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExprGroup.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOpExprGroup.java
@@ -158,7 +158,7 @@ public class SQLBinaryOpExprGroup extends SQLExprImpl implements SQLReplaceable 
             SQLUtils.replaceInParent(this, items.get(0));
         }
 
-        if (items.size() == 0) {
+        if (items.isEmpty()) {
             SQLUtils.replaceInParent(this, null);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAnalyzeTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAnalyzeTableStatement.java
@@ -66,7 +66,7 @@ public class SQLAnalyzeTableStatement extends SQLStatementImpl {
     }
 
     public SQLExprTableSource getTable() {
-        if (tableSources.size() == 0) {
+        if (tableSources.isEmpty()) {
             return null;
         }
 
@@ -86,7 +86,7 @@ public class SQLAnalyzeTableStatement extends SQLStatementImpl {
             table.setParent(this);
         }
 
-        if (tableSources.size() == 0) {
+        if (tableSources.isEmpty()) {
             if (table == null) {
                 return;
             }

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
@@ -525,7 +525,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
             if (element instanceof MySqlUnique) {
                 MySqlUnique unique = (MySqlUnique) element;
 
-                if (unique.getColumns().size() == 0) {
+                if (unique.getColumns().isEmpty()) {
                     continue;
                 }
 
@@ -671,7 +671,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
             }
         }
 
-        if (stmt.getItems().size() == 0) {
+        if (stmt.getItems().isEmpty()) {
             return null;
         }
 
@@ -1095,13 +1095,13 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
                 if (e instanceof SQLUnique) {
                     SQLUnique unique = (SQLUnique) e;
                     unique.applyDropColumn(column);
-                    if (unique.getColumns().size() == 0) {
+                    if (unique.getColumns().isEmpty()) {
                         tableElementList.remove(i);
                     }
                 } else if (e instanceof MySqlTableIndex) {
                     MySqlTableIndex index = (MySqlTableIndex) e;
                     index.applyDropColumn(column);
-                    if (index.getColumns().size() == 0) {
+                    if (index.getColumns().isEmpty()) {
                         tableElementList.remove(i);
                     }
                 }

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLDeleteStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLDeleteStatement.java
@@ -267,7 +267,7 @@ public class SQLDeleteStatement extends SQLStatementImpl implements SQLReplaceab
                     removedCount++;
                 }
             }
-            if (items.size() == 0) {
+            if (items.isEmpty()) {
                 where = null;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLInsertInto.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLInsertInto.java
@@ -164,14 +164,14 @@ public abstract class SQLInsertInto extends SQLStatementImpl implements SQLRepla
     }
 
     public ValuesClause getValues() {
-        if (valuesList.size() == 0) {
+        if (valuesList.isEmpty()) {
             return null;
         }
         return valuesList.get(0);
     }
 
     public void setValues(ValuesClause values) {
-        if (valuesList.size() == 0) {
+        if (valuesList.isEmpty()) {
             valuesList.add(values);
         } else {
             valuesList.set(0, values);

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelect.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelect.java
@@ -217,10 +217,10 @@ public class SQLSelect extends SQLObjectImpl implements SQLDbTypedObject {
 
     public boolean isSimple() {
         return withSubQuery == null
-                && (hints == null || hints.size() == 0)
+                && (hints == null || hints.isEmpty())
                 && restriction == null
                 && (!forBrowse)
-                && (forXmlOptions == null || forXmlOptions.size() == 0)
+                && (forXmlOptions == null || forXmlOptions.isEmpty())
                 && xmlPath == null
                 && rowCount == null
                 && offset == null;

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectQueryBlock.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectQueryBlock.java
@@ -176,7 +176,7 @@ public class SQLSelectQueryBlock extends SQLSelectQueryBase implements SQLReplac
                                 }
                             }
 
-                            if (andList.size() == 0) {
+                            if (andList.isEmpty()) {
                                 SQLUtils.replaceInParent(item, new SQLBooleanExpr(false));
                                 return;
                             }
@@ -1251,7 +1251,7 @@ public class SQLSelectQueryBlock extends SQLSelectQueryBase implements SQLReplac
                     removedCount++;
                 }
             }
-            if (items.size() == 0) {
+            if (items.isEmpty()) {
                 where = null;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnionQuery.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnionQuery.java
@@ -75,7 +75,7 @@ public class SQLUnionQuery extends SQLSelectQueryBase implements SQLDbTypedObjec
     }
 
     public SQLSelectQuery getLeft() {
-        if (relations.size() == 0) {
+        if (relations.isEmpty()) {
             return null;
         }
         return relations.get(0);
@@ -86,7 +86,7 @@ public class SQLUnionQuery extends SQLSelectQueryBase implements SQLDbTypedObjec
             left.setParent(this);
         }
 
-        if (relations.size() == 0) {
+        if (relations.isEmpty()) {
             relations.add(left);
         } else if (relations.size() <= 2) {
             relations.set(0, left);
@@ -111,7 +111,7 @@ public class SQLUnionQuery extends SQLSelectQueryBase implements SQLDbTypedObjec
             right.setParent(this);
         }
 
-        if (relations.size() == 0) {
+        if (relations.isEmpty()) {
             relations.add(null);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
@@ -312,7 +312,7 @@ public class SQLUpdateStatement extends SQLStatementImpl implements SQLReplaceab
                     removedCount++;
                 }
             }
-            if (items.size() == 0) {
+            if (items.isEmpty()) {
                 where = null;
             }
 

--- a/src/main/java/com/alibaba/druid/sql/builder/impl/SQLDeleteBuilderImpl.java
+++ b/src/main/java/com/alibaba/druid/sql/builder/impl/SQLDeleteBuilderImpl.java
@@ -42,7 +42,7 @@ public class SQLDeleteBuilderImpl implements SQLDeleteBuilder {
     public SQLDeleteBuilderImpl(String sql, DbType dbType){
         List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new IllegalArgumentException("not support empty-statement :" + sql);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/builder/impl/SQLSelectBuilderImpl.java
+++ b/src/main/java/com/alibaba/druid/sql/builder/impl/SQLSelectBuilderImpl.java
@@ -40,7 +40,7 @@ public class SQLSelectBuilderImpl implements SQLSelectBuilder {
     public SQLSelectBuilderImpl(String sql, DbType dbType){
         List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new IllegalArgumentException("not support empty-statement :" + sql);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/builder/impl/SQLUpdateBuilderImpl.java
+++ b/src/main/java/com/alibaba/druid/sql/builder/impl/SQLUpdateBuilderImpl.java
@@ -45,7 +45,7 @@ public class SQLUpdateBuilderImpl extends SQLBuilderImpl implements SQLUpdateBui
     public SQLUpdateBuilderImpl(String sql, DbType dbType){
         List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
 
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             throw new IllegalArgumentException("not support empty-statement :" + sql);
         }
 

--- a/src/main/java/com/alibaba/druid/sql/dialect/db2/parser/DB2StatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/db2/parser/DB2StatementParser.java
@@ -70,7 +70,7 @@ public class DB2StatementParser extends SQLStatementParser {
         SQLAlterTableAlterColumn alterColumn = new SQLAlterTableAlterColumn();
         alterColumn.setColumn(column);
 
-        if (column.getDataType() == null && column.getConstraints().size() == 0) {
+        if (column.getDataType() == null && column.getConstraints().isEmpty()) {
             if (lexer.token() == Token.SET) {
                 lexer.nextToken();
                 if (lexer.token() == Token.NOT) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/h2/visitor/H2OutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/h2/visitor/H2OutputVisitor.java
@@ -58,7 +58,7 @@ public class H2OutputVisitor extends SQLASTOutputVisitor implements H2ASTVisitor
         }
 
         List<SQLInsertStatement.ValuesClause> valuesClauseList = x.getValuesList();
-        if (valuesClauseList.size() != 0) {
+        if (!valuesClauseList.isEmpty()) {
             println();
             print0(ucase ? "VALUES " : "values ");
             int size = valuesClauseList.size();

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlKillStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlKillStatement.java
@@ -48,7 +48,7 @@ public class MySqlKillStatement extends SQLStatementImpl {
     }
 
     public void setThreadId(SQLExpr threadId) {
-        if (this.threadIds.size() == 0) {
+        if (this.threadIds.isEmpty()) {
             this.threadIds.add(threadId);
             return;
         }

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -1706,7 +1706,7 @@ public class MySqlStatementParser extends SQLStatementParser {
                     break;
             }
             if (hints.size() >= 1
-                    && statementList.size() == 0
+                    && statementList.isEmpty()
                     && acceptHint) {
                 SQLCommentHint hint = hints.get(0);
                 String hintText = hint.getText().toUpperCase();
@@ -2346,7 +2346,7 @@ public class MySqlStatementParser extends SQLStatementParser {
                 break;
             }
 
-            if (stmt.getTables().size() != 0) {
+            if (!stmt.getTables().isEmpty()) {
                 if (lexer.token() == Token.FOR) {
                     lexer.nextToken();
                     acceptIdentifier("EXPORT");

--- a/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -1244,7 +1244,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         }
 
         List<SQLExpr> duplicateKeyUpdate = x.getDuplicateKeyUpdate();
-        if (duplicateKeyUpdate.size() != 0) {
+        if (!duplicateKeyUpdate.isEmpty()) {
             println();
             print0(ucase ? "ON DUPLICATE KEY UPDATE " : "on duplicate key update ");
             for (int i = 0, size = duplicateKeyUpdate.size(); i < size; ++i) {
@@ -1278,7 +1278,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
                         SQLExpr value = values.get(i);
                         if (value instanceof SQLLiteralExpr || value instanceof SQLVariantRefExpr) {
                             continue;
-                        } else if (value instanceof SQLMethodInvokeExpr && ((SQLMethodInvokeExpr) value).getArguments().size() == 0) {
+                        } else if (value instanceof SQLMethodInvokeExpr && ((SQLMethodInvokeExpr) value).getArguments().isEmpty()) {
                             continue;
                         }
                         allConst = false;
@@ -1433,13 +1433,13 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             print0(ucase ? " LINES" : " lines");
         }
 
-        if (x.getColumns().size() != 0) {
+        if (!x.getColumns().isEmpty()) {
             print0(" (");
             printAndAccept(x.getColumns(), ", ");
             print(')');
         }
 
-        if (x.getSetList().size() != 0) {
+        if (!x.getSetList().isEmpty()) {
             print0(ucase ? " SET " : " set ");
             printAndAccept(x.getSetList(), ", ");
         }
@@ -1516,7 +1516,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         }
 
         List<SQLInsertStatement.ValuesClause> valuesClauseList = x.getValuesList();
-        if (valuesClauseList.size() != 0) {
+        if (!valuesClauseList.isEmpty()) {
             println();
             print0(ucase ? "VALUES " : "values ");
             int size = valuesClauseList.size();
@@ -1758,7 +1758,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             x.getRowsIdentifiedBy().accept(this);
         }
 
-        if (x.getSetList().size() != 0) {
+        if (!x.getSetList().isEmpty()) {
             print0(ucase ? " SET " : " set ");
             printAndAccept(x.getSetList(), ", ");
         }
@@ -4218,7 +4218,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         }
 
         List<SQLParameter> parameters = x.getParameters();
-        if (parameters.size() != 0) {
+        if (!parameters.isEmpty()) {
             this.indentCount++;
             if (parent instanceof SQLCreateProcedureStatement) {
                 printIndent();
@@ -4600,7 +4600,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             print(")");
         }
 
-        if (x.getOptions().size() != 0) {
+        if (!x.getOptions().isEmpty()) {
             println();
             print0(ucase ? "SUBPARTITION OPTIONS (" : "subpartition options (");
             printAndAccept(x.getOptions(), ", ");

--- a/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -2157,7 +2157,7 @@ public class OracleStatementParser extends SQLStatementParser {
         while (lexer.token() == Token.INTO) {
             OracleMultiInsertStatement.InsertIntoClause clause = new OracleMultiInsertStatement.InsertIntoClause();
 
-            boolean acceptSubQuery = stmt.getEntries().size() == 0;
+            boolean acceptSubQuery = stmt.getEntries().isEmpty();
             parseInsert0(clause, acceptSubQuery);
 
             clause.setReturning(parseReturningClause());

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGInsertStatement.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGInsertStatement.java
@@ -68,14 +68,14 @@ public class PGInsertStatement extends SQLInsertStatement implements PGSQLStatem
 
 
     public ValuesClause getValues() {
-        if (valuesList.size() == 0) {
+        if (valuesList.isEmpty()) {
             return null;
         }
         return valuesList.get(0);
     }
 
     public void setValues(ValuesClause values) {
-        if (valuesList.size() == 0) {
+        if (valuesList.isEmpty()) {
             valuesList.add(values);
         } else {
             valuesList.set(0, values);

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -459,7 +459,7 @@ public class PGSQLStatementParser extends SQLStatementParser {
         SQLAlterTableAlterColumn alterColumn = new SQLAlterTableAlterColumn();
         alterColumn.setColumn(column);
 
-        if (column.getDataType() == null && column.getConstraints().size() == 0) {
+        if (column.getDataType() == null && column.getConstraints().isEmpty()) {
             if (lexer.token() == Token.SET) {
                 lexer.nextToken();
                 if (lexer.token() == Token.NOT) {

--- a/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -435,7 +435,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
                 print('(');
                 expr.accept(this);
                 print(')');
-            } else if (expr instanceof PGTypeCastExpr && dataType.getArguments().size() == 0) {
+            } else if (expr instanceof PGTypeCastExpr && dataType.getArguments().isEmpty()) {
                 dataType.accept(this);
                 print('(');
                 visit((PGTypeCastExpr) expr);

--- a/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
@@ -156,7 +156,7 @@ public class SQLServerOutputVisitor extends SQLASTOutputVisitor implements SQLSe
             x.getOutput().accept(this);
         }
 
-        if (x.getValuesList().size() != 0) {
+        if (!x.getValuesList().isEmpty()) {
             println();
             print0(ucase ? "VALUES " : "values ");
             for (int i = 0, size = x.getValuesList().size(); i < size; ++i) {

--- a/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1113,7 +1113,7 @@ public class SQLSelectParser extends SQLParser {
                 tableSource.setAlias(alias);
 
                 if (tableSource instanceof SQLValuesTableSource
-                        && ((SQLValuesTableSource) tableSource).getColumns().size() == 0) {
+                        && ((SQLValuesTableSource) tableSource).getColumns().isEmpty()) {
                     SQLValuesTableSource values = (SQLValuesTableSource) tableSource;
                     accept(Token.LPAREN);
                     this.exprParser.names(values.getColumns(), values);
@@ -1351,7 +1351,7 @@ public class SQLSelectParser extends SQLParser {
                             tableSource.setAlias(alias);
 
                             if ((tableSource instanceof SQLValuesTableSource)
-                                    && ((SQLValuesTableSource) tableSource).getColumns().size() == 0) {
+                                    && ((SQLValuesTableSource) tableSource).getColumns().isEmpty()) {
                                 SQLValuesTableSource values = (SQLValuesTableSource) tableSource;
                                 accept(Token.LPAREN);
                                 this.exprParser.names(values.getColumns(), values);
@@ -1565,7 +1565,7 @@ public class SQLSelectParser extends SQLParser {
                 if (rightTableSource instanceof SQLValuesTableSource
                         && (lexer.token == Token.AS || lexer.token == Token.IDENTIFIER)
                         && rightTableSource.getAlias() == null
-                        && ((SQLValuesTableSource) rightTableSource).getColumns().size() == 0
+                        && ((SQLValuesTableSource) rightTableSource).getColumns().isEmpty()
                 ) {
                     if (lexer.token == Token.AS) {
                         lexer.nextToken();
@@ -1708,7 +1708,7 @@ public class SQLSelectParser extends SQLParser {
                         } else if (rightTableSource instanceof SQLExprTableSource
                                 && ((SQLExprTableSource) rightTableSource).getExpr() instanceof SQLMethodInvokeExpr) {
                             List<SQLName> columns = ((SQLExprTableSource) rightTableSource).getColumns();
-                            if (columns.size() == 0) {
+                            if (columns.isEmpty()) {
                                 lexer.nextToken();
                                 this.exprParser.names(columns, rightTableSource);
                                 accept(Token.RPAREN);

--- a/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
@@ -152,7 +152,7 @@ public class ParameterizedOutputVisitorUtils {
         }
 
         List<SQLStatement> statementList = parser.parseStatementList();
-        if (statementList.size() == 0) {
+        if (statementList.isEmpty()) {
             return sql;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -684,7 +684,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         boolean isRoot = parent instanceof SQLSelectQueryBlock || parent instanceof SQLBinaryOpExprGroup;
 
         List<SQLExpr> items = x.getItems();
-        if (items.size() == 0) {
+        if (items.isEmpty()) {
             print("true");
             return false;
         }
@@ -4801,7 +4801,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         }
 
         final List<List<SQLAssignItem>> storedBy = x.getStoredBy();
-        if (storedBy.size() != 0) {
+        if (!storedBy.isEmpty()) {
             println();
             print0(ucase ? "STORED BY " : "stored by ");
 
@@ -6719,7 +6719,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterTableEnableLifecycle x) {
-        if (x.getPartition().size() != 0) {
+        if (!x.getPartition().isEmpty()) {
             print0(ucase ? "PARTITION (" : "partition (");
             printAndAccept(x.getPartition(), ", ");
             print0(") ");
@@ -6731,7 +6731,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterTableDisableLifecycle x) {
-        if (x.getPartition().size() != 0) {
+        if (!x.getPartition().isEmpty()) {
             print0(ucase ? "PARTITION (" : "partition (");
             printAndAccept(x.getPartition(), ", ");
             print0(") ");
@@ -6743,7 +6743,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterTablePartition x) {
-        if (x.getPartition().size() != 0) {
+        if (!x.getPartition().isEmpty()) {
             print0(ucase ? "PARTITION (" : "partition (");
             printAndAccept(x.getPartition(), ", ");
             print0(") ");
@@ -6753,13 +6753,13 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterTablePartitionSetProperties x) {
-        if (x.getPartition().size() != 0) {
+        if (!x.getPartition().isEmpty()) {
             print0(ucase ? "PARTITION (" : "partition (");
             printAndAccept(x.getPartition(), ", ");
             print0(") ");
         }
 
-        if (x.getPartitionProperties().size() != 0) {
+        if (!x.getPartitionProperties().isEmpty()) {
             print0(ucase ? "SET PARTITIONPROPERTIES (" : "set partitionproperties (");
             printAndAccept(x.getPartitionProperties(), ", ");
             print0(") ");
@@ -6770,7 +6770,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     @Override
     public boolean visit(SQLAlterTableTouch x) {
         print0(ucase ? "TOUCH" : "touch");
-        if (x.getPartition().size() != 0) {
+        if (!x.getPartition().isEmpty()) {
             print0(ucase ? " PARTITION (" : " partition (");
             printAndAccept(x.getPartition(), ", ");
             print(')');
@@ -7290,7 +7290,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     @Override
     public boolean visit(SQLPartitionByRange x) {
         SQLExpr interval = x.getInterval();
-        if (x.getColumns().size() == 0
+        if (x.getColumns().isEmpty()
                 && (interval instanceof SQLBetweenExpr || interval instanceof SQLMethodInvokeExpr))
         {
             interval.accept(this);
@@ -8911,7 +8911,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLBlockStatement x) {
-        if (x.getParameters().size() != 0) {
+        if (!x.getParameters().isEmpty()) {
             this.indentCount++;
             if (x.getParent() instanceof SQLCreateProcedureStatement) {
                 SQLCreateProcedureStatement procedureStatement = (SQLCreateProcedureStatement) x.getParent();

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLDataTypeValidator.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLDataTypeValidator.java
@@ -127,7 +127,7 @@ public class SQLDataTypeValidator extends SQLASTVisitorAdapter {
     }
 
     public static void check(List<SQLStatement> stmtList) {
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             return;
         }
 
@@ -138,7 +138,7 @@ public class SQLDataTypeValidator extends SQLASTVisitorAdapter {
     }
 
     public static void check(List<SQLStatement> stmtList, DbType dbType) {
-        if (stmtList.size() == 0) {
+        if (stmtList.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/Ascii.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/Ascii.java
@@ -27,7 +27,7 @@ public class Ascii implements Function {
     public final static Ascii instance = new Ascii();
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
-        if (x.getArguments().size() == 0) {
+        if (x.getArguments().isEmpty()) {
             return SQLEvalVisitor.EVAL_ERROR;
         }
         SQLExpr param = x.getArguments().get(0);

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/Char.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/Char.java
@@ -28,7 +28,7 @@ public class Char implements Function {
     public final static Char instance = new Char();
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
-        if (x.getArguments().size() == 0) {
+        if (x.getArguments().isEmpty()) {
             return SQLEvalVisitor.EVAL_ERROR;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/If.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/If.java
@@ -32,7 +32,7 @@ public class If implements Function {
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
         final List<SQLExpr> arguments = x.getArguments();
-        if (arguments.size() == 0) {
+        if (arguments.isEmpty()) {
             return EVAL_ERROR;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/Isnull.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/Isnull.java
@@ -32,7 +32,7 @@ public class Isnull implements Function {
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
         final List<SQLExpr> arguments = x.getArguments();
-        if (arguments.size() == 0) {
+        if (arguments.isEmpty()) {
             return EVAL_ERROR;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/OneParamFunctions.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/OneParamFunctions.java
@@ -32,7 +32,7 @@ public class OneParamFunctions implements Function {
     public final static OneParamFunctions instance = new OneParamFunctions();
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
-        if (x.getArguments().size() == 0) {
+        if (x.getArguments().isEmpty()) {
             return SQLEvalVisitor.EVAL_ERROR;
         }
 

--- a/src/main/java/com/alibaba/druid/sql/visitor/functions/ToDate.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/functions/ToDate.java
@@ -36,7 +36,7 @@ public class ToDate implements Function {
 
     public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
         final List<SQLExpr> arguments = x.getArguments();
-        if (arguments.size() == 0) {
+        if (arguments.isEmpty()) {
             return EVAL_ERROR;
         }
 

--- a/src/main/java/com/alibaba/druid/support/calcite/CalciteMySqlNodeVisitor.java
+++ b/src/main/java/com/alibaba/druid/support/calcite/CalciteMySqlNodeVisitor.java
@@ -405,7 +405,7 @@ public class CalciteMySqlNodeVisitor extends MySqlASTVisitorAdapter {
             List<SQLName> columns = x.getColumns();
 
             SqlNode[] operands;
-            if (columns.size() == 0) {
+            if (columns.isEmpty()) {
                 operands = new SqlNode[] { sqlNode, aliasIdentifier };
             } else {
                 operands = new SqlNode[columns.size() + 2];

--- a/src/main/java/com/alibaba/druid/support/console/DruidStat.java
+++ b/src/main/java/com/alibaba/druid/support/console/DruidStat.java
@@ -83,7 +83,7 @@ public class DruidStat {
        
         if (option.printActiveConn()) {
             List<List<String>> content = (List<List<String>>) invokeService(jmxConn, Option.ACTIVE_CONN);
-			if (content == null || content.size() == 0 ) {
+			if (content == null || content.isEmpty() ) {
 				out.println("目前无活动中的数据库连接");
 			} else {
 				TabledDataPrinter.printActiveConnStack(content, option);

--- a/src/main/java/com/alibaba/druid/support/http/ResourceServlet.java
+++ b/src/main/java/com/alibaba/druid/support/http/ResourceServlet.java
@@ -255,7 +255,7 @@ public abstract class ResourceServlet extends HttpServlet {
             boolean ipV6 = remoteAddress != null && remoteAddress.indexOf(':') != -1;
 
             if (ipV6) {
-                return "0:0:0:0:0:0:0:1".equals(remoteAddress) || (denyList.size() == 0 && allowList.size() == 0);
+                return "0:0:0:0:0:0:0:1".equals(remoteAddress) || (denyList.isEmpty() && allowList.isEmpty());
             }
 
             IPAddress ipAddress = new IPAddress(remoteAddress);

--- a/src/main/java/com/alibaba/druid/support/monitor/dao/MonitorDaoJdbcImpl.java
+++ b/src/main/java/com/alibaba/druid/support/monitor/dao/MonitorDaoJdbcImpl.java
@@ -498,7 +498,7 @@ public class MonitorDaoJdbcImpl implements MonitorDao {
     }
 
     private void save(BeanInfo beanInfo, MonitorContext ctx, List<?> list) {
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/alibaba/druid/support/opds/udf/ExportConditions.java
+++ b/src/main/java/com/alibaba/druid/support/opds/udf/ExportConditions.java
@@ -60,7 +60,7 @@ public class ExportConditions extends UDF {
                 row.add(column.getTable());
                 row.add(column.getName());
                 row.add(operator);
-                if (values.size() == 0) {
+                if (values.isEmpty()) {
                     row.add(null);
                 } else if (values.size() == 1) {
                     if (compactValues != null && compactValues.booleanValue()) {

--- a/src/main/java/com/alibaba/druid/support/opds/udf/SqlTypeUDF.java
+++ b/src/main/java/com/alibaba/druid/support/opds/udf/SqlTypeUDF.java
@@ -155,7 +155,7 @@ public class SqlTypeUDF extends UDF {
         try {
             List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
 
-            if (stmtList.size() == 0) {
+            if (stmtList.isEmpty()) {
                 return SQLType.EMPTY.name();
             }
 

--- a/src/test/java/com/alibaba/druid/bvt/bug/Issue1759.java
+++ b/src/test/java/com/alibaba/druid/bvt/bug/Issue1759.java
@@ -19,6 +19,6 @@ public class Issue1759 extends TestCase {
 
         WallCheckResult result1 = provider.check(sql);
 
-        assertTrue(result1.getViolations().size() == 0);
+        assertTrue(result1.getViolations().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateCheckTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateCheckTest.java
@@ -24,7 +24,7 @@ public class WallUpdateCheckTest extends TestCase {
     public void test_update_check_handler() throws Exception {
         {
             WallCheckResult result = wallProvider.check("update t_orders set status = 3 where id = 3 and status = 4");
-            assertTrue(result.getViolations().size() == 0);
+            assertTrue(result.getViolations().isEmpty());
         }
         wallProvider.getConfig().setUpdateCheckHandler(new WallUpdateCheckHandler() {
 
@@ -46,7 +46,7 @@ public class WallUpdateCheckTest extends TestCase {
         });
         {
             WallCheckResult result = wallProvider.check("update t_orders set status = 3 where id = 3 and status = 4");
-            assertTrue(result.getViolations().size() == 0);
+            assertTrue(result.getViolations().isEmpty());
         }
         assertEquals(0, wallProvider.getWhiteListHitCount());
         assertEquals(0, wallProvider.getBlackListHitCount());
@@ -61,11 +61,11 @@ public class WallUpdateCheckTest extends TestCase {
         });
         {
             WallCheckResult result = wallProvider.check("update t_orders set status = 3 where id = 3 and status in (1, 2)");
-            assertTrue(result.getViolations().size() == 0);
+            assertTrue(result.getViolations().isEmpty());
         }
         {
             WallCheckResult result = wallProvider.check("update t_orders set status = 3 where id = 3 and status = 3 and status in (3, 4)");
-            assertTrue(result.getViolations().size() == 0);
+            assertTrue(result.getViolations().isEmpty());
         }
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_question_placeholder.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_question_placeholder.java
@@ -32,7 +32,7 @@ public class PagerUtilsTest_Limit_mysql_question_placeholder extends TestCase {
             Assert.fail(e.getMessage());
             return;
         }
-        if (statements == null || statements.size() == 0){
+        if (statements == null || statements.isEmpty()){
             Assert.fail("no sql found!");
             return;
         }

--- a/src/test/java/com/alibaba/druid/bvt/sql/mysql/DropTableTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/mysql/DropTableTest.java
@@ -49,7 +49,7 @@ public class DropTableTest extends MysqlTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("films")).getDropCount() == 1);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("distributors")).getDropCount() == 1);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 
    

--- a/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsListResourcesTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsListResourcesTest.java
@@ -91,7 +91,7 @@ public class OdpsListResourcesTest extends TestCase {
                 , SQLParserFeature.EnableMultiUnion
                 , SQLParserFeature.KeepComments);
         List<SQLStatement> statementList = parser.parseStatementList();
-        if (statementList.size() == 0) {
+        if (statementList.isEmpty()) {
             throw new Exception("empty");
         }
         SQLStatement stmt = statementList.get(0);

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/DropTableTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/DropTableTest.java
@@ -49,7 +49,7 @@ public class DropTableTest extends PGTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("films")).getDropCount() == 1);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("distributors")).getDropCount() == 1);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 
    

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGDeleteTest2.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGDeleteTest2.java
@@ -46,7 +46,7 @@ public class PGDeleteTest2 extends PGTest {
 
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("tasks")));
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 
     

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGDeleteTest7.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PGDeleteTest7.java
@@ -50,7 +50,7 @@ public class PGDeleteTest7 extends PGTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("foo")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("bar")));
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
         
 //        Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("products", "date")));
     }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/TruncateTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/TruncateTest.java
@@ -46,7 +46,7 @@ public class TruncateTest extends PGTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("bigtable")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("fattable")));
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 
     public void test_1() throws Exception {
@@ -68,7 +68,7 @@ public class TruncateTest extends PGTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("bigtable")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("fattable")));
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 
     public void test_2() throws Exception {
@@ -89,6 +89,6 @@ public class TruncateTest extends PGTest {
 
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("othertable")));
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGAlterTableDropConstraint.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGAlterTableDropConstraint.java
@@ -33,6 +33,6 @@ public class PGAlterTableDropConstraint extends PGTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("products")).getDropCount() == 0);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("products")).getAlterCount() == 1);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGAlterTableRenameTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGAlterTableRenameTest.java
@@ -33,6 +33,6 @@ public class PGAlterTableRenameTest extends PGTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("products")).getDropCount() == 0);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("products")).getAlterCount() == 1);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGDropTableIfExistsTest.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGDropTableIfExistsTest.java
@@ -32,6 +32,6 @@ public class PGDropTableIfExistsTest extends PGTest {
         
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("t_report_1_19")).getDropCount() == 1);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGGrantTest0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGGrantTest0.java
@@ -33,6 +33,6 @@ public class PGGrantTest0 extends PGTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("accounts")).getDropCount() == 0);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("accounts")).getAlterCount() == 0);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGRovokeTest0.java
+++ b/src/test/java/com/alibaba/druid/bvt/sql/postgresql/ddl/PGRovokeTest0.java
@@ -33,6 +33,6 @@ public class PGRovokeTest0 extends PGTest {
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("accounts")).getDropCount() == 0);
         Assert.assertTrue(visitor.getTables().get(new TableStat.Name("accounts")).getAlterCount() == 0);
 
-        Assert.assertTrue(visitor.getColumns().size() == 0);
+        Assert.assertTrue(visitor.getColumns().isEmpty());
     }
 }

--- a/src/test/java/com/alibaba/druid/sql/TestMigrate.java
+++ b/src/test/java/com/alibaba/druid/sql/TestMigrate.java
@@ -228,7 +228,7 @@ public class TestMigrate extends OracleTest {
     }
 
     public void insert(List<Record> list) throws Exception {
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             return;
         }
 

--- a/src/test/java/com/alibaba/druid/sql/TestTransform.java
+++ b/src/test/java/com/alibaba/druid/sql/TestTransform.java
@@ -330,7 +330,7 @@ public class TestTransform extends OracleTest {
     }
 
     public void insert(List<Record> list) throws Exception {
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             return;
         }
 

--- a/src/test/java/com/alibaba/druid/sql/parser/SQLMergeTest.java
+++ b/src/test/java/com/alibaba/druid/sql/parser/SQLMergeTest.java
@@ -141,7 +141,7 @@ public class SQLMergeTest extends TestCase {
                     print(")");
                 }
 
-                if (x.getValuesList().size() != 0) {
+                if (!x.getValuesList().isEmpty()) {
                     print(" VALUES ");
                     int size = x.getValuesList().size();
                     if (size == 0) {
@@ -160,7 +160,7 @@ public class SQLMergeTest extends TestCase {
                     x.getQuery().accept(this);
                 }
 
-                if (x.getDuplicateKeyUpdate().size() != 0) {
+                if (!x.getDuplicateKeyUpdate().isEmpty()) {
                     print(" ON DUPLICATE KEY UPDATE ");
                     printAndAccept(x.getDuplicateKeyUpdate(), ", ");
                 }

--- a/src/test/java/com/alibaba/druid/test/wall/PGWallTest.java
+++ b/src/test/java/com/alibaba/druid/test/wall/PGWallTest.java
@@ -16,6 +16,6 @@ public class PGWallTest {
         WallProvider provider = new PGWallProvider(new WallConfig(PGWallProvider.DEFAULT_CONFIG_DIR));
         String sql = "CREATE TABLE test_pg_wall (col_int INT NOT NULL, col_double_x DOUBLE PRECISION NOT NULL DEFAULT 0, col_varchar VARCHAR(200) NULL)";
         WallCheckResult result = provider.check(sql);
-        Assert.assertTrue(result.getViolations().size() == 0);
+        Assert.assertTrue(result.getViolations().isEmpty());
     }
 }


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections



Created with: [Moderne](https://app.moderne.io)