### PR TITLE
修复SQLUtils的toSQLString在VisitorFeature.OutputNameQuote模式下,会将Mysql的TIME…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -1910,6 +1910,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     protected void printMethodParameters(SQLMethodInvokeExpr x) {
         String function = x.getMethodName();
+        long nameHashCode64 = x.methodNameHashCode64();
         List<SQLExpr> parameters = x.getArguments();
 
         print('(');
@@ -1954,6 +1955,14 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                     this.indentCount++;
                     printExpr(param, parameterized);
                     this.indentCount--;
+                    continue;
+                }
+            }
+
+            if (i == 0 && (nameHashCode64 == FnvHash.Constants.TIMESTAMPDIFF || nameHashCode64 == FnvHash.Constants.TIMESTAMPADD)
+                    && param instanceof SQLIdentifierExpr) {
+                if (DbType.mysql == dbType) {
+                    print(((SQLIdentifierExpr) param).getName());
                     continue;
                 }
             }


### PR DESCRIPTION
修复SQLUtils的toSQLString在VisitorFeature.OutputNameQuote模式下,会将Mysql的TIMESTAMPDIFF和TIMESTAMPADD第一个unit参数当作字段添加``问题 #5309