### PR TITLE
添加对Lealone数据库的支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/DbType.java
+++ b/core/src/main/java/com/alibaba/druid/DbType.java
@@ -66,6 +66,8 @@ public enum DbType {
 
     starrocks(1L << 43),
 
+    lealone(1L << 44),
+
     ingres(0),
     cloudscape(0),
     timesten(0),

--- a/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -159,6 +159,7 @@ public class PagerUtils {
             case mariadb:
             case tidb:
             case h2:
+            case lealone:
             case ads:
             case clickhouse:
                 return limitMySqlQueryBlock(queryBlock, dbType, offset, count, check);

--- a/core/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -515,6 +515,7 @@ public class SQLUtils {
             case odps:
                 return new OdpsOutputVisitor(out);
             case h2:
+            case lealone:
                 return new H2OutputVisitor(out);
             case hive:
                 return new HiveOutputVisitor(out);
@@ -577,6 +578,7 @@ public class SQLUtils {
             case odps:
                 return new OdpsSchemaStatVisitor(repository);
             case h2:
+            case lealone:
                 return new H2SchemaStatVisitor(repository);
             case hive:
                 return new HiveSchemaStatVisitor(repository);

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
@@ -129,6 +129,7 @@ public class SQLParserUtils {
             case jtds:
                 return new SQLServerStatementParser(sql, features);
             case h2:
+            case lealone:
                 return new H2StatementParser(sql, features);
             case blink:
                 return new BlinkStatementParser(sql, features);
@@ -173,6 +174,7 @@ public class SQLParserUtils {
                 return parser;
             }
             case h2:
+            case lealone:
                 return new H2ExprParser(sql, features);
             case postgresql:
             case edb:
@@ -223,6 +225,7 @@ public class SQLParserUtils {
                 return lexer;
             }
             case h2:
+            case lealone:
                 return new H2Lexer(sql, features);
             case postgresql:
             case edb:

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/ExportParameterVisitorUtils.java
@@ -49,6 +49,7 @@ public final class ExportParameterVisitorUtils {
             case db2:
                 return new DB2ExportParameterVisitor(out);
             case h2:
+            case lealone:
                 return new MySqlExportParameterVisitor(out);
             case sqlserver:
             case jtds:

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
@@ -409,6 +409,7 @@ public class ParameterizedOutputVisitorUtils {
             case elastic_search:
                 return new MySqlOutputVisitor(out, true);
             case h2:
+            case lealone:
                 return new H2OutputVisitor(out, true);
             case postgresql:
             case edb:

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -116,6 +116,7 @@ public class SQLEvalVisitorUtils {
             case mariadb:
             case tidb:
             case h2:
+            case lealone:
                 return new MySqlEvalVisitorImpl();
             case oracle:
                 return new OracleEvalVisitor();

--- a/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -69,6 +69,9 @@ public interface JdbcConstants {
     DbType H2 = DbType.h2;
     String H2_DRIVER = "org.h2.Driver";
 
+    DbType LEALONE = DbType.lealone;
+    String LEALONE_DRIVER = "org.lealone.client.jdbc.JdbcDriver";
+
     DbType DM = DbType.dm;
     String DM_DRIVER = "dm.jdbc.driver.DmDriver";
 

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -460,6 +460,8 @@ public final class JdbcUtils implements JdbcConstants {
             return "com.ingres.jdbc.IngresDriver";
         } else if (rawUrl.startsWith("jdbc:h2:")) {
             return H2_DRIVER;
+        } else if (rawUrl.startsWith("jdbc:lealone:")) {
+            return LEALONE_DRIVER;
         } else if (rawUrl.startsWith("jdbc:mckoi:")) {
             return "com.mckoi.JDBCDriver";
         } else if (rawUrl.startsWith("jdbc:cloudscape:")) {
@@ -577,7 +579,7 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.sqlite;
         } else if (rawUrl.startsWith("jdbc:ingres:")) {
             return DbType.ingres;
-        } else if (rawUrl.startsWith("jdbc:h2:") || rawUrl.startsWith("jdbc:log4jdbc:h2:")) {
+        } else if (rawUrl.startsWith("jdbc:h2:") || rawUrl.startsWith("jdbc:log4jdbc:h2:") || rawUrl.startsWith("jdbc:lealone:")) {
             return DbType.h2;
         } else if (rawUrl.startsWith("jdbc:mckoi:")) {
             return DbType.mock;
@@ -961,6 +963,7 @@ public final class JdbcUtils implements JdbcConstants {
             case mariadb:
             case tidb:
             case h2:
+            case lealone:
                 return true;
             default:
                 return false;

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -579,8 +579,10 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.sqlite;
         } else if (rawUrl.startsWith("jdbc:ingres:")) {
             return DbType.ingres;
-        } else if (rawUrl.startsWith("jdbc:h2:") || rawUrl.startsWith("jdbc:log4jdbc:h2:") || rawUrl.startsWith("jdbc:lealone:")) {
+        } else if (rawUrl.startsWith("jdbc:h2:") || rawUrl.startsWith("jdbc:log4jdbc:h2:")) {
             return DbType.h2;
+        } else if (rawUrl.startsWith("jdbc:lealone:")) {
+            return DbType.lealone;
         } else if (rawUrl.startsWith("jdbc:mckoi:")) {
             return DbType.mock;
         } else if (rawUrl.startsWith("jdbc:cloudscape:")) {

--- a/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
@@ -110,6 +110,7 @@ public class WallFilter extends FilterAdapter implements WallFilterMBean {
             case mariadb:
             case tidb:
             case h2:
+            case lealone:
             case presto:
             case trino:
                 if (config == null) {

--- a/druid-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/druid-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -100,6 +100,9 @@
           "value": "h2"
         },
         {
+          "value": "lealone"
+        },
+        {
           "value": "dm"
         },
         {
@@ -167,6 +170,9 @@
         },
         {
           "value": "h2"
+        },
+        {
+          "value": "lealone"
         },
         {
           "value": "dm"


### PR DESCRIPTION
https://github.com/lealone/Lealone
Lealone是基于H2发展而来的数据库

已经在本地测试过. 截图如下:
所有选项卡都是正常的, 包括首页, 数据源, SQL监控, SQL防火墙, Web应用, URI监控, Session监控, Spring监控, JSON API, 都有内容, 不再一一截图.
开启慢sql记录后, 慢sql也记录到了错误日志文件.
![image](https://github.com/alibaba/druid/assets/8288988/e2127671-e5b4-43b0-84f9-b137358f5161)
![image](https://github.com/alibaba/druid/assets/8288988/05c24365-b3a9-4268-bdb1-a9123ad4177d)
![image](https://github.com/alibaba/druid/assets/8288988/a7db18fc-fd92-4e4d-8ea6-1285c100eaee)
