### PR TITLE
fix: 修复解析sql条件为global in的问题，补充Clickhouse相关数据库处理

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
@@ -26,6 +26,8 @@ import com.alibaba.druid.sql.dialect.ads.parser.AdsStatementParser;
 import com.alibaba.druid.sql.dialect.antspark.parser.AntsparkLexer;
 import com.alibaba.druid.sql.dialect.antspark.parser.AntsparkStatementParser;
 import com.alibaba.druid.sql.dialect.blink.parser.BlinkStatementParser;
+import com.alibaba.druid.sql.dialect.clickhouse.parser.ClickhouseExprParser;
+import com.alibaba.druid.sql.dialect.clickhouse.parser.ClickhouseLexer;
 import com.alibaba.druid.sql.dialect.clickhouse.parser.ClickhouseStatementParser;
 import com.alibaba.druid.sql.dialect.db2.ast.stmt.DB2SelectQueryBlock;
 import com.alibaba.druid.sql.dialect.db2.parser.DB2ExprParser;
@@ -180,6 +182,8 @@ public class SQLParserUtils {
                 return new PrestoExprParser(sql, features);
             case hive:
                 return new HiveExprParser(sql, features);
+            case clickhouse:
+                return new ClickhouseExprParser(sql, features);
             default:
                 return new SQLExprParser(sql, dbType, features);
         }
@@ -221,6 +225,8 @@ public class SQLParserUtils {
                 return new PrestoLexer(sql);
             case antspark:
                 return new AntsparkLexer(sql);
+            case clickhouse:
+                return new ClickhouseLexer(sql);
             default:
                 return new Lexer(sql, null, dbType);
         }
@@ -734,6 +740,9 @@ public class SQLParserUtils {
                 break;
             case mysql:
                 exprParser = new MySqlExprParser(lexer);
+                break;
+            case clickhouse:
+                exprParser = new ClickhouseExprParser(lexer);
                 break;
             default:
                 exprParser = new SQLExprParser(lexer);


### PR DESCRIPTION
给SQLParserUtils 工具类，补充Clickhouse相关数据库处理，以免解析 clickhouse 的global in语法的时候报错，
如果不加这个的话，则执行如下代码的时候会报错：

```java
    /**
     * 测试解析sql条件
     */
    @Test
    public void testParseGlobalInSqlCondition() {
        String sql1 = "a global in (select * from t)";
        SQLExpr conditionExpr = SQLUtils.toSQLExpr(sql1, DbType.clickhouse);
        System.out.println(conditionExpr.toString());
    }
```

报错信息如下：


com.alibaba.druid.sql.parser.ParserException: illegal sql expr : a global in (select * from t), pos 8, line 1, column 3, token IDENTIFIER global

	at com.alibaba.druid.sql.SQLUtils.toSQLExpr(SQLUtils.java:279)
	at com.hiido.SelfDruidSqlUtilsTest.testParseGlobalInSqlCondition(SelfDruidSqlUtilsTest.java:50)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)

