### PR TITLE
Update StatFilter.java

### DIFF
--- a/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -413,7 +413,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         // //////////SQL
 
         JdbcSqlStat sqlStat = statement.getSqlStat();
-        if (sqlStat == null || sqlStat.isRemoved()) {
+        if (sqlStat == null || sqlStat.isRemoved() || !sqlStat.getSql().equals(sql)) {
             sqlStat = createSqlStat(statement, sql);
             statement.setSqlStat(sqlStat);
         }


### PR DESCRIPTION
修复当使用Statement不同sql执行多次execute方法，sql监控只会有一条sql记录。