### PR TITLE
fix maven error for spring-petclinic

### DIFF
--- a/druid-demo-petclinic/pom.xml
+++ b/druid-demo-petclinic/pom.xml
@@ -9,6 +9,7 @@
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
     <version>2.7.3</version>
+    <relativePath/>
   </parent>
   <name>druid-demo-petclinic</name>
 


### PR DESCRIPTION
There is a problem when running maven install for spring-petclinic:
'parent.relativePath' of POM org.springframework.samples:spring-petclinic:2.7.3 points at com.alibaba:druid-parent instead of org.springframework.boot:spring-boot-starter-parent, please verify your project structure @ line 8, column 11
It is highly recommended to fix these problems because they threaten the stability of your build.
For this reason, future Maven versions might no longer support building such malformed projects.
Just fix this error.

