### PR TITLE
修复OceanBase validateQuery问题

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
@@ -25,8 +25,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapter implements ValidConnectionChecker {
-    private String oracleModeValidateQuery = "SELECT 'x' FROM DUAL";
-    private String mysqlModeValidateQuery = "SELECT 'x'";
+    private String commonValidateQuery = "SELECT 'x' FROM DUAL";
     private DbType dbType;
 
     public OceanBaseValidConnectionChecker() {
@@ -47,11 +46,7 @@ public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapt
         }
         if (validateQuery == null || validateQuery.isEmpty()) {
             if (dbType != null) {
-                if (dbType == DbType.oceanbase) {
-                    validateQuery = mysqlModeValidateQuery;
-                } else {
-                    validateQuery = oracleModeValidateQuery;
-                }
+                validateQuery = commonValidateQuery;
             }
         }
 


### PR DESCRIPTION
druid通过jdbc前缀来区分是mysql租户还是oracle租户这种方式是不准确的，因为oceanbase官方给的是两种租户都可以采用jdbc:oceanbase://host:port方式进行连接，所以当我采用这种方式的时候，druid就会报错