### PR TITLE
Improved 'jdbc:wrap-jdbc:' URL Parser Function

### DIFF
--- a/core/src/main/java/com/alibaba/druid/proxy/DruidDriver.java
+++ b/core/src/main/java/com/alibaba/druid/proxy/DruidDriver.java
@@ -26,6 +26,7 @@ import com.alibaba.druid.support.logging.Log;
 import com.alibaba.druid.support.logging.LogFactory;
 import com.alibaba.druid.util.JMXUtils;
 import com.alibaba.druid.util.JdbcUtils;
+import com.alibaba.druid.util.StringUtils;
 import com.alibaba.druid.util.Utils;
 
 import javax.management.MBeanServer;
@@ -201,49 +202,47 @@ public class DruidDriver implements Driver, DruidDriverMBean {
 
     public static DataSourceProxyConfig parseConfig(String url, Properties info) throws SQLException {
         String restUrl = url.substring(DEFAULT_PREFIX.length());
-
         DataSourceProxyConfig config = new DataSourceProxyConfig();
-
-        if (restUrl.startsWith(DRIVER_PREFIX)) {
-            int pos = restUrl.indexOf(':', DRIVER_PREFIX.length());
-            String driverText = restUrl.substring(DRIVER_PREFIX.length(), pos);
-            if (driverText.length() > 0) {
-                config.setRawDriverClassName(driverText.trim());
+        int colonPos = -1;
+        while ((colonPos = restUrl.indexOf(":")) != -1)
+        {
+            if (restUrl.indexOf("=") == -1)
+            {
+                break;
             }
-            restUrl = restUrl.substring(pos + 1);
-        }
-
-        if (restUrl.startsWith(FILTERS_PREFIX)) {
-            int pos = restUrl.indexOf(':', FILTERS_PREFIX.length());
-            String filtersText = restUrl.substring(FILTERS_PREFIX.length(), pos);
-            for (String filterItem : filtersText.split(",")) {
-                FilterManager.loadFilter(config.getFilters(), filterItem);
+            String fragmentText = restUrl.substring(0, colonPos);
+            int equalPos = fragmentText.indexOf("=");
+            if (equalPos == -1)
+            {
+                continue;
             }
-            restUrl = restUrl.substring(pos + 1);
+            String key = fragmentText.substring(0, equalPos + 1);
+            String value = fragmentText.substring(equalPos + 1);
+            if (StringUtils.equalsIgnoreCase(key, DRIVER_PREFIX))
+            {
+                config.setRawDriverClassName(value.trim());
+            }
+            else if (StringUtils.equalsIgnoreCase(key, FILTERS_PREFIX))
+            {
+                for (String filterItem : value.split(",")) {
+                    FilterManager.loadFilter(config.getFilters(), filterItem);
+                }
+            }
+            else if (StringUtils.equalsIgnoreCase(key, NAME_PREFIX))
+            {
+                config.setName(value);
+            }
+            else if (StringUtils.equalsIgnoreCase(key, JMX_PREFIX))
+            {
+                config.setJmxOption(value);
+            }
+            restUrl = restUrl.substring(colonPos + 1);
         }
-
-        if (restUrl.startsWith(NAME_PREFIX)) {
-            int pos = restUrl.indexOf(':', NAME_PREFIX.length());
-            String name = restUrl.substring(NAME_PREFIX.length(), pos);
-            config.setName(name);
-            restUrl = restUrl.substring(pos + 1);
-        }
-
-        if (restUrl.startsWith(JMX_PREFIX)) {
-            int pos = restUrl.indexOf(':', JMX_PREFIX.length());
-            String jmxOption = restUrl.substring(JMX_PREFIX.length(), pos);
-            config.setJmxOption(jmxOption);
-            restUrl = restUrl.substring(pos + 1);
-        }
-
-        String rawUrl = restUrl;
-        config.setRawUrl(rawUrl);
-
+        config.setRawUrl(restUrl);
         if (config.getRawDriverClassName() == null) {
-            String rawDriverClassname = JdbcUtils.getDriverClassName(rawUrl);
+            String rawDriverClassname = JdbcUtils.getDriverClassName(restUrl);
             config.setRawDriverClassName(rawDriverClassname);
         }
-
         config.setUrl(url);
         return config;
     }

--- a/core/src/test/java/com/alibaba/druid/proxy/DruidDriverTest.java
+++ b/core/src/test/java/com/alibaba/druid/proxy/DruidDriverTest.java
@@ -14,6 +14,13 @@ public class DruidDriverTest {
         Properties properties;
         DataSourceProxyConfig config;
         String url = "";
+        //non driver property , getRawDriverClassName() = convert(jdbc:sqlite:) = org.sqlite.JDBC
+        url = "jdbc:wrap-jdbc:jdbc:sqlite:";
+        properties = new Properties();
+        config = DruidDriver.parseConfig(url,properties);
+        Assert.assertEquals(config.getRawDriverClassName() , JdbcConstants.SQLITE_DRIVER);
+        Assert.assertEquals(config.getRawUrl() , "jdbc:sqlite:");
+
         //have driver property , getRawDriverClassName() = driver1 , getRawUrl()=jdbc:sqlite:
         url = "jdbc:wrap-jdbc:driver=driver1:filters=com.alibaba.druid.filter.stat.StatFilter,com.alibaba.druid.filter.encoding.EncodingConvertFilter:name=name1:jmx=true:jdbc:sqlite:";
         properties = new Properties();

--- a/core/src/test/java/com/alibaba/druid/proxy/DruidDriverTest.java
+++ b/core/src/test/java/com/alibaba/druid/proxy/DruidDriverTest.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.proxy;
+
+import com.alibaba.druid.proxy.jdbc.DataSourceProxyConfig;
+import com.alibaba.druid.util.JdbcConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class DruidDriverTest {
+    @Test
+    public void parseConfig() throws Exception {
+       // String url = "jdbc:wrap-jdbc:driver=driver1:filters=filters1:name=name1:jmx=true:jdbc:sqlite:";
+        Properties properties;
+        DataSourceProxyConfig config;
+        String url = "";
+        //have driver property , getRawDriverClassName() = driver1 , getRawUrl()=jdbc:sqlite:
+        url = "jdbc:wrap-jdbc:driver=driver1:filters=com.alibaba.druid.filter.stat.StatFilter,com.alibaba.druid.filter.encoding.EncodingConvertFilter:name=name1:jmx=true:jdbc:sqlite:";
+        properties = new Properties();
+        config = DruidDriver.parseConfig(url,properties);
+        Assert.assertEquals(config.getRawDriverClassName() , "driver1");
+        Assert.assertEquals(config.getName() , "name1");
+        Assert.assertEquals(config.isJmxOption() , true);
+        Assert.assertEquals(config.getRawUrl() , "jdbc:sqlite:");
+
+        //non driver property , getRawDriverClassName() = convert(jdbc:sqlite:) = org.sqlite.JDBC
+        url = "jdbc:wrap-jdbc:name=name2:jmx=true:jdbc:sqlite:";
+        properties = new Properties();
+        config = DruidDriver.parseConfig(url,properties);
+        Assert.assertEquals(config.getName() , "name2");
+        Assert.assertEquals(config.getRawDriverClassName() , JdbcConstants.SQLITE_DRIVER);
+        Assert.assertEquals(config.getRawUrl() , "jdbc:sqlite:");
+
+        //mix properties order, have driver property , getRawDriverClassName() = driver2
+        url = "jdbc:wrap-jdbc:jmx=false:name=name2:filters=com.alibaba.druid.filter.stat.StatFilter:driver=driver2:jdbc:sqlite:";
+        properties = new Properties();
+        config = DruidDriver.parseConfig(url,properties);
+        Assert.assertEquals(config.getRawDriverClassName() , "driver2");
+        Assert.assertEquals(config.getName() , "name2");
+        Assert.assertEquals(config.isJmxOption() , false);
+        Assert.assertEquals(config.getRawUrl() , "jdbc:sqlite:");
+
+        //mix properties order, have driver property , getRawDriverClassName() = driver2
+        url = "jdbc:wrap-jdbc:jmx=true:name=name2:filters=com.alibaba.druid.filter.stat.StatFilter:driver=driver2:jdbc:sqlite:";
+        properties = new Properties();
+        config = DruidDriver.parseConfig(url,properties);
+        Assert.assertEquals(config.getRawDriverClassName() , "driver2");
+        Assert.assertEquals(config.getName() , "name2");
+        Assert.assertEquals(config.isJmxOption() , true);
+        Assert.assertEquals(config.getRawUrl() , "jdbc:sqlite:");
+
+    }
+}


### PR DESCRIPTION
Improved **'jdbc:wrap-jdbc:'** URL parser function, In previous versions, attribute names must be sequential,such as `"jdbc:wrap-jdbc:driver=driver1:filters=filters1:name=name1:jmx=true:jdbc:sqlite:"`, If not in order, the parsing result will be incorrect.Now,the attribute names can be in any order , such as `"jdbc:wrap-jdbc:filters=filters1:jmx=true:name=name1:driver=driver1:jdbc:sqlite:"`