### PR TITLE
修改触发器sql解析,解决触发器后续sql被吞掉的情况

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -4157,8 +4157,9 @@ public class SQLStatementParser extends SQLParser {
             stmt.setWhen(condition);
         }
 
-        List<SQLStatement> body = this.parseStatementList();
-        if (body == null || body.isEmpty()) {
+        List<SQLStatement> body = new ArrayList<>();
+        this.parseStatementList(body, 1);
+        if (body.isEmpty()) {
             throw new ParserException("syntax error");
         }
         stmt.setBody(body.get(0));


### PR DESCRIPTION
## 修改触发器sql解析

1. 原来的触发器解析时使用 `this.parseStatementList()` 方法解析全部的sql，这样就会导致触发器后续的sql也会一起解析；
2. 解析完成之后需要拿触发器内的sql语句`stmt.setBody(body.get(0))`  这样再触发器后面的sql解析了，但是却被丢弃了，就导致了sql的丢失；
3. 如示例sql中修改前解析出来的SQLStatement 只包含触发器 my_trigger前的，后续的sql将丢失(create table_2)。
相同问题issues [#3989](https://github.com/alibaba/druid/issues/3989)
### 测试sql

```
CREATE TABLE table_1 (
  id INT AUTO_INCREMENT,
  name VARCHAR(100),
  PRIMARY KEY (id)
);

CREATE TRIGGER my_trigger
    BEFORE INSERT ON table_1 
    FOR EACH ROW
BEGIN
    SET NEW.id = (SELECT MAX(id) + 1 FROM table_1 );
END;

CREATE TABLE table_2 (
  id INT AUTO_INCREMENT,
  name VARCHAR(100),
  PRIMARY KEY (id)
);
```

### 测试代码
```
    public static void test(){

        String ddl2 = "CREATE TABLE table_1 (\n" +
                "  id INT AUTO_INCREMENT,\n" +
                "  name VARCHAR(100),\n" +
                "  PRIMARY KEY (id)\n" +
                ");\n" +
                "\n" +
                "CREATE TRIGGER my_trigger\n" +
                "    BEFORE INSERT ON table_1 \n" +
                "    FOR EACH ROW\n" +
                "BEGIN\n" +
                "    SET NEW.id = (SELECT MAX(id) + 1 FROM table_1 );\n" +
                "END;\n" +
                "\n" +
                "CREATE TABLE table_2 (\n" +
                "  id INT AUTO_INCREMENT,\n" +
                "  name VARCHAR(100),\n" +
                "  PRIMARY KEY (id)\n" +
                ");";

        List<SQLStatement> sqlStatements = SQLUtils.parseStatements(ddl2, DbType.mysql);
        System.out.println("ok");
    }
```
