### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven

--- a/druid-demo-petclinic/.github/workflows/maven-build.yml
+++ b/druid-demo-petclinic/.github/workflows/maven-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{matrix.java}}
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: Build with Maven Wrapper
         run: ./mvnw -B package


### PR DESCRIPTION
AdoptOpenJDK has moved to the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"