### PR TITLE
Precompute function and rebuild the AST sqlstatement

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -538,12 +538,8 @@ public class SQLEvalVisitorUtils {
                 // 3. 遍历父对象找到当前函数所对应的字段并用函数的结果替换函数表达式
                 for (Field field : fields) {
                     try {
-                        Object o = null;
                         field.setAccessible(true);
-                        if (field.isAccessible()) {
-                            o = field.get(parent);
-                        }
-                        if (field.isAccessible() && o == x) {
+                        if (field.isAccessible() && field.get(parent) == x) {
                             String fieldName = field.getName();
                             String setMethodName = "set" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
                             Method setMethod = parentClass.getMethod(setMethodName, SQLExpr.class);

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -38,7 +38,6 @@ import com.alibaba.druid.wall.spi.WallVisitorUtils;
 import com.alibaba.druid.wall.spi.WallVisitorUtils.WallConditionContext;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -525,9 +525,9 @@ public class SQLEvalVisitorUtils {
         return false;
     }
 
-    public static boolean visit(SQLEvalVisitor visitor, SQLMethodInvokeExpr x, boolean preComputed) {
+    public static boolean visit(SQLEvalVisitor visitor, SQLMethodInvokeExpr x, boolean preCompute) {
         boolean visit = visit(visitor, x);
-        if(!preComputed){
+        if(!preCompute){
             return visit;
         }else{
             // 1. 拿到函数的计算结果

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -527,22 +527,20 @@ public class SQLEvalVisitorUtils {
 
     public static boolean visit(SQLEvalVisitor visitor, SQLMethodInvokeExpr x, boolean preCompute) {
         boolean visit = visit(visitor, x);
-        if(!preCompute){
-            return visit;
-        }else{
+        if (preCompute) {
             // 1. 拿到函数的计算结果
             Object result = x.getAttributes().get(EVAL_VALUE);
-            if(result instanceof SQLExpr){
+            if (result instanceof SQLExpr) {
                 // 2. 获得函数的父节点
                 SQLObject parent = x.getParent();
                 Class<? extends SQLObject> parentClass = parent.getClass();
                 Field[] fields = parentClass.getDeclaredFields();
                 // 3. 遍历父对象找到当前函数所对应的字段并用函数的结果替换函数表达式
-                for(Field field: fields){
+                for (Field field : fields) {
                     try {
                         Object o = null;
                         field.setAccessible(true);
-                        if(field.isAccessible()){
+                        if (field.isAccessible()) {
                             o = field.get(parent);
                         }
                         if (field.isAccessible() && o == x) {
@@ -551,13 +549,13 @@ public class SQLEvalVisitorUtils {
                             Method setMethod = parentClass.getMethod(setMethodName, SQLExpr.class);
                             setMethod.invoke(parent, result);
                         }
-                    }catch(Exception e){
+                    } catch (Exception e) {
                         throw new ParserException("SQL rebuild failed");
                     }
                 }
             }
-            return true;
         }
+        return visit;
     }
 
     public static boolean visit(SQLEvalVisitor visitor, SQLCharExpr x) {

--- a/core/src/test/java/com/alibaba/druid/sql/parser/PrecomputedFunctionTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/PrecomputedFunctionTest.java
@@ -1,0 +1,57 @@
+package com.alibaba.druid.sql.parser;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.odps.visitor.OdpsSchemaStatVisitor;
+import com.alibaba.druid.sql.visitor.SQLEvalVisitor;
+import com.alibaba.druid.sql.visitor.SQLEvalVisitorImpl;
+import com.alibaba.druid.sql.visitor.SQLEvalVisitorUtils;
+import com.alibaba.druid.sql.visitor.functions.Function;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+public class PrecomputedFunctionTest extends TestCase {
+    public void test_0() throws Exception {
+        String sql = "select * from tb1 where dt > '20230320' and dt < TO_DATE2('20230320', 'yyyymmdd')";
+        DbType dbType = JdbcConstants.ODPS;
+        SQLStatement statement = SQLUtils.parseSingleStatement(sql, dbType);
+
+        // 只考虑查询语句
+        SQLSelectStatement sqlSelectStatement = (SQLSelectStatement) statement;
+        SQLEvalVisitor sqlEvalVisitor = new SQLEvalVisitorImpl();
+
+        // 1. 向visitor里面注册函数，一定要【小写】
+        sqlEvalVisitor.registerFunction("to_date2", new Function() {
+            @Override
+            public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
+                List<SQLExpr> arguments = x.getArguments();
+                if(!arguments.get(0).computeDataType().isString() && !arguments.get(1).computeDataType().isString()){
+                    throw new RuntimeException("函数参数类型错误");
+                }
+                SQLCharExpr dateFormat = (SQLCharExpr) arguments.get(1);
+                SimpleDateFormat formatter = new SimpleDateFormat(dateFormat.getText());
+
+                SQLCharExpr date = (SQLCharExpr) arguments.get(0);
+                String dateString = date.getText();
+                return new SQLCharExpr(dateString);
+            }
+        });
+
+        // 2. 获得所有函数
+        OdpsSchemaStatVisitor visitor = new OdpsSchemaStatVisitor();
+        sqlSelectStatement.accept(visitor);
+        List<SQLMethodInvokeExpr> functions = visitor.getFunctions();
+
+        // 3. 执行函数并进行替换
+        functions.forEach(f -> SQLEvalVisitorUtils.visit(sqlEvalVisitor, f, true));
+        System.out.println(SQLUtils.toSQLString(sqlSelectStatement));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/sql/parser/PrecomputedFunctionTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/PrecomputedFunctionTest.java
@@ -33,7 +33,7 @@ public class PrecomputedFunctionTest extends TestCase {
             @Override
             public Object eval(SQLEvalVisitor visitor, SQLMethodInvokeExpr x) {
                 List<SQLExpr> arguments = x.getArguments();
-                if(!arguments.get(0).computeDataType().isString() && !arguments.get(1).computeDataType().isString()){
+                if (!arguments.get(0).computeDataType().isString() && !arguments.get(1).computeDataType().isString()) {
                     throw new RuntimeException("函数参数类型错误");
                 }
                 SQLCharExpr dateFormat = (SQLCharExpr) arguments.get(1);


### PR DESCRIPTION
Usually, we hope that the elements in the SQL statement will be parsed and processed before they are actually submitted to the executor (such as checking the permissions of fields and the number of partitions, etc.), but some functions, including some UDFs defined by users, make it difficult to preprocess these elements. For example, the commonly used DATEADD function, if users need to check the partition range involved in the SQL query before submitting it to the executor, it will be quite difficult. In fastsql, we provide a good Function function to define functions and use SQLEvalVisitorUtil to calculate the results of functions and write them into functions, but we do not reconstruct the original SqlStatement (using the results of functions to replace the function expression). Here, I have made a complement to this.