### PR TITLE
fix: CreateConnectionThread that keeps endlessly reconnecting even after the data source has been properly closed 

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2949,13 +2949,15 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                     continue;
                 }
 
-                boolean result = put(connection);
-                if (!result) {
-                    JdbcUtils.close(connection.getPhysicalConnection());
-                    LOG.info("put physical connection to pool failed.");
-                }
+                if (connection != null) {
+                    boolean result = put(connection);
+                    if (!result) {
+                        JdbcUtils.close(connection.getPhysicalConnection());
+                        LOG.info("put physical connection to pool failed.");
+                    }
 
-                errorCount = 0; // reset errorCount
+                    errorCount = 0; // reset errorCount
+                }
 
                 if (closing || closed) {
                     break;

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2945,10 +2945,6 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
                     break;
                 }
 
-                if (connection == null) {
-                    continue;
-                }
-
                 if (connection != null) {
                     boolean result = put(connection);
                     if (!result) {


### PR DESCRIPTION
After calling the `DruidDataSource.close()` method, the interrupt status of the `CreateConnectionThread` is set to true. However, if the MySQL is configured with `autoReconnect=true`, it will trigger the MySQL reconnection mechanism, which includes a call to `Thread.sleep()`, resetting the interrupt status.

`ConnectionImpl:connectWithRetries()`
![image](https://user-images.githubusercontent.com/13183021/218951931-c4c37563-fcb1-4389-a1e1-641538330314.png)

`CreateConnectionThread`：Due to the reset of the interrupt status, calling `lock.lockInterruptibly()` fails to throw an exception.
![image](https://user-images.githubusercontent.com/13183021/218952034-6035f5fa-06d2-4dcc-85fd-dd66364377d8.png)

If the connection is always NULL due to constant exceptions, it will result in an infinite loop.
![image](https://user-images.githubusercontent.com/13183021/218952422-ca440bdf-e104-4e1a-99b9-4e905d1dce16.png)

Here is the code for reproducing the issue：
```java
DruidDataSource dataSource = new DruidDataSource();
Properties properties = new Properties();
properties.put("druid.url", "jdbc:mysql://10.0.0.1:3306/xx?autoReconnect=true");
properties.put("druid.username", "root");
properties.put("druid.password", "root");
dataSource.configFromPropety(properties);
new Thread(() -> {
    try (DruidPooledConnection connection = dataSource.getConnection()) {

    } catch (Exception e) {
        e.printStackTrace();
    }
}).start();

Thread.sleep(1000);
dataSource.close();
System.out.println("close success");
LockSupport.park();
```
