### PR TITLE
Update DruidAbstractDataSource.java

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -772,7 +772,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
     public void setMinEvictableIdleTimeMillis(long minEvictableIdleTimeMillis) {
         if (minEvictableIdleTimeMillis < 1000 * 30) {
-            LOG.error("minEvictableIdleTimeMillis should be greater than 30000");
+            LOG.warn("minEvictableIdleTimeMillis should be greater than 30000");
         }
 
         this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;


### PR DESCRIPTION
修改PhoenixExceptionSorter的日志和检查方式，修改minEvictableIdleTimeMillis日志的级别。
minEvictableIdleTimeMillis可以设置少于 30000吗，我们项目需求是希望在使用连接池的时候，每次使用后1s后就断开连接，可以设置为1000吗，若可以，源代码的error可以修改为warn级别的日志