### PR TITLE
clickhouse cluster view 语法解析错误

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -2316,6 +2316,12 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             visit(subQuery);
             this.indentCount--;
             println();
+        } else if (parent instanceof SQLMethodInvokeExpr) {
+            this.indentCount++;
+            println();
+            visit(subQuery);
+            this.indentCount--;
+            println();
         } else {
             print('(');
             this.indentCount++;


### PR DESCRIPTION
clickhouse cluster view 语法SQL
类似，select a from cluster('test', view( select a from table))

经过SqlParser解析后
SELECT a
FROM cluster('test', view((
	SELECT a
	FROM table
)))
view 表达式后多了一对括号。

view 为 SQLMethodInvokeExpr， 参数为 SQLQueryExpr
SQLASTOutputVisitor 遍历view expr 时会因为SQLMethodInvokeExpr 加上一对括号
遍历SQLQueryExpr 时还会加上一对括号，导致上面的错误。

如果SQLQueryExpr 的parent 为 SQLMethodInvokeExpr 时，取消后者补充括号的逻辑。

