### PR TITLE
fix DB2 解析器在解析包含别名的 delete 时解析错误

### DIFF
--- a/src/test/java/com/alibaba/druid/sql/dialect/db2/parser/DB2StatementParserTest.java
+++ b/src/test/java/com/alibaba/druid/sql/dialect/db2/parser/DB2StatementParserTest.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.sql.dialect.db2.parser;
+
+import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
+import junit.framework.TestCase;
+
+/**
+ * 验证 db2 SQL 解析器
+ *
+ * @author abomb4 2022-08-29
+ */
+public class DB2StatementParserTest extends TestCase {
+
+    /**
+     * 测试修改了 parseDeleteStatement 后 delete 语句能否正常解析
+     */
+    public void testDelete() {
+        final String[] caseList = new String[]{
+                // 普通语句
+                "delete from aaa where 1 = 1 and id = 2",
+                // 别名语句
+                "delete from test aaa where 1 = 1 and aaa.id = 2",
+                // 子查询语句
+                "delete from test aaa where exists ( select 1 from b where b.status = 'a' )",
+        };
+
+        for (int i = 0; i < caseList.length; i++) {
+            final String sql = caseList[i];
+            final DB2StatementParser parser = new DB2StatementParser(sql);
+            final SQLDeleteStatement parsed = parser.parseDeleteStatement();
+            final String result = parsed.toUnformattedString().replaceAll("\\s+", " ").toLowerCase();
+            assertEquals("第 " + (i + 1) + "个用例验证失败", sql, result);
+        }
+    }
+}


### PR DESCRIPTION
修复前解析带有别名的 `delete` 时会去掉 `where` ，生成非常危险的全表删除语句，如解析 `delete from table_name aaa where aaa.id = 1` 会生成 `delete from table_name`。

修复后会正常解析带有别名的 `delete`。