### PR TITLE
fix #5079 SQLServer socketTimeout support

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -45,6 +45,7 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Condition;
@@ -1763,8 +1764,15 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
                 physicalConnectProperties.put("oracle.net.CONNECT_TIMEOUT", connectTimeoutStr);
             } else if (driver != null && "org.postgresql.Driver".equals(driver.getClass().getName())) {
-                physicalConnectProperties.put("loginTimeout", connectTimeout);
-                physicalConnectProperties.put("socketTimeout", socketTimeout);
+                physicalConnectProperties.put("loginTimeout", Long.toString(TimeUnit.MILLISECONDS.toSeconds(connectTimeout)));
+                if (socketTimeout > 0) {
+                    physicalConnectProperties.put("socketTimeout", Long.toString(TimeUnit.MILLISECONDS.toSeconds(socketTimeout)));
+                }
+            } else if (dbTypeName.equals(DbType.sqlserver.name())) {
+                physicalConnectProperties.put("loginTimeout", Long.toString(TimeUnit.MILLISECONDS.toSeconds(connectTimeout)));
+                if (socketTimeout > 0) {
+                    physicalConnectProperties.put("socketTimeout", Integer.toString(socketTimeout));
+                }
             }
         }
 

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -826,7 +826,7 @@ public class DruidDataSource extends DruidAbstractDataSource implements DruidDat
             }
 
             if (connectTimeout == 0) {
-                socketTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
+                connectTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
             }
 
             if (socketTimeout == 0) {


### PR DESCRIPTION
fix #5079, in SQLServer,  [loginTimeout in second, socketTimeout in millisecond 
](https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties)
also, do some fix about #5096 modify the Postgres timeout values unit from milliseconds to seconds,
and fix one wrong field assignment