### PR TITLE
SQLASTOutputVisitor优化

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -39,6 +39,12 @@ import java.util.List;
 import java.util.Map;
 
 public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTVisitor {
+
+    /**
+     * 默认使用 '
+     */
+    protected boolean useBackSlashAsPrefixForSingleQuotation;
+
     {
         this.dbType = DbType.mysql;
         this.shardingSupport = true;
@@ -763,7 +769,11 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
                 for (int i = 0; i < text.length(); ++i) {
                     char ch = text.charAt(i);
                     if (ch == '\'') {
-                        appender.append('\'');
+                        if (useBackSlashAsPrefixForSingleQuotation) {
+                            appender.append('\\');
+                        } else {
+                            appender.append('\'');
+                        }
                         appender.append('\'');
                     } else if (ch == '\\') {
                         appender.append('\\');
@@ -5567,4 +5577,9 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         }
         return false;
     }
+
+    public void setUseBackSlashAsPrefixForSingleQuotation(boolean useBackSlashAsPrefixForSingleQuotation) {
+        this.useBackSlashAsPrefixForSingleQuotation = useBackSlashAsPrefixForSingleQuotation;
+    }
+
 } //

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -95,6 +95,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     protected boolean shardingSupport;
 
     protected transient int lines;
+
+    protected boolean printBlankAsEnter;
+
     private TimeZone timeZone;
 
     protected Boolean printStatementAfterSemi = defaultPrintStatementAfterSemi;
@@ -548,7 +551,12 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             return;
         }
 
-        print('\n');
+        if (printBlankAsEnter) {
+            print(' ');
+        } else {
+            print('\n');
+        }
+
         lines++;
         printIndent();
     }
@@ -11438,4 +11446,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
         return false;
     }
+
+    public void setPrintBlankAsEnter(boolean printBlankAsEnter) {
+        this.printBlankAsEnter = printBlankAsEnter;
+    }
+
 }


### PR DESCRIPTION
1、MySqlOutputVisitor增加参数useBackSlashAsPrefixForSingleQuotation控制单引号前缀使用'还是\。
2、SQLASTOutputVisitor增加参数printBlankAsEnter控制换行的地方可以使用空字符替代。