### PR TITLE
fix sql parsing for create statements without AS

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/antspark/parser/AntsparkCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/antspark/parser/AntsparkCreateTableParser.java
@@ -277,8 +277,10 @@ public class AntsparkCreateTableParser extends SQLCreateTableParser {
             stmt.setMetaLifeCycle(this.exprParser.primary());
         }
 
-        if (lexer.token() == Token.AS) {
-            lexer.nextToken();
+        if (lexer.token() == Token.SELECT || lexer.token() == Token.AS) {
+            if (lexer.token() == Token.AS) {
+                lexer.nextToken();
+            }
             SQLSelect select = this.createSQLSelectParser().select();
             stmt.setSelect(select);
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
@@ -289,8 +289,10 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
             stmt.setMetaLifeCycle(this.exprParser.primary());
         }
 
-        if (lexer.token() == Token.AS) {
-            lexer.nextToken();
+        if (lexer.token() == Token.SELECT || lexer.token() == Token.AS) {
+            if (lexer.token() == Token.AS) {
+                lexer.nextToken();
+            }
             SQLSelect select = this.createSQLSelectParser().select();
             stmt.setSelect(select);
         }


### PR DESCRIPTION
Fixes for parsing create statements like `create table some_table select * from another_table`.