### PR TITLE
mysql数据库，distrubted by关键字支持duplicate函数解析

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -954,6 +954,20 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     }
                     accept(Token.RPAREN);
                     stmt.setDistributeByType(new SQLIdentifierExpr("HASH"));
+                } else if (lexer.identifierEquals(FnvHash.Constants.DUPLICATE)) {
+                    lexer.nextToken();
+                    accept(Token.LPAREN);
+                    for (; ; ) {
+                        SQLName name = this.exprParser.name();
+                        stmt.getDistributeBy().add(name);
+                        if (lexer.token() == Token.COMMA) {
+                            lexer.nextToken();
+                            continue;
+                        }
+                        break;
+                    }
+                    accept(Token.RPAREN);
+                    stmt.setDistributeByType(new SQLIdentifierExpr("DUPLICATE"));
                 } else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
                     lexer.nextToken();
                     stmt.setDistributeByType(new SQLIdentifierExpr("BROADCAST"));

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3785,6 +3785,20 @@ public class SQLStatementParser extends SQLParser {
                         }
                         accept(Token.RPAREN);
                         stmt.setDistributedByType(new SQLIdentifierExpr("HASH"));
+                    } else if (lexer.identifierEquals(Constants.DUPLICATE)) {
+                        lexer.nextToken();
+                        accept(Token.LPAREN);
+                        for (; ; ) {
+                            SQLName name = this.exprParser.name();
+                            stmt.getDistributedBy().add(name);
+                            if (lexer.token() == Token.COMMA) {
+                                lexer.nextToken();
+                                continue;
+                            }
+                            break;
+                        }
+                        accept(Token.RPAREN);
+                        stmt.setDistributedByType(new SQLIdentifierExpr("DUPLICATE"));
                     } else if (lexer.identifierEquals(FnvHash.Constants.BROADCAST)) {
                         lexer.nextToken();
                         stmt.setDistributedByType(new SQLIdentifierExpr("BROADCAST"));

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -8609,6 +8609,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                     printAndAccept(x.getDistributedBy(), ",");
                     print0(")");
 
+                } else if ("DUPLICATE".equalsIgnoreCase(distributeByType.getSimpleName())) {
+                    print0(ucase ? "DUPLICATE(" : "duplicate(");
+                    printAndAccept(x.getDistributedBy(), ",");
+                    print0(")");
+
                 } else if ("BROADCAST".equalsIgnoreCase(distributeByType.getSimpleName())) {
                     print0(ucase ? "BROADCAST " : "broadcast ");
                 }
@@ -9698,6 +9703,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
             if ("HASH".equalsIgnoreCase(distributeByType.getSimpleName())) {
                 print0(ucase ? "HASH(" : "hash(");
+                printAndAccept(x.getDistributeBy(), ",");
+                print0(")");
+
+            } else if ("DUPLICATE".equalsIgnoreCase(distributeByType.getSimpleName())) {
+                print0(ucase ? "DUPLICATE(" : "duplicate(");
                 printAndAccept(x.getDistributeBy(), ",");
                 print0(")");
 

--- a/core/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/core/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -385,6 +385,7 @@ public final class FnvHash {
         long START = fnv1a_64_lower("START");
         long BTREE = fnv1a_64_lower("BTREE");
         long HASH = fnv1a_64_lower("HASH");
+        long DUPLICATE = fnv1a_64_lower("DUPLICATE");
         long LIST = fnv1a_64_lower("LIST");
         long NO_WAIT = fnv1a_64_lower("NO_WAIT");
         long WAIT = fnv1a_64_lower("WAIT");

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySQLCreateMaterializedViewTest8_distributed_by_with_duplicate.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySQLCreateMaterializedViewTest8_distributed_by_with_duplicate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.mysql.create;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleSchemaStatVisitor;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
+import com.alibaba.druid.stat.TableStat;
+
+public class MySQLCreateMaterializedViewTest8_distributed_by_with_duplicate extends MysqlTest {
+    public void test_types() throws Exception {
+        String sql = //
+                "CREATE MATERIALIZED VIEW mymv (\n" +
+                        "  default_col varchar,\n" +
+                        "  PRIMARY KEY(id)\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY DUPLICATE (id)\n" +
+                        "REFRESH FAST ON DEMAND\n" +
+                        "ENABLE QUERY REWRITE\n" +
+                        "AS SELECT id FROM base;";
+
+        SQLStatement stmt = SQLUtils.parseSingleMysqlStatement(sql);
+
+        assertEquals("CREATE MATERIALIZED VIEW mymv (\n" +
+                        "\tdefault_col varchar,\n" +
+                        "\tPRIMARY KEY (id)\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY DUPLICATE(id)\n" +
+                        "REFRESH FAST ON DEMAND\n" +
+                        "ENABLE QUERY REWRITE\n" +
+                        "AS\n" +
+                        "SELECT id\n" +
+                        "FROM base;",//
+                SQLUtils.toSQLString(stmt, DbType.mysql, null, VisitorFeature.OutputDistributedLiteralInCreateTableStmt));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("relationships : " + visitor.getRelationships());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
+
+        assertEquals(1, visitor.getTables().size());
+
+        assertEquals(1, visitor.getColumns().size());
+
+        assertTrue(visitor.getColumns().contains(new TableStat.Column("base", "id")));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest162_distributed_by_with_duplicate.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest162_distributed_by_with_duplicate.java
@@ -1,0 +1,29 @@
+package com.alibaba.druid.bvt.sql.mysql.createTable;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
+
+
+public class MySqlCreateTableTest162_distributed_by_with_duplicate extends MysqlTest {
+    public void test_0() throws Exception {
+        String sql = "CREATE TABLE `test_user` ( `id` int(11) NOT NULL AUTO_INCREMENT ) DISTRIBUTE BY DUPLICATE(g1,g2);";
+
+        MySqlCreateTableStatement stmt = (MySqlCreateTableStatement) SQLUtils.parseSingleMysqlStatement(sql);
+
+        assertEquals(sql, SQLUtils.toSQLString(stmt, DbType.mysql, new SQLUtils.FormatOption(VisitorFeature.OutputUCase)));
+    }
+
+    public void test_1() throws Exception {
+        String sql = "CREATE TABLE `test_user` ( `id` int(11) NOT NULL AUTO_INCREMENT ) DISTRIBUTED BY DUPLICATE(g1,g2);";
+
+        MySqlCreateTableStatement stmt = (MySqlCreateTableStatement) SQLUtils.parseSingleMysqlStatement(sql);
+
+        assertEquals(sql, SQLUtils.toSQLString(stmt, DbType.mysql, new SQLUtils.FormatOption(
+                VisitorFeature.OutputDistributedLiteralInCreateTableStmt, VisitorFeature.OutputUCase)));
+    }
+
+}


### PR DESCRIPTION
适配mysql数据库场景下，建表语句包含`distrubuted by duplicate()`。写法类似`hash`函数。

```java
String sql = "CREATE TABLE `test_user`\n" +
                "(\n" +
                "    `id`          int(11)     NOT NULL AUTO_INCREMENT,\n" +
                "    `account`     varchar(70) NOT NULL COMMENT '账号',\n" +
                "    `user_name`   varchar(60) NOT NULL COMMENT '姓名',\n" +
                ") DISTRIBUTED BY DUPLICATE(g1,g2);";
```