### PR TITLE
bug fix for connectTimeout setting

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -815,7 +815,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
             }
 
             if (connectTimeout == 0) {
-                socketTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
+                connectTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
             }
 
             if (socketTimeout == 0) {


### PR DESCRIPTION
I found that when `connectTimeout` is 0, now set `socketTimeout` instead of `connectTimeout` to default value.
I think this is very wrong.