### PR TITLE
修复OceanBase validateQuery问题

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -190,6 +190,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.alipay.oceanbase</groupId>
+			<artifactId>oceanbase-client</artifactId>
+			<version>2.2.9</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.sourceforge.jtds</groupId>
 			<artifactId>jtds</artifactId>
 			<version>1.3.0</version>

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.DbType;
 import com.alibaba.druid.pool.ValidConnectionChecker;
 import com.alibaba.druid.pool.ValidConnectionCheckerAdapter;
 import com.alibaba.druid.util.JdbcUtils;
+import com.oceanbase.jdbc.OceanBaseConnection;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -47,10 +48,14 @@ public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapt
         }
         if (validateQuery == null || validateQuery.isEmpty()) {
             if (dbType != null) {
-                if (dbType == DbType.oceanbase) {
-                    validateQuery = mysqlModeValidateQuery;
-                } else {
-                    validateQuery = oracleModeValidateQuery;
+                if (c instanceof OceanBaseConnection) {
+                    OceanBaseConnection obConn = (OceanBaseConnection) c;
+
+                    if (obConn.getProtocol().isOracleMode()) {
+                        validateQuery = oracleModeValidateQuery;
+                    } else {
+                        validateQuery = mysqlModeValidateQuery;
+                    }
                 }
             }
         }


### PR DESCRIPTION
当前druid针对oceanbase区分租户的方式是通过jdbc中前缀，但是其实oceanbase无论是mysql租户还是oracle租户jdbc连接方式都可以是jdbc:oceanbase://host:port，所以这种区分方式是不准确的（会报错），目前oceanbase内部区分主要是通过与ob server通信，获取当前是什么租户，然后在oceanbaseBaseConnection中protocol中isOracleMode判断是否是oracle租户