### PR TITLE
修复MySqlUpdateStatement.equals判断错误问题

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlUpdateStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlUpdateStatement.java
@@ -191,7 +191,7 @@ public class MySqlUpdateStatement extends SQLUpdateStatement implements MySqlSta
         if (queryOnPk != that.queryOnPk) {
             return false;
         }
-        if (this.hints != null ? hints.equals(that.hints) : that.hints != null) {
+        if (this.hints != null ? !hints.equals(that.hints) : that.hints != null) {
             return false;
         }
         if (limit != null ? !limit.equals(that.limit) : that.limit != null) {


### PR DESCRIPTION
修复因为对于hint的判断逻辑有误，导致equals返回了错误的值