### PR TITLE
增加 postgresql 刷新物化视图关键字支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLRefreshMaterializedViewStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLRefreshMaterializedViewStatement.java
@@ -27,11 +27,23 @@ import java.util.List;
 public class SQLRefreshMaterializedViewStatement extends SQLStatementImpl {
     private SQLExpr name;
 
+    private boolean concurrently;
+
+    private boolean withNoData;
+
+    private boolean withData;
+
     public SQLRefreshMaterializedViewStatement() {
+        this.setConcurrently(false);
+        this.setWithData(false);
+        this.setWithNoData(false);
     }
 
     public SQLRefreshMaterializedViewStatement(DbType dbType) {
         super(dbType);
+        this.setConcurrently(false);
+        this.setWithData(false);
+        this.setWithNoData(false);
     }
 
     @Override
@@ -51,6 +63,30 @@ public class SQLRefreshMaterializedViewStatement extends SQLStatementImpl {
             x.setParent(this);
         }
         this.name = x;
+    }
+
+    public boolean isConcurrently() {
+        return concurrently;
+    }
+
+    public void setConcurrently(boolean concurrently) {
+        this.concurrently = concurrently;
+    }
+
+    public boolean isWithNoData() {
+        return withNoData;
+    }
+
+    public void setWithNoData(boolean withNoData) {
+        this.withNoData = withNoData;
+    }
+
+    public void setWithData(boolean withData) {
+        this.withData = withData;
+    }
+
+    public boolean isWithData() {
+        return withData;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -926,9 +926,29 @@ public class SQLStatementParser extends SQLParser {
 
         acceptIdentifier("MATERIALIZED");
 
+        if (lexer.identifierEquals("CONCURRENTLY")) {
+            lexer.nextToken();
+            stmt.setConcurrently(true);
+        }
         accept(Token.VIEW);
 
         stmt.setName(this.exprParser.name());
+
+        if (lexer.token() == WITH) {
+            lexer.nextToken();
+
+            if (lexer.token() == IDENTIFIER && "NO".equalsIgnoreCase(lexer.stringVal())) {
+                lexer.nextToken();
+                stmt.setWithNoData(true);
+            }
+
+            if (lexer.token() == IDENTIFIER && "DATA".equalsIgnoreCase(lexer.stringVal())) {
+                lexer.nextToken();
+                stmt.setWithData(true);
+            } else {
+                throw new ParserException("syntax error, expect DATA, actual " + lexer.token() + ", pos " + lexer.pos());
+            }
+        }
         return stmt;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -8544,8 +8544,22 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLRefreshMaterializedViewStatement x) {
-        print0(ucase ? "REFRESH MATERIALIZED VIEW " : "refresh materialized view ");
+        print0(ucase ? "REFRESH MATERIALIZED" : "refresh materialized");
+
+        if (x.isConcurrently()) {
+            print0(ucase ? " CONCURRENTLY" : " concurrently");
+        }
+
+        print0(ucase ? " VIEW " : " view ");
+
         x.getName().accept(this);
+
+        if (x.isWithNoData()) {
+            print0(ucase ? " WITH NO DATA" : " with no data");
+        } else if (x.isWithData()) {
+            print0(ucase ? " WITH DATA" : " with data");
+        }
+
         return false;
     }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresqlResourceTest.java
@@ -95,6 +95,10 @@ public class PostgresqlResourceTest extends PGTest {
         exec_test("bvt/parser/postgresql-14.txt");
     }
 
+    public void test_15() throws Exception {
+        exec_test("bvt/parser/postgresql-15.txt");
+    }
+
     public void exec_test(String resource) throws Exception {
         System.out.println(resource);
         InputStream is = null;

--- a/core/src/test/resources/bvt/parser/postgresql-15.txt
+++ b/core/src/test/resources/bvt/parser/postgresql-15.txt
@@ -1,0 +1,3 @@
+refresh materialized concurrently view v1 with no data
+---------------------------
+REFRESH MATERIALIZED CONCURRENTLY VIEW v1 WITH NO DATA


### PR DESCRIPTION
刷新物化视图：REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] name [ WITH [ NO ] DATA ]
改动内容：增加对 concurrently 和 with [no] data 关键字的支持
issue：https://github.com/alibaba/druid/issues/4987