### PR TITLE
数据源获取物理连接的时候，如果出现RuntionException，会不停的申请数据库物理连接，导致数据库连接被迅速占用完

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2841,7 +2841,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                 } catch (RuntimeException e) {
                     LOG.error("create connection RuntimeException", e);
                     setFailContinuous(true);
-                    continue;
+                    break;
                 } catch (Error e) {
                     LOG.error("create connection Error", e);
                     setFailContinuous(true);


### PR DESCRIPTION
数据源获取物理连接的时候，如果出现RuntionException，由于是会不停的申请数据库物理连接，会导致物理连接申请成功，但是由于RuntimeException不能正确的返回DruidSource的连接，从而导致数据库连接被迅速占用完