### PR TITLE
mysql数据库，distrubted by关键字支持duplicate函数解析

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -954,7 +954,21 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     }
                     accept(Token.RPAREN);
                     stmt.setDistributeByType(new SQLIdentifierExpr("HASH"));
-                } else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
+                } else if (lexer.identifierEquals(FnvHash.Constants.DUPLICATE)) {
+                    lexer.nextToken();
+                    accept(Token.LPAREN);
+                    for (; ; ) {
+                        SQLName name = this.exprParser.name();
+                        stmt.getDistributeBy().add(name);
+                        if (lexer.token() == Token.COMMA) {
+                            lexer.nextToken();
+                            continue;
+                        }
+                        break;
+                    }
+                    accept(Token.RPAREN);
+                    stmt.setDistributeByType(new SQLIdentifierExpr("DUPLICATE"));
+                }else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
                     lexer.nextToken();
                     stmt.setDistributeByType(new SQLIdentifierExpr("BROADCAST"));
                 }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3785,7 +3785,21 @@ public class SQLStatementParser extends SQLParser {
                         }
                         accept(Token.RPAREN);
                         stmt.setDistributedByType(new SQLIdentifierExpr("HASH"));
-                    } else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
+                    } else if (lexer.identifierEquals(Constants.DUPLICATE)) {
+                        lexer.nextToken();
+                        accept(Token.LPAREN);
+                        for (; ; ) {
+                            SQLName name = this.exprParser.name();
+                            stmt.getDistributedBy().add(name);
+                            if (lexer.token() == Token.COMMA) {
+                                lexer.nextToken();
+                                continue;
+                            }
+                            break;
+                        }
+                        accept(Token.RPAREN);
+                        stmt.setDistributedByType(new SQLIdentifierExpr("DUPLICATE"));
+                    }else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
                         lexer.nextToken();
                         stmt.setDistributedByType(new SQLIdentifierExpr("BROADCAST"));
                     }

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -8602,7 +8602,12 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                     printAndAccept(x.getDistributedBy(), ",");
                     print0(")");
 
-                } else if ("BROADCAST".equalsIgnoreCase(distributeByType.getSimpleName())) {
+                } else if ("DUPLICATE".equalsIgnoreCase(distributeByType.getSimpleName())) {
+                    print0(ucase ? "DUPLICATE(" : "duplicate(");
+                    printAndAccept(x.getDistributedBy(), ",");
+                    print0(")");
+
+                }else if ("BROADCAST".equalsIgnoreCase(distributeByType.getSimpleName())) {
                     print0(ucase ? "BROADCAST " : "broadcast ");
                 }
             }
@@ -9691,6 +9696,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
             if ("HASH".equalsIgnoreCase(distributeByType.getSimpleName())) {
                 print0(ucase ? "HASH(" : "hash(");
+                printAndAccept(x.getDistributeBy(), ",");
+                print0(")");
+
+            } else if ("DUPLICATE".equalsIgnoreCase(distributeByType.getSimpleName())) {
+                print0(ucase ? "DUPLICATE(" : "duplicate(");
                 printAndAccept(x.getDistributeBy(), ",");
                 print0(")");
 

--- a/core/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/core/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -385,6 +385,7 @@ public final class FnvHash {
         long START = fnv1a_64_lower("START");
         long BTREE = fnv1a_64_lower("BTREE");
         long HASH = fnv1a_64_lower("HASH");
+        long DUPLICATE = fnv1a_64_lower("DUPLICATE");
         long LIST = fnv1a_64_lower("LIST");
         long NO_WAIT = fnv1a_64_lower("NO_WAIT");
         long WAIT = fnv1a_64_lower("WAIT");


### PR DESCRIPTION
适配mysql数据库场景下，建表语句包含`distrubuted by duplicate()`。写法类似`hash`函数。

```java
String sql = "CREATE TABLE `test_user`\n" +
                "(\n" +
                "    `id`          int(11)     NOT NULL AUTO_INCREMENT,\n" +
                "    `account`     varchar(70) NOT NULL COMMENT '账号',\n" +
                "    `user_name`   varchar(60) NOT NULL COMMENT '姓名',\n" +
                ") DISTRIBUTED BY DUPLICATE(g1,g2);";
```