### PR TITLE
support more ORACLE DDL statement for parser

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableRenameConstraint.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableRenameConstraint.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.ast.statement;
+
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLObjectImpl;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class SQLAlterTableRenameConstraint extends SQLObjectImpl implements SQLAlterTableItem {
+    private SQLName constraint;
+    private SQLName to;
+
+    public SQLAlterTableRenameConstraint() {
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, constraint);
+            acceptChild(visitor, to);
+        }
+        visitor.endVisit(this);
+    }
+    
+    public SQLName getConstraint() {
+        return constraint;
+    }
+
+    public void setConstraint(SQLName constraint) {
+        if (constraint != null) {
+            constraint.setParent(this);
+        }
+        this.constraint = constraint;
+    }
+
+    public SQLName getTo() {
+        return to;
+    }
+
+    public void setTo(SQLName to) {
+        if (to != null) {
+            to.setParent(this);
+        }
+        this.to = to;
+    }
+
+}

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableRenameConstraint.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableRenameConstraint.java
@@ -34,7 +34,6 @@ public class SQLAlterTableRenameConstraint extends SQLObjectImpl implements SQLA
         }
         visitor.endVisit(this);
     }
-    
     public SQLName getConstraint() {
         return constraint;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableRowMovement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableRowMovement.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.druid.sql.dialect.oracle.ast.stmt;
 
-import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
 
 public class OracleAlterTableRowMovement extends OracleAlterTableItem {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableRowMovement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableRowMovement.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.oracle.ast.stmt;
+
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
+
+public class OracleAlterTableRowMovement extends OracleAlterTableItem {
+    /**
+     * true:ENABLE,false:DISABLE
+     */
+    private boolean enable;
+
+    @Override
+    public void accept0(OracleASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableShrinkSpace.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableShrinkSpace.java
@@ -18,7 +18,6 @@ package com.alibaba.druid.sql.dialect.oracle.ast.stmt;
 import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
 
 public class OracleAlterTableShrinkSpace extends OracleAlterTableItem {
-
     private boolean compact;
 
     private boolean cascade;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableShrinkSpace.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleAlterTableShrinkSpace.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.oracle.ast.stmt;
+
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
+
+public class OracleAlterTableShrinkSpace extends OracleAlterTableItem {
+
+    private boolean compact;
+
+    private boolean cascade;
+
+    private boolean check;
+
+    @Override
+    public void accept0(OracleASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+
+    public boolean isCompact() {
+        return compact;
+    }
+
+    public void setCompact(boolean compact) {
+        this.compact = compact;
+    }
+
+    public boolean isCascade() {
+        return cascade;
+    }
+
+    public void setCascade(boolean cascade) {
+        this.cascade = cascade;
+    }
+
+    public boolean isCheck() {
+        return check;
+    }
+
+    public void setCheck(boolean check) {
+        this.check = check;
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -1600,6 +1600,12 @@ public class OracleStatementParser extends SQLStatementParser {
                     SQLAlterTableDisableConstraint item = new SQLAlterTableDisableConstraint();
                     item.setConstraintName(this.exprParser.name());
                     stmt.addItem(item);
+                } else if (lexer.token() == Token.ROW) {
+                    lexer.nextToken();
+                    OracleAlterTableRowMovement item = new OracleAlterTableRowMovement();
+                    acceptIdentifier("MOVEMENT");
+                    item.setEnable(false);
+                    stmt.addItem(item);
                 } else {
                     throw new ParserException("TODO : " + lexer.info());
                 }
@@ -1610,8 +1616,26 @@ public class OracleStatementParser extends SQLStatementParser {
                     SQLAlterTableEnableConstraint item = new SQLAlterTableEnableConstraint();
                     item.setConstraintName(this.exprParser.name());
                     stmt.addItem(item);
+                } else if (lexer.token() == Token.ROW) {
+                    lexer.nextToken();
+                    OracleAlterTableRowMovement item = new OracleAlterTableRowMovement();
+                    acceptIdentifier("MOVEMENT");
+                    item.setEnable(true);
+                    stmt.addItem(item);
                 } else {
                     throw new ParserException("TODO : " + lexer.info());
+                }
+            } else if (lexer.identifierEquals("SHRINK")) {
+                lexer.nextToken();
+                if (lexer.identifierEquals("SPACE")) {
+                    lexer.nextToken();
+
+                    OracleAlterTableShrinkSpace item = new OracleAlterTableShrinkSpace();
+                    fillShrinkSpace(item);
+                    fillShrinkSpace(item);
+                    fillShrinkSpace(item);
+
+                    stmt.addItem(item);
                 }
             }
 
@@ -1631,6 +1655,19 @@ public class OracleStatementParser extends SQLStatementParser {
         }
 
         return stmt;
+    }
+
+    public void fillShrinkSpace(OracleAlterTableShrinkSpace item) {
+        if (lexer.identifierEquals("COMPACT")) {
+            item.setCompact(true);
+            lexer.nextToken();
+        } else if (lexer.token() == Token.CASCADE) {
+            item.setCascade(true);
+            lexer.nextToken();
+        } else if (lexer.token() == Token.CHECK) {
+            item.setCheck(true);
+            lexer.nextToken();
+        }
     }
 
     public void parseAlterDrop(SQLAlterTableStatement stmt) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleASTVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleASTVisitor.java
@@ -503,6 +503,20 @@ public interface OracleASTVisitor extends SQLASTVisitor {
     default void endVisit(OracleAlterTableMoveTablespace x) {
     }
 
+    default boolean visit(OracleAlterTableRowMovement x) {
+        return true;
+    }
+
+    default void endVisit(OracleAlterTableRowMovement x) {
+    }
+
+    default boolean visit(OracleAlterTableShrinkSpace x) {
+        return true;
+    }
+
+    default void endVisit(OracleAlterTableShrinkSpace x) {
+    }
+
     default boolean visit(OracleFileSpecification x) {
         return true;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1983,6 +1983,36 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
     }
 
     @Override
+    public boolean visit(OracleAlterTableRowMovement x) {
+        if (x.isEnable()) {
+            print0(ucase ? " ENABLE ROW MOVEMENT " : " enable row movement ");
+        } else {
+            print0(ucase ? " DISABLE ROW MOVEMENT " : " disable row movement ");
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean visit(OracleAlterTableShrinkSpace x) {
+        print0(ucase ? " SHRINK SPACE " : " shrink space ");
+
+        if (x.isCompact()) {
+            print0(ucase ? "COMPACT " : "compact ");
+        }
+
+        if (x.isCascade()) {
+            print0(ucase ? "CASCADE " : "cascade ");
+        }
+
+        if (x.isCheck()) {
+            print0(ucase ? "CHECK " : "check ");
+        }
+
+        return false;
+    }
+
+    @Override
     public boolean visit(OracleFileSpecification x) {
         printAndAccept(x.getFileNames(), ", ");
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -2898,6 +2898,38 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
     }
 
     @Override
+    public boolean visit(SQLExprTableSource x) {
+        printTableSourceExpr(x.getExpr());
+
+        final SQLTableSampling sampling = x.getSampling();
+        if (sampling != null) {
+            print(' ');
+            sampling.accept(this);
+        }
+
+        String alias = x.getAlias();
+        List<SQLName> columns = x.getColumnsDirect();
+        if (alias != null) {
+            print(' ');
+            print0(ucase ? " AS " : " as ");
+            print0(alias);
+        }
+
+        if (columns != null && columns.size() > 0) {
+            print(" (");
+            printAndAccept(columns, ", ");
+            print(')');
+        }
+
+        if (isPrettyFormat() && x.hasAfterComment()) {
+            print(' ');
+            printlnComment(x.getAfterCommentsDirect());
+        }
+
+        return false;
+    }
+
+    @Override
     public boolean visit(OracleXmlColumnProperties.OracleXMLTypeStorage x) {
         return false;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
@@ -160,6 +160,7 @@ public class Keywords {
         map.put("INOUT", Token.INOUT);
 
         map.put("LIMIT", Token.LIMIT);
+        map.put("CASCADE", Token.CASCADE);
 
         DEFAULT_KEYWORDS = new Keywords(map);
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -2762,7 +2762,16 @@ public class SQLStatementParser extends SQLParser {
 
         for (; ; ) {
             SQLName name = this.exprParser.name();
-            stmt.addPartition(new SQLExprTableSource(name));
+            SQLExprTableSource tab;
+            if (lexer.token == Token.AS) {
+                lexer.nextToken();
+                String alias = this.exprParser.name().getSimpleName();
+                tab = new SQLExprTableSource(name, alias);
+            } else {
+                tab = new SQLExprTableSource(name);
+            }
+
+            stmt.addPartition(tab);
             if (lexer.token == Token.COMMA) {
                 lexer.nextToken();
                 continue;

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -2520,6 +2520,13 @@ public class SQLStatementParser extends SQLParser {
             accept(Token.TO);
             renameColumn.setTo(this.exprParser.name());
             return renameColumn;
+        } else if (lexer.token == Token.CONSTRAINT) {
+            lexer.nextToken();
+            SQLAlterTableRenameConstraint renameConstraint = new SQLAlterTableRenameConstraint();
+            renameConstraint.setConstraint(this.exprParser.name());
+            accept(Token.TO);
+            renameConstraint.setTo(this.exprParser.name());
+            return renameConstraint;
         }
 
         if (lexer.token == Token.TO) {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -5769,6 +5769,15 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     }
 
     @Override
+    public boolean visit(SQLAlterTableRenameConstraint x) {
+        print0(ucase ? "RENAME CONSTRAINT " : "rename constraint ");
+        x.getConstraint().accept(this);
+        print0(ucase ? " TO " : " to ");
+        x.getTo().accept(this);
+        return false;
+    }
+
+    @Override
     public boolean visit(SQLColumnReference x) {
         SQLName name = x.getName();
         if (name != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTVisitor.java
@@ -776,6 +776,13 @@ public interface SQLASTVisitor {
     default void endVisit(SQLAlterTableRenameColumn x) {
     }
 
+    default boolean visit(SQLAlterTableRenameConstraint x) {
+        return true;
+    }
+
+    default void endVisit(SQLAlterTableRenameConstraint x) {
+    }
+
     default boolean visit(SQLColumnReference x) {
         return true;
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
@@ -179,8 +179,8 @@ public class OracleAlterTableTest26 extends OracleTest {
     }
 
 
-    public void test_7()throws Exception{
-        String sql="create table \"JUNYU_ORCL\".\"KBS_QUESTION\"(\n" +
+    public void test_7() throws Exception {
+        String sql = "create table \"JUNYU_ORCL\".\"KBS_QUESTION\"(\n" +
                 "  \"ID\"  number(19, 0)  not null,\n" +
                 "  \"QUESTION\"  varchar2(1500)  null,\n" +
                 "  \"GRADE\"  number(3, 0) default 0 not null,\n" +
@@ -304,7 +304,7 @@ public class OracleAlterTableTest26 extends OracleTest {
 
         Assert.assertEquals(1, visitor.getTables().size());
 
-        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("customers")));
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("JUNYU_ORCL.MYSQL_ALL_TYPES_FOR_8_0")));
     }
 
     public void test_9() throws Exception {
@@ -326,6 +326,27 @@ public class OracleAlterTableTest26 extends OracleTest {
 
         Assert.assertEquals(1, visitor.getTables().size());
 
-        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("customers")));
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("JUNYU_ORCL.KBS_QUESTION")));
+    }
+
+    public void test_10() throws Exception {
+        String sql = "drop table KBS_QUESTION AS \"BIN$9Ue7xItyBs3gUyUdEKzZKg==$0\"\n";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("DROP TABLE KBS_QUESTION  AS \"BIN$9Ue7xItyBs3gUyUdEKzZKg==$0\"",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("KBS_QUESTION")));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
@@ -28,9 +28,7 @@ import java.util.List;
 
 public class OracleAlterTableTest26 extends OracleTest {
     public void test_0() throws Exception {
-//        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space CHECK;";
         String sql = "alter table mytable enable row movement";
-
 
         OracleStatementParser parser = new OracleStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();
@@ -70,5 +68,92 @@ public class OracleAlterTableTest26 extends OracleTest {
         Assert.assertEquals(1, visitor.getTables().size());
 
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("EIFINI_BCS.SHEET_DA")));
+    }
+
+    public void test_2() throws Exception {
+        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space compact";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"EIFINI_BCS\".\"SHEET_DA\"\n" +
+                        "\t SHRINK SPACE COMPACT ",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("EIFINI_BCS.SHEET_DA")));
+    }
+
+    public void test_3() throws Exception {
+        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space CASCADE";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"EIFINI_BCS\".\"SHEET_DA\"\n" +
+                        "\t SHRINK SPACE CASCADE ",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("EIFINI_BCS.SHEET_DA")));
+    }
+
+    public void test_4() throws Exception {
+        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space COMPACT CASCADE";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"EIFINI_BCS\".\"SHEET_DA\"\n" +
+                        "\t SHRINK SPACE COMPACT CASCADE ",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("EIFINI_BCS.SHEET_DA")));
+    }
+
+    public void test_5() throws Exception {
+        String sql = "ALTER TABLE tester.t1 RENAME TO tester.\"BIN$9SBcFDaAYgDgUykdEKzT1Q==$0\"";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("RENAME tester.t1 TO tester.\"BIN$9SBcFDaAYgDgUykdEKzT1Q==$0\"",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("tester.t1")));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.oracle.alter;
+
+import com.alibaba.druid.sql.OracleTest;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleSchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.util.JdbcConstants;
+import org.junit.Assert;
+
+import java.util.List;
+
+public class OracleAlterTableTest26 extends OracleTest {
+    public void test_0() throws Exception {
+//        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space CHECK;";
+        String sql = "alter table mytable enable row movement";
+
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE mytable\n\t ENABLE ROW MOVEMENT ",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("mytable")));
+    }
+
+    public void test_1() throws Exception {
+        String sql = "alter table \"EIFINI_BCS\".\"SHEET_DA\" shrink space CHECK";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"EIFINI_BCS\".\"SHEET_DA\"\n" +
+                        "\t SHRINK SPACE CHECK ",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("EIFINI_BCS.SHEET_DA")));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/alter/OracleAlterTableTest26.java
@@ -156,4 +156,176 @@ public class OracleAlterTableTest26 extends OracleTest {
 
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("tester.t1")));
     }
+
+    public void test_6() throws Exception {
+        String sql = "ALTER TABLE customers MODIFY city varchar2(75) DEFAULT 'Seattle' NOT NULL;";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE customers\n\tMODIFY (\n\t\tcity varchar2(75) DEFAULT 'Seattle' NOT NULL\n\t);",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("customers")));
+    }
+
+
+    public void test_7()throws Exception{
+        String sql="create table \"JUNYU_ORCL\".\"KBS_QUESTION\"(\n" +
+                "  \"ID\"  number(19, 0)  not null,\n" +
+                "  \"QUESTION\"  varchar2(1500)  null,\n" +
+                "  \"GRADE\"  number(3, 0) default 0 not null,\n" +
+                "  \"CATEGORY\"  varchar2(1500)  null,\n" +
+                "  \"CATEGORY_ID\"  number(19, 0)  null,\n" +
+                "  \"PRIMARY_KEYWORD\"  varchar2(180)  null,\n" +
+                "  \"ALTERNATE_KEYWORD\"  varchar2(180)  null,\n" +
+                "  \"SEARCH_KEYWORD\"  varchar2(1500)  null,\n" +
+                "  \"KEYWORD_OPTION\"  number(3, 0) default 0 not null,\n" +
+                "  \"SYNONYMS\"  varchar2(1500)  null,\n" +
+                "  \"ANSWER_SHAPE\"  number(3, 0) default 0 not null,\n" +
+                "  \"PERSPECTIVE_ID\"  varchar2(900) default '500' null,\n" +
+                "  \"ANSWER\"  varchar2(4000)  null,\n" +
+                "  \"ANSWER_MD5\"  varchar2(96)  null,\n" +
+                "  \"VOICE_ANSWER\"  varchar2(4000)  null,\n" +
+                "  \"SHOW_ANSWER\"  varchar2(4000)  null,\n" +
+                "  \"REMARK\"  varchar2(3000)  null,\n" +
+                "  \"STATUS\"  number(3, 0) default 0 not null,\n" +
+                "  \"VALID_DATE\"  timestamp(0)  null,\n" +
+                "  \"INVALID_DATE\"  timestamp(0)  null,\n" +
+                "  \"INVALID_REASON\"  varchar2(300)  null,\n" +
+                "  \"ADD_MODE\"  number(3, 0) default 0 not null,\n" +
+                "  \"ORIGINAL\"  varchar2(192)  null,\n" +
+                "  \"APPROVAL_STATUS\"  number(3, 0) default 1 not null,\n" +
+                "  \"MAP_SOURCE\"  varchar2(192)  null,\n" +
+                "  \"MAP_ID\"  varchar2(192)  null,\n" +
+                "  \"VOICE_URL\"  varchar2(765)  null,\n" +
+                "  \"SYNC_FLAG\"  number(10, 0) default 0 not null,\n" +
+                "  \"SYNC_TIME\"  timestamp(0)  null,\n" +
+                "  \"BIZ_CATEGORY_ID\"  number(19, 0)  null,\n" +
+                "  \"FILE_CODE\"  varchar2(1536)  null,\n" +
+                "  \"REFERENCE\"  varchar2(3072)  null,\n" +
+                "  \"SUGGESTION\"  varchar2(1536)  null,\n" +
+                "  \"BRIGHTNESS\"  number(3, 0) default 0 not null,\n" +
+                "  \"OPEN_FLAG\"  number(3, 0) default 1 not null,\n" +
+                "  \"RELATION_STATUS\"  number(3, 0) default 0 not null,\n" +
+                "  \"CREATOR\"  varchar2(150)  null,\n" +
+                "  \"CREATION_DATE\"  timestamp(0) default sysdate not null,\n" +
+                "  \"MODIFIER\"  varchar2(150)  null,\n" +
+                "  \"MODIFICATION_DATE\"  timestamp(0) default sysdate not null,\n" +
+                "  \"QUESTION_TYPE\"  varchar2(30)  null,\n" +
+                "primary key(\"ID\"))";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("CREATE TABLE \"JUNYU_ORCL\".\"KBS_QUESTION\" (\n" +
+                        "\t\"ID\" number(19, 0) NOT NULL,\n" +
+                        "\t\"QUESTION\" varchar2(1500) NULL,\n" +
+                        "\t\"GRADE\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"CATEGORY\" varchar2(1500) NULL,\n" +
+                        "\t\"CATEGORY_ID\" number(19, 0) NULL,\n" +
+                        "\t\"PRIMARY_KEYWORD\" varchar2(180) NULL,\n" +
+                        "\t\"ALTERNATE_KEYWORD\" varchar2(180) NULL,\n" +
+                        "\t\"SEARCH_KEYWORD\" varchar2(1500) NULL,\n" +
+                        "\t\"KEYWORD_OPTION\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"SYNONYMS\" varchar2(1500) NULL,\n" +
+                        "\t\"ANSWER_SHAPE\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"PERSPECTIVE_ID\" varchar2(900) DEFAULT '500' NULL,\n" +
+                        "\t\"ANSWER\" varchar2(4000) NULL,\n" +
+                        "\t\"ANSWER_MD5\" varchar2(96) NULL,\n" +
+                        "\t\"VOICE_ANSWER\" varchar2(4000) NULL,\n" +
+                        "\t\"SHOW_ANSWER\" varchar2(4000) NULL,\n" +
+                        "\t\"REMARK\" varchar2(3000) NULL,\n" +
+                        "\t\"STATUS\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"VALID_DATE\" timestamp(0) NULL,\n" +
+                        "\t\"INVALID_DATE\" timestamp(0) NULL,\n" +
+                        "\t\"INVALID_REASON\" varchar2(300) NULL,\n" +
+                        "\t\"ADD_MODE\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"ORIGINAL\" varchar2(192) NULL,\n" +
+                        "\t\"APPROVAL_STATUS\" number(3, 0) DEFAULT 1 NOT NULL,\n" +
+                        "\t\"MAP_SOURCE\" varchar2(192) NULL,\n" +
+                        "\t\"MAP_ID\" varchar2(192) NULL,\n" +
+                        "\t\"VOICE_URL\" varchar2(765) NULL,\n" +
+                        "\t\"SYNC_FLAG\" number(10, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"SYNC_TIME\" timestamp(0) NULL,\n" +
+                        "\t\"BIZ_CATEGORY_ID\" number(19, 0) NULL,\n" +
+                        "\t\"FILE_CODE\" varchar2(1536) NULL,\n" +
+                        "\t\"REFERENCE\" varchar2(3072) NULL,\n" +
+                        "\t\"SUGGESTION\" varchar2(1536) NULL,\n" +
+                        "\t\"BRIGHTNESS\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"OPEN_FLAG\" number(3, 0) DEFAULT 1 NOT NULL,\n" +
+                        "\t\"RELATION_STATUS\" number(3, 0) DEFAULT 0 NOT NULL,\n" +
+                        "\t\"CREATOR\" varchar2(150) NULL,\n" +
+                        "\t\"CREATION_DATE\" timestamp(0) DEFAULT SYSDATE NOT NULL,\n" +
+                        "\t\"MODIFIER\" varchar2(150) NULL,\n" +
+                        "\t\"MODIFICATION_DATE\" timestamp(0) DEFAULT SYSDATE NOT NULL,\n" +
+                        "\t\"QUESTION_TYPE\" varchar2(30) NULL,\n" +
+                        "\tPRIMARY KEY (\"ID\")\n" +
+                        ")",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("JUNYU_ORCL.KBS_QUESTION")));
+    }
+
+    public void test_8() throws Exception {
+        String sql = "ALTER TABLE \"JUNYU_ORCL\".\"MYSQL_ALL_TYPES_FOR_8_0\" ADD CONSTRAINT \"uk_c_serial_7049_f_759141250\" UNIQUE (\"C_SERIAL\")";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"JUNYU_ORCL\".\"MYSQL_ALL_TYPES_FOR_8_0\"\n" +
+                        "\tADD CONSTRAINT \"uk_c_serial_7049_f_759141250\" UNIQUE (\"C_SERIAL\")",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("customers")));
+    }
+
+    public void test_9() throws Exception {
+        String sql = "ALTER TABLE \"JUNYU_ORCL\".\"KBS_QUESTION\" RENAME CONSTRAINT \"SYS_C007896\" TO \"BIN$9Ue7xItcBs3gUyUdEKzZKg==$0\"";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        Assert.assertEquals("ALTER TABLE \"JUNYU_ORCL\".\"KBS_QUESTION\"\n" +
+                        "\tRENAME CONSTRAINT \"SYS_C007896\" TO \"BIN$9Ue7xItcBs3gUyUdEKzZKg==$0\"",
+                SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("customers")));
+    }
 }


### PR DESCRIPTION
 ## supported sql
- [ORACLE] alter table mytable enable row movement
- [ORACLE] alter table "EIFINI_BCS"."SHEET_DA" shrink space COMPACT/CASCADE/CHECK
- [ORACLE] ALTER TABLE "KBS_QUESTION" RENAME CONSTRAINT "SYS_C007896" TO "ABC"
- [ORACLE] drop table KBS_QUESTION AS "abc" 

## testcase
- com.alibaba.druid.bvt.sql.oracle.alter.OracleAlterTableTest26
