### PR TITLE
在 DB2 数据库 INTERVAL 表达式输出时，将 VALUE 用括号包装

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitor.java
@@ -153,7 +153,9 @@ public class DB2OutputVisitor extends SQLASTOutputVisitor implements DB2ASTVisit
 
     public boolean visit(SQLIntervalExpr x) {
         SQLExpr value = x.getValue();
+        print('(');
         value.accept(this);
+        print(')');
 
         SQLIntervalUnit unit = x.getUnit();
         if (unit != null) {

--- a/src/test/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitorTest.java
+++ b/src/test/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitorTest.java
@@ -1,0 +1,59 @@
+package com.alibaba.druid.sql.dialect.db2.visitor;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author abomb4 2022-06-19
+ */
+public class DB2OutputVisitorTest {
+
+    @Test
+    public void test() {
+
+        List<TestCase> testCases = Arrays.asList(
+                new TestCase("interval 表达式应该带括号 select",
+                        "SELECT A, B, C FROM D WHERE C < CURRENT TIMESTAMP + (10 * 60) SECONDS",
+                        "SELECT A, B, C FROM D WHERE C < CURRENT TIMESTAMP + (10 * 60) SECONDS"),
+                new TestCase("interval 表达式应该带括号 insert",
+                        "INSERT INTO TEST VALUES (1, CURRENT TIMESTAMP + ((10 + 60) SECONDS))",
+                        "INSERT INTO TEST VALUES (1, CURRENT TIMESTAMP + (10 + 60) SECONDS)"),
+                new TestCase("interval 表达式应该带括号 update",
+                        "UPDATE test SET created = CURRENT TIMESTAMP + 10 SECONDS WHERE created < CURRENT TIMESTAMP + (10 * 60) SECONDS",
+                        "UPDATE test SET created = CURRENT TIMESTAMP + (10) SECONDS WHERE created < CURRENT TIMESTAMP + (10 * 60) SECONDS")
+        );
+
+        for (TestCase testCase : testCases) {
+            SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(testCase.origin, DbType.db2);
+            StringBuilder builder = new StringBuilder();
+            DB2OutputVisitor visitor = new DB2OutputVisitor(builder);
+            visitor.setUppCase(false);
+            visitor.setPrettyFormat(false);
+            visitor.setParameterized(false);
+            SQLStatement stmt = parser.parseStatement();
+            stmt.accept(visitor);
+            String result = builder.toString();
+            Assert.assertEquals(testCase.name, testCase.expected, result);
+        }
+        System.out.println("DB2 Interval test ok.");
+    }
+
+    private static class TestCase {
+        String name;
+        String origin;
+        String expected;
+
+        public TestCase(String name, String origin, String expected) {
+            this.name = name;
+            this.origin = origin;
+            this.expected = expected;
+        }
+    }
+}


### PR DESCRIPTION
修复打印 DB2 的 SQL 时，INTERVAL 输出不正确的问题。
以原始 SQL 为说明：
INSERT INTO test VALUES (1, CURRENT TIMESTAMP + (10 * 60) SECONDS)
修复前输出：
INSERT INTO test VALUES (1, CURRENT TIMESTAMP + 10 * 60 SECONDS)
这个语句是不能用的，会报“SQLCODE=-182, SQLSTATE=42816”。
修复后输出为：
INSERT INTO test VALUES (1, CURRENT TIMESTAMP + (10 * 60) SECONDS)

可使用 IBM 官方的 DB2 Docker 镜像进行快速验证。（https://hub.docker.com/r/ibmcom/db2）