### PR TITLE
补充 mysql visitor 丢失的 endVisit 方法

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableChangeColumn.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableChangeColumn.java
@@ -40,6 +40,7 @@ public class MySqlAlterTableChangeColumn extends MySqlObjectImpl implements SQLA
             acceptChild(visitor, firstColumn);
             acceptChild(visitor, afterColumn);
         }
+        visitor.endVisit(this);
     }
 
     public SQLName getFirstColumn() {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableModifyColumn.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableModifyColumn.java
@@ -37,6 +37,7 @@ public class MySqlAlterTableModifyColumn extends MySqlObjectImpl implements SQLA
             acceptChild(visitor, firstColumn);
             acceptChild(visitor, afterColumn);
         }
+        visitor.endVisit(this);
     }
 
     public SQLName getFirstColumn() {


### PR DESCRIPTION
添加 MySqlAlterTableChangeColumn 以及 MySqlAlterTableModifyColumn 缺失的 endVisit 方法调用
