### PR TITLE
补齐换行符归一化确保单元测试用例在Windows上也能正常运行#5334

### DIFF
--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/parser/MySqlParserResourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/parser/MySqlParserResourceTest.java
@@ -58,7 +58,7 @@ public class MySqlParserResourceTest extends TestCase {
         JdbcUtils.close(reader);
         String[] items = input.split("---------------------------");
         String sql = items[0].trim();
-        String expect = items[1].trim();
+        String expect = items[1].trim().replaceAll("\\r\\n", "\n");
 
         MySqlStatementParser parser = new MySqlStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsInsertTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsInsertTest.java
@@ -48,7 +48,7 @@ public class OdpsInsertTest extends TestCase {
         JdbcUtils.close(reader);
         String[] items = input.split("---------------------------");
         String sql = items[0].trim();
-        String expect = items[1].trim();
+        String expect = items[1].trim().replaceAll("\\r\\n", "\n");
 
         OdpsStatementParser parser = new OdpsStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsMultiInsertTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsMultiInsertTest.java
@@ -48,7 +48,7 @@ public class OdpsMultiInsertTest extends TestCase {
         JdbcUtils.close(reader);
         String[] items = input.split("---------------------------");
         String sql = items[0].trim();
-        String expect = items[1].trim();
+        String expect = items[1].trim().replaceAll("\\r\\n", "\n");
 
         OdpsStatementParser parser = new OdpsStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsResourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsResourceTest.java
@@ -67,11 +67,11 @@ public class OdpsResourceTest extends TestCase {
     public void exec_test(String resource) throws Exception {
         String input = TestUtil.getResource(resource);
         String[] items = input.split("---------------------------");
-        String sql = items[0].trim();
+        String sql = items[0].trim().replaceAll("\\r\\n", "\n");
         String expect = null;
 
         if (items.length > 1) {
-            expect = items[1].trim();
+            expect = items[1].trim().replaceAll("\\r\\n", "\n");
         }
 
         OdpsStatementParser parser = new OdpsStatementParser(sql, SQLParserFeature.KeepComments);

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsSelect_distribute_by_Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsSelect_distribute_by_Test.java
@@ -50,7 +50,7 @@ public class OdpsSelect_distribute_by_Test extends TestCase {
         JdbcUtils.close(reader);
         String[] items = input.split("---------------------------");
         String sql = items[0].trim();
-        String expect = items[1].trim();
+        String expect = items[1].trim().replaceAll("\\r\\n", "\n");
 
         OdpsStatementParser parser = new OdpsStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/sql/odps/OdpsFileTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/odps/OdpsFileTest.java
@@ -47,8 +47,8 @@ public class OdpsFileTest extends TestCase {
         String input = Utils.read(reader);
         JdbcUtils.close(reader);
         String[] items = input.split("---------------------------");
-        String sql = items[0].trim();
-        String expect = items[1].trim();
+        String sql = items[0].trim().replaceAll("\\r\\n", "\n");
+        String expect = items[1].trim().replaceAll("\\r\\n", "\n");
 
         OdpsStatementParser parser = new OdpsStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();


### PR DESCRIPTION
补齐换行符归一化操作，确保执行 mvn clean install命令时，单元测试用例在Windows上也能正常运行#5334