### PR TITLE
Update StatFilter.java

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -413,7 +413,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         // //////////SQL
 
         JdbcSqlStat sqlStat = statement.getSqlStat();
-        if (sqlStat == null || sqlStat.isRemoved() !sql.equals(sqlStat.getSql())) {
+        if (sqlStat == null || sqlStat.isRemoved() || !sql.equals(sqlStat.getSql())) {
             sqlStat = createSqlStat(statement, sql);
             statement.setSqlStat(sqlStat);
         }

--- a/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -413,7 +413,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         // //////////SQL
 
         JdbcSqlStat sqlStat = statement.getSqlStat();
-        if (sqlStat == null || sqlStat.isRemoved()) {
+        if (sqlStat == null || sqlStat.isRemoved() !sql.equals(sqlStat.getSql())) {
             sqlStat = createSqlStat(statement, sql);
             statement.setSqlStat(sqlStat);
         }


### PR DESCRIPTION
问题说明：当使用Statement不同sql执行多次execute方法，sql监控只会有一条sql记录。伪代码如下：
Connection connection = dataSource.getConnection();
        Statement stmt= connection.createStatement();
        stmt.execute("create table account0(accno varchar(20),customer varchar(30),balance int)");
        stmt.execute("insert into account0 values('20','user1',9)");
        stmt.close();
        connection.close();
此时sql监控只有create语句的sql。但是执行数、执行时间等都会进行相应的累加。