### PR TITLE
feat: 给global in语法补充多global not in 的逻辑处理

### DIFF
--- a/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3036,6 +3036,11 @@ public class SQLExprParser extends SQLParser {
         if (lexer.token == Token.GLOBAL) {
             global = true;
             lexer.nextToken();
+            // global not in logic
+            if (lexer.token == Token.NOT) {
+                lexer.nextToken();
+                return notRationalRest(expr, true);
+            }
         }
 
         if (lexer.token == Token.IN) {
@@ -3729,12 +3734,12 @@ public class SQLExprParser extends SQLParser {
                 break;
             case NOT:
                 lexer.nextToken();
-                expr = notRationalRest(expr);
+                expr = notRationalRest(expr, false);
                 break;
             case BANG:
                 if (dbType == DbType.odps) {
                     lexer.nextToken();
-                    expr = notRationalRest(expr);
+                    expr = notRationalRest(expr, false);
                 }
                 break;
             case BETWEEN:
@@ -3894,7 +3899,7 @@ public class SQLExprParser extends SQLParser {
         return expr;
     }
 
-    public SQLExpr notRationalRest(SQLExpr expr) {
+    public SQLExpr notRationalRest(SQLExpr expr, boolean global) {
         switch (lexer.token) {
             case LIKE:
                 lexer.nextTokenValue();
@@ -3953,6 +3958,7 @@ public class SQLExprParser extends SQLParser {
                         inSubQueryExpr.setNot(true);
                         inSubQueryExpr.setExpr(inListExpr.getExpr());
                         inSubQueryExpr.setSubQuery(((SQLQueryExpr) targetExpr).getSubQuery());
+                        inSubQueryExpr.setGlobal(global);
                         expr = inSubQueryExpr;
                     }
                 }
@@ -4547,6 +4553,7 @@ public class SQLExprParser extends SQLParser {
         return charType;
     }
 
+    @Override
     public void accept(Token token) {
         if (lexer.token == token) {
             lexer.nextToken();

--- a/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4327,7 +4327,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     public boolean visit(SQLInSubQueryExpr x) {
         x.getExpr().accept(this);
         if (x.isNot()) {
-            print0(ucase ? " NOT IN (" : " not in (");
+            if (x.isGlobal()) {
+                print0(ucase ? " GLOBAL NOT IN (" : " global not in (");
+            } else {
+                print0(ucase ? " NOT IN (" : " not in (");
+            }
         } else {
             if (x.isGlobal()) {
                 print0(ucase ? " GLOBAL IN (" : " global in (");


### PR DESCRIPTION
feat: 给global in语法补充多global not in 的逻辑处理

之前看到 这个commit https://github.com/alibaba/druid/commit/8c5c56c313b5153133b4ff2bd6030ac185c44142 ，有做global in的处理，但是没有做global not in的处理，所以这里加多global not in的逻辑处理，以免解析global not in 的时候有问题，例如，下面的单元测试，如果没加这个逻辑，会解析出错误的sql，把 global 关键字去掉了

```java
    /**
     * 测试解析sql条件
     */
    @Test
    public void testParseGlobalNotInSqlCondition() {
        String sql1 = "a global not in (select * from t)";
        SQLExpr conditionExpr = SQLUtils.toSQLExpr(sql1, DbType.clickhouse);
        System.out.println(conditionExpr.toString());
    }

```


预想结果：

```
a GLOBAL NOT IN (
	SELECT *
	FROM t
)
```

运行结果：

```
a NOT IN (
	SELECT *
	FROM t
)
```



使用的druid版本为：1.2.11