### PR TITLE
增加TimeoutFilter，用来创建控制创建连接的最大时间。

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/timeout/TimeoutFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/timeout/TimeoutFilter.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.filter.timeout;
+
+import com.alibaba.druid.DruidRuntimeException;
+import com.alibaba.druid.filter.FilterAdapter;
+import com.alibaba.druid.filter.FilterChain;
+import com.alibaba.druid.pool.DruidAbstractDataSource;
+import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
+import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
+
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.*;
+
+public class TimeoutFilter extends FilterAdapter {
+    static ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+    public ConnectionProxy connection_connect(FilterChain chain, Properties info) throws SQLException {
+        DataSourceProxy dataSource = chain.getDataSource();
+        if (!(dataSource instanceof DruidAbstractDataSource)) {
+            throw new IllegalArgumentException("timeout filter can only use on druid datasource.");
+        }
+        long maxConnectTime = ((DruidAbstractDataSource) dataSource).getMaxConnect();
+        if (maxConnectTime < 0) {
+            return chain.connection_connect(info);
+        }
+        Future<ConnectionProxy> future = executorService.submit(() -> chain.connection_connect(info));
+        try {
+            return future.get(maxConnectTime, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            String errMessage = String.format("create The creation time exceeded the limit time milliseconds %d", maxConnectTime);
+            throw new DruidRuntimeException(errMessage, e);
+        }
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -68,6 +68,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     public static final int DEFAULT_MAX_IDLE = 8;
     public static final int DEFAULT_MIN_IDLE = 0;
     public static final int DEFAULT_MAX_WAIT = -1;
+    public static final int DEFAULT_MAX_CONNECT = -1;
     public static final String DEFAULT_VALIDATION_QUERY = null;                                                //
     public static final boolean DEFAULT_TEST_ON_BORROW = false;
     public static final boolean DEFAULT_TEST_ON_RETURN = false;
@@ -104,6 +105,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     protected volatile int minIdle = DEFAULT_MIN_IDLE;
     protected volatile int maxIdle = DEFAULT_MAX_IDLE;
     protected volatile long maxWait = DEFAULT_MAX_WAIT;
+    protected volatile long maxConnect = DEFAULT_MAX_CONNECT;
     protected int notFullTimeoutRetryCount;
 
     protected volatile String validationQuery = DEFAULT_VALIDATION_QUERY;
@@ -1088,6 +1090,14 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
         }
 
         this.maxWait = maxWaitMillis;
+    }
+
+    public long getMaxConnect() {
+        return maxConnect;
+    }
+
+    public void setMaxConnect(long maxConnectMillis) {
+        this.maxConnect = maxConnectMillis;
     }
 
     public int getNotFullTimeoutRetryCount() {

--- a/core/src/main/resources/META-INF/druid-filter.properties
+++ b/core/src/main/resources/META-INF/druid-filter.properties
@@ -12,3 +12,4 @@ druid.filters.wall=com.alibaba.druid.wall.WallFilter
 druid.filters.config=com.alibaba.druid.filter.config.ConfigFilter
 druid.filters.haRandomValidator=com.alibaba.druid.pool.ha.selector.RandomDataSourceValidateFilter
 druid.filters.mysql8DateTime=com.alibaba.druid.filter.mysql8datetime.MySQL8DateTimeSqlTypeFilter
+druid.filters.timeout=com.alibaba.druid.filter.timeout.TimeoutFilter

--- a/core/src/test/java/com/alibaba/druid/bvt/proxy/TimeoutFilterTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/proxy/TimeoutFilterTest.java
@@ -1,0 +1,49 @@
+package com.alibaba.druid.bvt.proxy;
+
+import com.alibaba.druid.DruidRuntimeException;
+import com.alibaba.druid.mock.MockDriver;
+import com.alibaba.druid.pool.DruidDataSource;
+import junit.framework.TestCase;
+
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+
+public class TimeoutFilterTest extends TestCase {
+
+    public void test_connection_connect_fail() throws SQLException {
+        MockDriver driver = new MockDriver();
+        Properties connectionProperties = new Properties();
+        connectionProperties.put("connectSleep", "3000");
+        connectionProperties.put("executeSleep", "1000");
+        try (final DruidDataSource dataSource = new DruidDataSource()) {
+            dataSource.setUrl("jdbc:mock:xxx");
+            dataSource.setDriver(driver);
+            dataSource.setInitialSize(1);
+            dataSource.setMinIdle(1);
+            dataSource.setFilters("timeout");
+            dataSource.setMaxConnect(1000);
+            dataSource.setConnectProperties(connectionProperties);
+            dataSource.getConnection();
+        } catch (DruidRuntimeException e) {
+            assertTrue(e.getCause() instanceof TimeoutException);
+        }
+    }
+
+    public void test_connection_connect_success() throws SQLException {
+        MockDriver driver = new MockDriver();
+        Properties connectionProperties = new Properties();
+        connectionProperties.put("connectSleep", "3000");
+        connectionProperties.put("executeSleep", "1000");
+        try (final DruidDataSource dataSource = new DruidDataSource()) {
+            dataSource.setUrl("jdbc:mock:xxx");
+            dataSource.setDriver(driver);
+            dataSource.setInitialSize(1);
+            dataSource.setMinIdle(1);
+            dataSource.setFilters("timeout");
+            dataSource.setMaxConnect(5000);
+            dataSource.setConnectProperties(connectionProperties);
+            assertNotNull(dataSource.getConnection());
+        }
+    }
+}


### PR DESCRIPTION
参考postgresql的设计。

增加了用来控制创建连接最大耗时的参数，用来防止在连接阶段，tls握手时出现网络异常，导致创建连接线程一直卡在socketread0，直到sockettimeout。
