### PR TITLE
修复mysql 等数据库PagerUtils分页设置limit 0 ，在原sql中包含limit offset 时不生效问题

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -119,7 +119,7 @@ public class PagerUtils {
     private static boolean limitUnion(SQLUnionQuery queryBlock, DbType dbType, int offset, int count, boolean check) {
         SQLLimit limit = queryBlock.getLimit();
         if (limit != null) {
-            if (offset > 0) {
+            if (offset >= 0) {
                 limit.setOffset(new SQLIntegerExpr(offset));
             }
 
@@ -182,7 +182,7 @@ public class PagerUtils {
                                               boolean check) {
         SQLLimit limit = queryBlock.getLimit();
         if (limit != null) {
-            if (offset > 0) {
+            if (offset >= 0) {
                 limit.setOffset(new SQLIntegerExpr(offset));
             }
 
@@ -445,7 +445,7 @@ public class PagerUtils {
                                                 boolean check) {
         SQLLimit limit = queryBlock.getLimit();
         if (limit != null) {
-            if (offset > 0) {
+            if (offset >= 0) {
                 limit.setOffset(new SQLIntegerExpr(offset));
             }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
@@ -76,6 +76,6 @@ public class PagerUtilsTest_Limit_mysql_0 extends TestCase {
         String result = PagerUtils.limit(sql, JdbcConstants.MYSQL, 0, 100, true);
         assertEquals("SELECT *\n" +
                 "FROM t\n" +
-                "LIMIT 1000, 100", result);
+                "LIMIT 0, 100", result);
     }
 }


### PR DESCRIPTION
 对应这个pr  https://github.com/alibaba/druid/pull/3263 的，不知道为什么之前 mysql 等数据库修改过一次，新版本还是有问题


```
    /**
     * 测试分页
     */
    @Test
    public void testLimit() {
        String mysqlSql = "select a,b from test limit 10,20";
        System.out.println(PagerUtils.limit(mysqlSql, DbType.mysql, 0, 10));
        // 应该出来的 select a,b from test limit 0,20 的，但是目前的版本出来 select a,b from test limit 10,10

        String unionSql = "select a,b from test union all select a,b from test2 limit 10,20";
        System.out.println(PagerUtils.limit(unionSql, DbType.mysql, 0, 10));
        // 应该出来的 select a,b from test union all select a,b from test2 limit 0,20 的，但是目前的版本出来 select a,b from test union all select a,b from test2 limit 10,10
    }
```