### PR TITLE
repository console drop index error

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
@@ -851,7 +851,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
             SQLTableElement e = tableElementList.get(i);
             if (e instanceof SQLUniqueConstraint) {
                 SQLUniqueConstraint unique = (SQLUniqueConstraint) e;
-                if (unique.getName().nameHashCode64() == indexNameHashCode64) {
+                if (unique.getName() != null && unique.getName().nameHashCode64() == indexNameHashCode64) {
                     tableElementList.remove(i);
                     return true;
                 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlRepTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlRepTest.java
@@ -1,0 +1,23 @@
+package com.alibaba.druid.bvt.sql.mysql;
+
+import com.alibaba.druid.sql.repository.SchemaRepository;
+import com.alibaba.druid.util.JdbcUtils;
+
+public class MySqlRepTest {
+
+    public static void main(String[] args) {
+        SchemaRepository repository = new SchemaRepository(JdbcUtils.MYSQL);
+        repository.setDefaultSchema("test_db");
+        repository.console("CREATE TABLE `test_table` (" +
+                "  `id` bigint(11) unsigned NOT NULL AUTO_INCREMENT," +
+                "  `varchar_column` varchar(64) DEFAULT ''," +
+                "  PRIMARY KEY (`id`))");
+        try {
+            repository.console("CREATE INDEX idx_unikey ON test_db.test_table(varchar_column)");
+            String ddl2 = "drop index idx_ordinary on test_table";
+            repository.console(ddl2);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
repository.console("CREATE INDEX idx_unikey ON test_db.test_table(varchar_column)");
在 canal 中使用，创建了 一个 index 后，再删除这个 index，
repository.console("drop index idx_ordinary on test_table");
内部维护的 repository，会报 npe