### PR TITLE
presto 部分 ddl 语句解析支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/PrestoObject.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/PrestoObject.java
@@ -1,4 +1,8 @@
 package com.alibaba.druid.sql.dialect.presto.ast;
 
-public interface PrestoObject {
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.dialect.presto.visitor.PrestoVisitor;
+
+public interface PrestoObject extends SQLObject {
+    void accept0(PrestoVisitor visitor);
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoAlterFunctionStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoAlterFunctionStatement.java
@@ -15,44 +15,44 @@
  */
 package com.alibaba.druid.sql.dialect.presto.ast.stmt;
 
-import com.alibaba.druid.DbType;
-import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLAlterFunctionStatement;
 import com.alibaba.druid.sql.dialect.presto.visitor.PrestoVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
-public class PrestoCreateTableStatement extends SQLCreateTableStatement implements PrestoSQLStatement {
-    public PrestoCreateTableStatement() {
-        this.dbType = DbType.hive;
+public class PrestoAlterFunctionStatement extends SQLAlterFunctionStatement implements PrestoSQLStatement {
+    public PrestoAlterFunctionStatement() {
     }
 
-    public PrestoCreateTableStatement(DbType dbType) {
-        this.dbType = dbType;
+    private boolean returnsNullOnNullInput;
+    private boolean calledOnNullInput;
+
+    public boolean isReturnsNullOnNullInput() {
+        return returnsNullOnNullInput;
+    }
+
+    public void setReturnsNullOnNullInput(boolean returnsNullOnNullInput) {
+        this.returnsNullOnNullInput = returnsNullOnNullInput;
+    }
+
+    public boolean isCalledOnNullInput() {
+        return calledOnNullInput;
+    }
+
+    public void setCalledOnNullInput(boolean calledOnNullInput) {
+        this.calledOnNullInput = calledOnNullInput;
     }
 
     @Override
     protected void accept0(SQLASTVisitor v) {
         if (v instanceof PrestoVisitor) {
             this.accept0((PrestoVisitor) v);
+        } else {
+            super.accept0(v);
         }
-        super.accept0(v);
     }
 
     @Override
     public void accept0(PrestoVisitor visitor) {
         visitor.visit(this);
-    }
-
-    protected void acceptChild(SQLASTVisitor v) {
-        super.acceptChild(v);
-    }
-
-    public void cloneTo(PrestoCreateTableStatement x) {
-        super.cloneTo(x);
-    }
-
-    public PrestoCreateTableStatement clone() {
-        PrestoCreateTableStatement x = new PrestoCreateTableStatement();
-        cloneTo(x);
-        return x;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoAlterSchemaStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoAlterSchemaStatement.java
@@ -15,26 +15,25 @@
  */
 package com.alibaba.druid.sql.dialect.presto.ast.stmt;
 
-import com.alibaba.druid.DbType;
-import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatementImpl;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAlterStatement;
 import com.alibaba.druid.sql.dialect.presto.visitor.PrestoVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
-public class PrestoCreateTableStatement extends SQLCreateTableStatement implements PrestoSQLStatement {
-    public PrestoCreateTableStatement() {
-        this.dbType = DbType.hive;
-    }
+public class PrestoAlterSchemaStatement extends SQLStatementImpl implements PrestoSQLStatement, SQLAlterStatement {
+    private SQLName schemaName;
 
-    public PrestoCreateTableStatement(DbType dbType) {
-        this.dbType = dbType;
-    }
+    private SQLIdentifierExpr newName;
 
     @Override
     protected void accept0(SQLASTVisitor v) {
         if (v instanceof PrestoVisitor) {
             this.accept0((PrestoVisitor) v);
+        } else {
+            super.accept0(v);
         }
-        super.accept0(v);
     }
 
     @Override
@@ -42,17 +41,19 @@ public class PrestoCreateTableStatement extends SQLCreateTableStatement implemen
         visitor.visit(this);
     }
 
-    protected void acceptChild(SQLASTVisitor v) {
-        super.acceptChild(v);
+    public SQLName getSchemaName() {
+        return schemaName;
     }
 
-    public void cloneTo(PrestoCreateTableStatement x) {
-        super.cloneTo(x);
+    public void setSchemaName(SQLName schemaName) {
+        this.schemaName = schemaName;
     }
 
-    public PrestoCreateTableStatement clone() {
-        PrestoCreateTableStatement x = new PrestoCreateTableStatement();
-        cloneTo(x);
-        return x;
+    public SQLIdentifierExpr getNewName() {
+        return newName;
+    }
+
+    public void setNewName(SQLIdentifierExpr newName) {
+        this.newName = newName;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoCreateTableStatement.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.presto.ast.stmt;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+public class PrestoCreateTableStatement extends SQLCreateTableStatement {
+    public PrestoCreateTableStatement() {
+        this.dbType = DbType.hive;
+    }
+
+    public PrestoCreateTableStatement(DbType dbType) {
+        this.dbType = dbType;
+    }
+
+    protected void accept0(SQLASTVisitor v) {
+        if (v.visit(this)) {
+            acceptChild(v);
+        }
+        v.endVisit(this);
+    }
+
+    protected void acceptChild(SQLASTVisitor v) {
+        super.acceptChild(v);
+    }
+
+    public void cloneTo(PrestoCreateTableStatement x) {
+        super.cloneTo(x);
+    }
+
+    public PrestoCreateTableStatement clone() {
+        PrestoCreateTableStatement x = new PrestoCreateTableStatement();
+        cloneTo(x);
+        return x;
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.presto.ast.stmt;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.presto.ast.PrestoObject;
+
+public interface PrestoSQLStatement  extends SQLStatement, PrestoObject {
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
@@ -18,4 +18,4 @@ package com.alibaba.druid.sql.dialect.presto.ast.stmt;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.presto.ast.PrestoObject;
 
-public interface PrestoSQLStatement  extends SQLStatement, PrestoObject {}
+public interface PrestoSQLStatement extends SQLStatement, PrestoObject {}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSQLStatement.java
@@ -18,5 +18,4 @@ package com.alibaba.druid.sql.dialect.presto.ast.stmt;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.presto.ast.PrestoObject;
 
-public interface PrestoSQLStatement  extends SQLStatement, PrestoObject {
-}
+public interface PrestoSQLStatement  extends SQLStatement, PrestoObject {}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSelectStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/ast/stmt/PrestoSelectStatement.java
@@ -16,7 +16,6 @@
 package com.alibaba.druid.sql.dialect.presto.ast.stmt;
 
 import com.alibaba.druid.DbType;
-import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.dialect.presto.visitor.PrestoVisitor;
@@ -28,7 +27,7 @@ import com.alibaba.druid.sql.visitor.SQLASTVisitor;
  * author zhangcanlong
  * date 2022/01/11
  */
-public class PrestoSelectStatement extends SQLSelectStatement implements SQLStatement {
+public class PrestoSelectStatement extends SQLSelectStatement implements PrestoSQLStatement {
     public PrestoSelectStatement() {
         super(DbType.postgresql);
     }
@@ -47,9 +46,6 @@ public class PrestoSelectStatement extends SQLSelectStatement implements SQLStat
     }
 
     public void accept0(PrestoVisitor visitor) {
-        if (visitor.visit(this)) {
-            this.acceptChild(visitor, this.select);
-        }
-        visitor.endVisit(this);
+        super.accept0(visitor);
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoCreateTableParser.java
@@ -29,8 +29,6 @@ import java.util.List;
  * presto 的create table解析器
  *
  * @author yanlong
- * @see <a href="https://prestodb.io/docs/current/sql/create-table.html">CREATE_TABLE STATEMENT</a>
- * @see <a href=" https://prestodb.io/docs/current/sql/create-table-as.html">CREATE_TABLE_AS STATEMENT</a>
  * @since 2023-03-13
  */
 public class PrestoCreateTableParser extends SQLCreateTableParser {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoCreateTableParser.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.dialect.presto.parser;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoCreateTableStatement;
+import com.alibaba.druid.sql.parser.SQLCreateTableParser;
+import com.alibaba.druid.sql.parser.SQLExprParser;
+import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.util.FnvHash;
+
+import java.util.List;
+
+/**
+ * presto 的create table解析器
+ *
+ * @author yanlong
+ * @see <a href="https://prestodb.io/docs/current/sql/create-table.html">CREATE_TABLE STATEMENT</a>
+ * @see <a href=" https://prestodb.io/docs/current/sql/create-table-as.html">CREATE_TABLE_AS STATEMENT</a>
+ * @since 2023-03-13
+ */
+public class PrestoCreateTableParser extends SQLCreateTableParser {
+    public PrestoCreateTableParser(String sql) {
+        super(sql);
+    }
+
+    public PrestoCreateTableParser(SQLExprParser exprParser) {
+        super(exprParser);
+    }
+
+    public SQLCreateTableStatement parseCreateTable() {
+        List<String> comments = null;
+        if (lexer.isKeepComments() && lexer.hasComment()) {
+            comments = lexer.readAndResetComments();
+        }
+
+        SQLCreateTableStatement stmt = parseCreateTable(true);
+        if (comments != null) {
+            stmt.addBeforeComment(comments);
+        }
+
+        return stmt;
+    }
+
+    public SQLCreateTableStatement parseCreateTable(boolean acceptCreate) {
+        PrestoCreateTableStatement createTable = newCreateStatement();
+        createTable.setDbType(getDbType());
+
+        if (acceptCreate) {
+            if (lexer.hasComment() && lexer.isKeepComments()) {
+                createTable.addBeforeComment(lexer.readAndResetComments());
+            }
+
+            accept(Token.CREATE);
+        }
+
+        accept(Token.TABLE);
+
+        if (lexer.token() == Token.IF || lexer.identifierEquals(FnvHash.Constants.IF)) {
+            lexer.nextToken();
+            accept(Token.NOT);
+            accept(Token.EXISTS);
+
+            createTable.setIfNotExiists(true);
+        }
+
+        createTable.setName(this.exprParser.name());
+
+        if (lexer.token() == Token.LPAREN) {
+            lexer.nextToken();
+
+            for (; ; ) {
+                Token token = lexer.token();
+                if (lexer.token() == Token.LIKE) {
+                    lexer.nextToken();
+                    SQLTableLike tableLike = new SQLTableLike();
+                    tableLike.setTable(new SQLExprTableSource(this.exprParser.name()));
+                    tableLike.setParent(createTable);
+                    createTable.getTableElementList().add(tableLike);
+
+                    if (lexer.identifierEquals(FnvHash.Constants.INCLUDING)) {
+                        lexer.nextToken();
+                        acceptIdentifier("PROPERTIES");
+                        tableLike.setIncludeProperties(true);
+                    } else if (lexer.identifierEquals(FnvHash.Constants.EXCLUDING)) {
+                        lexer.nextToken();
+                        acceptIdentifier("PROPERTIES");
+                        tableLike.setExcludeProperties(true);
+                    }
+                } else if (token == Token.IDENTIFIER //
+                        || token == Token.LITERAL_ALIAS) {
+                    SQLColumnDefinition column = this.exprParser.parseColumn(createTable);
+                    column.setParent(createTable);
+                    createTable.getTableElementList().add(column);
+                } else {
+                    SQLColumnDefinition column = this.exprParser.parseColumn();
+                    createTable.getTableElementList().add(column);
+                }
+
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+
+                    if (lexer.token() == Token.RPAREN) { // compatible for sql server
+                        break;
+                    }
+                    continue;
+                }
+
+                break;
+            }
+
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.COMMENT) {
+            lexer.nextToken();
+            SQLExpr comment = this.exprParser.expr();
+            createTable.setComment(comment);
+        }
+
+        if (lexer.token() == Token.WITH) {
+            lexer.nextToken();
+            accept(Token.LPAREN);
+            parseAssignItems(createTable.getTableOptions(), createTable, false);
+            accept(Token.RPAREN);
+        }
+
+        if (lexer.token() == Token.AS) {
+            lexer.nextToken();
+            SQLSelect select = this.createSQLSelectParser().select();
+            createTable.setSelect(select);
+        }
+
+        parseCreateTableRest(createTable);
+
+        return createTable;
+    }
+
+    protected PrestoCreateTableStatement newCreateStatement() {
+        return new PrestoCreateTableStatement();
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoStatementParser.java
@@ -17,13 +17,15 @@ package com.alibaba.druid.sql.dialect.presto.parser;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
 import com.alibaba.druid.sql.ast.statement.SQLInsertInto;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
-import com.alibaba.druid.sql.parser.Lexer;
-import com.alibaba.druid.sql.parser.SQLCreateTableParser;
-import com.alibaba.druid.sql.parser.SQLStatementParser;
-import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterFunctionStatement;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterSchemaStatement;
+import com.alibaba.druid.sql.parser.*;
 
 /**
  * Created by wenshao on 16/9/13.
@@ -93,5 +95,114 @@ public class PrestoStatementParser extends SQLStatementParser {
     @Override
     public SQLCreateTableParser getSQLCreateTableParser() {
         return new PrestoCreateTableParser(this.exprParser);
+    }
+
+    @Override
+    public SQLStatement parseAlter() {
+        Lexer.SavePoint mark = lexer.mark();
+        accept(Token.ALTER);
+
+        if (lexer.token() == Token.FUNCTION) {
+            lexer.reset(mark);
+            return parseAlterFunction();
+        }
+        if (lexer.token() == Token.SCHEMA) {
+            lexer.reset(mark);
+            return parseAlterSchema();
+        } else {
+            lexer.reset(mark);
+            return super.parseAlter();
+        }
+    }
+
+    protected SQLStatement parseAlterFunction() {
+        accept(Token.ALTER);
+        accept(Token.FUNCTION);
+
+        PrestoAlterFunctionStatement stmt = new PrestoAlterFunctionStatement();
+        stmt.setDbType(dbType);
+
+        SQLName name = this.exprParser.name();
+
+        /*
+         * 因支持写函数参数项，名称处理
+         * ALTER FUNCTION qualified_function_name [ ( parameter_type[, ...] ) ]
+         * RETURNS NULL ON NULL INPUT | CALLED ON NULL INPUT
+         */
+        if (lexer.token() == Token.LPAREN) {
+            StringBuilder needAppendName = new StringBuilder();
+            needAppendName.append("(");
+            for (; ; ) {
+                lexer.nextToken();
+                needAppendName.append(lexer.stringVal());
+
+                lexer.nextToken();
+                if (lexer.token() == Token.RPAREN) {
+                    break;
+                }
+
+                // 处理fn(a, )
+                if (lexer.token() == Token.COMMA) {
+                    needAppendName.append(",");
+                    Lexer.SavePoint mark = lexer.mark();
+
+                    lexer.nextToken();
+
+                    if (lexer.token() == Token.RPAREN) {
+                        setErrorEndPos(lexer.pos());
+                        throw new ParserException("syntax error, actual " + lexer.token() + ", " + lexer.info());
+                    }
+                    lexer.reset(mark);
+                }
+            }
+            accept(Token.RPAREN);
+            needAppendName.append(")");
+
+            if (needAppendName.length() > 0) {
+                if (name instanceof SQLPropertyExpr) {
+                    SQLPropertyExpr sqlPropertyExpr = (SQLPropertyExpr) name;
+                    sqlPropertyExpr.setName(sqlPropertyExpr.getName() + needAppendName);
+                } else if (name instanceof SQLIdentifierExpr) {
+                    SQLIdentifierExpr sqlIdentifierExpr = (SQLIdentifierExpr) name;
+                    sqlIdentifierExpr.setName(sqlIdentifierExpr.getName() + needAppendName);
+                }
+            }
+        }
+        stmt.setName(name);
+
+        if (lexer.identifierEquals("CALLED")) {
+            lexer.nextToken();
+            stmt.setCalledOnNullInput(true);
+        } else if (lexer.identifierEquals("RETURNS")) {
+            lexer.nextToken();
+            acceptIdentifier("NULL");
+            stmt.setCalledOnNullInput(true);
+        } else {
+            setErrorEndPos(lexer.pos());
+            throw new ParserException("syntax error, actual " + lexer.token() + ", " + lexer.info());
+        }
+        accept(Token.ON);
+        accept(Token.NULL);
+        acceptIdentifier("INPUT");
+        return stmt;
+    }
+
+    @Override
+    protected SQLStatement parseAlterSchema() {
+        accept(Token.ALTER);
+        accept(Token.SCHEMA);
+
+        PrestoAlterSchemaStatement stmt = new PrestoAlterSchemaStatement();
+        stmt.setDbType(dbType);
+
+        SQLName name = this.exprParser.name();
+        stmt.setSchemaName(name);
+
+        acceptIdentifier("RENAME");
+        accept(Token.TO);
+
+        stmt.setNewName(this.exprParser.identifier());
+
+        return stmt;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/parser/PrestoStatementParser.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.sql.ast.statement.SQLInsertInto;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.parser.Lexer;
+import com.alibaba.druid.sql.parser.SQLCreateTableParser;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.alibaba.druid.sql.parser.Token;
 
@@ -87,5 +88,10 @@ public class PrestoStatementParser extends SQLStatementParser {
 
             break;
         }
+    }
+
+    @Override
+    public SQLCreateTableParser getSQLCreateTableParser() {
+        return new PrestoCreateTableParser(this.exprParser);
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
@@ -17,10 +17,9 @@ package com.alibaba.druid.sql.dialect.presto.visitor;
 
 import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.expr.SQLDecimalExpr;
-import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
-import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
-import com.alibaba.druid.sql.ast.statement.SQLSelect;
-import com.alibaba.druid.sql.dialect.phoenix.visitor.PhoenixASTVisitor;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterFunctionStatement;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterSchemaStatement;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 
 import java.math.BigDecimal;
@@ -32,7 +31,7 @@ import java.util.List;
  * @author zhangcanlong
  * @since 2022-01-07
  */
-public class PrestoOutputVisitor extends SQLASTOutputVisitor implements PhoenixASTVisitor {
+public class PrestoOutputVisitor extends SQLASTOutputVisitor implements PrestoVisitor {
     public PrestoOutputVisitor(Appendable appender) {
         super(appender);
     }
@@ -106,6 +105,31 @@ public class PrestoOutputVisitor extends SQLASTOutputVisitor implements PhoenixA
             println();
             visit(select);
         }
+        return false;
+    }
+
+    @Override
+    public boolean visit(PrestoAlterFunctionStatement x) {
+        print0(ucase ? "ALTER FUNCTION " : "alter function ");
+        x.getName().accept(this);
+
+        if (x.isCalledOnNullInput()) {
+            print0(" CALLED ON NULL INPUT");
+        }
+
+        if (x.isReturnsNullOnNullInput()) {
+            print0(" RETURNS NULL ON NULL INPUT");
+        }
+        return false;
+    }
+
+    @Override
+    public boolean visit(PrestoAlterSchemaStatement x) {
+        print0(ucase ? "ALTER SCHEMA " : "alter achema ");
+        x.getSchemaName().accept(this);
+
+        print0(ucase ? " RENAME TO " : " rename to ");
+        x.getNewName().accept(this);
         return false;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
@@ -17,10 +17,14 @@ package com.alibaba.druid.sql.dialect.presto.visitor;
 
 import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.expr.SQLDecimalExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.dialect.phoenix.visitor.PhoenixASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * presto 的输出的视图信息
@@ -54,6 +58,54 @@ public class PrestoOutputVisitor extends SQLASTOutputVisitor implements PhoenixA
         print(value.toString());
         print('\'');
 
+        return false;
+    }
+
+    @Override
+    public boolean visit(SQLCreateTableStatement x) {
+        /*
+            https://prestodb.io/docs/current/sql/create-table.html
+            CREATE TABLE [ IF NOT EXISTS ]
+            table_name (
+              { column_name data_type [ COMMENT comment ] [ WITH ( property_name = expression [, ...] ) ]
+              | LIKE existing_table_name [ { INCLUDING | EXCLUDING } PROPERTIES ] }
+              [, ...]
+            )
+            [ COMMENT table_comment ]
+            [ WITH ( property_name = expression [, ...] ) ]
+
+            https://prestodb.io/docs/current/sql/create-table-as.html
+            CREATE TABLE [ IF NOT EXISTS ] table_name [ ( column_alias, ... ) ]
+            [ COMMENT table_comment ]
+            [ WITH ( property_name = expression [, ...] ) ]
+            AS query
+            [ WITH [ NO ] DATA ]
+         */
+
+        printCreateTable(x, false);
+
+        if (null != x.getComment()) {
+            println();
+            print0(ucase ? "COMMENT " : "comment ");
+            printExpr(x.getComment());
+        }
+
+        List<SQLAssignItem> options = x.getTableOptions();
+        if (options.size() > 0) {
+            println();
+            print0(ucase ? "WITH (" : "with (");
+            printAndAccept(options, ", ");
+            print(')');
+        }
+
+        SQLSelect select = x.getSelect();
+        if (select != null) {
+            println();
+            print0(ucase ? "AS" : "as");
+
+            println();
+            visit(select);
+        }
         return false;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoVisitor.java
@@ -1,5 +1,7 @@
 package com.alibaba.druid.sql.dialect.presto.visitor;
 
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterFunctionStatement;
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoAlterSchemaStatement;
 import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
@@ -9,5 +11,19 @@ public interface PrestoVisitor extends SQLASTVisitor {
     }
 
     default void endVisit(PrestoCreateTableStatement x) {
+    }
+
+    default boolean visit(PrestoAlterFunctionStatement x) {
+        return true;
+    }
+
+    default void endVisit(PrestoAlterFunctionStatement x) {
+    }
+
+    default boolean visit(PrestoAlterSchemaStatement x) {
+        return true;
+    }
+
+    default void endVisit(PrestoAlterSchemaStatement x) {
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoVisitor.java
@@ -1,6 +1,13 @@
 package com.alibaba.druid.sql.dialect.presto.visitor;
 
+import com.alibaba.druid.sql.dialect.presto.ast.stmt.PrestoCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public interface PrestoVisitor extends SQLASTVisitor {
+    default boolean visit(PrestoCreateTableStatement x) {
+        return true;
+    }
+
+    default void endVisit(PrestoCreateTableStatement x) {
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoAlterFunction_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoAlterFunction_0.java
@@ -1,0 +1,33 @@
+package com.alibaba.druid.bvt.sql.presto;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrestoAlterFunction_0 {
+    @Test
+    public void test_alter_function_called() {
+        String sql = "ALTER FUNCTION prod.default.tan(double)\n" +
+                "CALLED ON NULL INPUT";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        assertEquals("ALTER FUNCTION prod.default.tan(double) CALLED ON NULL INPUT", stmt.toString());
+    }
+
+    @Test
+    public void test_alter_function_returns() {
+        String sql = "ALTER FUNCTION prod.default.tan\n" +
+                "CALLED ON NULL INPUT";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        assertEquals("ALTER FUNCTION prod.default.tan CALLED ON NULL INPUT", stmt.toString());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoAlterTableRename_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoAlterTableRename_0.java
@@ -1,0 +1,32 @@
+package com.alibaba.druid.bvt.sql.presto;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrestoAlterTableRename_0 {
+
+    @Test
+    public void test_alter_schema() {
+        String sql = "ALTER SCHEMA name RENAME TO new_name";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        assertEquals("ALTER SCHEMA name RENAME TO new_name", stmt.toString());
+    }
+
+    @Test
+    public void test_alter_schema2() {
+        String sql = "ALTER SCHEMA db.name RENAME TO new_name";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        assertEquals("ALTER SCHEMA db.name RENAME TO new_name", stmt.toString());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
@@ -1,0 +1,143 @@
+package com.alibaba.druid.bvt.sql.presto;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class PrestoCreateTable_0 {
+
+    private final DbType dbType = DbType.presto;
+
+    @Test
+    public void test_create_table_with() {
+        String sql = "CREATE TABLE orders (\n" +
+                "  orderkey bigint,\n" +
+                "  orderstatus varchar,\n" +
+                "  totalprice double,\n" +
+                "  orderdate date\n" +
+                ")\n" +
+                "WITH (format = 'ORC')";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+        SQLStatement stmt = parser.parseStatement();
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+        stmt.accept(visitor);
+        Map<TableStat.Name, TableStat> tableMap = visitor.getTables();
+        assertFalse(tableMap.isEmpty());
+        assertEquals("CREATE TABLE orders (\n" +
+                "\torderkey bigint,\n" +
+                "\torderstatus varchar,\n" +
+                "\ttotalprice double,\n" +
+                "\torderdate date\n" +
+                ")\n" +
+                "WITH (format = 'ORC')", stmt.toString());
+    }
+
+    @Test
+    public void test_create_table_comment() {
+        String sql = "CREATE TABLE IF NOT EXISTS orders (\n" +
+                "  orderkey bigint,\n" +
+                "  orderstatus varchar,\n" +
+                "  totalprice double COMMENT 'Price in cents.',\n" +
+                "  orderdate date\n" +
+                ")\n" +
+                "COMMENT 'A table to keep track of orders.'";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+        stmt.accept(visitor);
+        Map<TableStat.Name, TableStat> tableMap = visitor.getTables();
+        assertFalse(tableMap.isEmpty());
+        assertEquals("CREATE TABLE IF NOT EXISTS orders (\n" +
+                "\torderkey bigint,\n" +
+                "\torderstatus varchar,\n" +
+                "\ttotalprice double COMMENT 'Price in cents.',\n" +
+                "\torderdate date\n" +
+                ")\n" +
+                "COMMENT 'A table to keep track of orders.'", stmt.toString());
+    }
+
+    @Test
+    public void test_create_table_column_like_table() {
+        String sql = "CREATE TABLE bigger_orders (\n" +
+                "  another_orderkey bigint,\n" +
+                "  LIKE orders,\n" +
+                "  another_orderdate date\n" +
+                ")";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+        stmt.accept(visitor);
+        Map<TableStat.Name, TableStat> tableMap = visitor.getTables();
+        assertFalse(tableMap.isEmpty());
+        assertEquals("CREATE TABLE bigger_orders (\n" +
+                "\tanother_orderkey bigint,\n" +
+                "\tLIKE orders,\n" +
+                "\tanother_orderdate date\n" +
+                ")", stmt.toString());
+    }
+
+    @Test
+    public void test_create_table_as_select_0() {
+        String sql = "CREATE TABLE orders_column_aliased (order_date, total_price)\n" +
+                "AS\n" +
+                "SELECT orderdate, totalprice\n" +
+                "FROM orders";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+        stmt.accept(visitor);
+        Map<TableStat.Name, TableStat> tableMap = visitor.getTables();
+        assertFalse(tableMap.isEmpty());
+        assertEquals("CREATE TABLE orders_column_aliased (\n" +
+                "\torder_date,\n" +
+                "\ttotal_price\n" +
+                ")\n" +
+                "AS\n" +
+                "SELECT orderdate, totalprice\n" +
+                "FROM orders", stmt.toString());
+    }
+
+    @Test
+    public void test_create_table_as_select_1() {
+        String sql = "CREATE TABLE orders_by_date\n" +
+                "COMMENT 'Summary of orders by date'\n" +
+                "WITH (format = 'ORC')\n" +
+                "AS\n" +
+                "SELECT orderdate, sum(totalprice) AS price\n" +
+                "FROM orders\n" +
+                "GROUP BY orderdate";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        SQLStatement stmt = parser.parseStatement();
+
+        SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+        stmt.accept(visitor);
+        Map<TableStat.Name, TableStat> tableMap = visitor.getTables();
+        assertFalse(tableMap.isEmpty());
+        assertEquals("CREATE TABLE orders_by_date\n" +
+                "COMMENT 'Summary of orders by date'\n" +
+                "WITH (format = 'ORC')\n" +
+                "AS\n" +
+                "SELECT orderdate, sum(totalprice) AS price\n" +
+                "FROM orders\n" +
+                "GROUP BY orderdate", stmt.toString());
+    }
+
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class PrestoCreateTable_0 {
-
     private final DbType dbType = DbType.presto;
 
     @Test

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/PrestoCreateTable_0.java
@@ -138,5 +138,4 @@ public class PrestoCreateTable_0 {
                 "FROM orders\n" +
                 "GROUP BY orderdate", stmt.toString());
     }
-
 }


### PR DESCRIPTION
presto 支持  语句解析
1. create table
2. alter schema
3. alter function

支持官方语句规范：
https://prestodb.io/docs/current/sql/create-table.html
https://prestodb.io/docs/current/sql/create-table-as.html
https://prestodb.io/docs/current/sql/alter-schema.html
https://prestodb.io/docs/current/sql/alter-function.html