### PR TITLE
针对Issue 5430，增强了hive create table sql的解析识别逻辑 #5430

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLColumnDefinition.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLColumnDefinition.java
@@ -34,6 +34,7 @@ public class SQLColumnDefinition extends SQLObjectImpl implements SQLTableElemen
     protected SQLDataType dataType;
     protected SQLExpr defaultExpr;
     protected final List<SQLColumnConstraint> constraints = new ArrayList<SQLColumnConstraint>(0);
+    protected boolean disableNovalidate;
     protected SQLExpr comment;
 
     protected Boolean enable;
@@ -267,6 +268,14 @@ public class SQLColumnDefinition extends SQLObjectImpl implements SQLTableElemen
             constraint.setParent(this);
         }
         this.constraints.add(constraint);
+    }
+
+    public boolean isDisableNovalidate() {
+        return disableNovalidate;
+    }
+
+    public void setDisableNovalidate(boolean disableNovalidate) {
+        this.disableNovalidate = disableNovalidate;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
@@ -191,7 +191,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
     }
 
     public static enum Type {
-        GLOBAL_TEMPORARY, LOCAL_TEMPORARY, TEMPORARY, SHADOW
+        GLOBAL_TEMPORARY, LOCAL_TEMPORARY, TEMPORARY, SHADOW, TRANSACTIONAL
     }
 
     public List<SQLTableElement> getTableElementList() {

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnique.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnique.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class SQLUnique extends SQLConstraintImpl implements SQLUniqueConstraint, SQLTableElement {
     protected final SQLIndexDefinition indexDefinition = new SQLIndexDefinition();
 
+    protected boolean disableNovalidate;
     public SQLUnique() {
         indexDefinition.setParent(this);
     }
@@ -47,6 +48,14 @@ public class SQLUnique extends SQLConstraintImpl implements SQLUniqueConstraint,
     @Override
     public void setName(String name) {
         this.setName(new SQLIdentifierExpr(name));
+    }
+
+    public boolean isDisableNovalidate() {
+        return disableNovalidate;
+    }
+
+    public void setDisableNovalidate(boolean disableNovalidate) {
+        this.disableNovalidate = disableNovalidate;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.expr.SQLListExpr;
 import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement.Type;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInputOutputFormat;
 import com.alibaba.druid.sql.dialect.hive.stmt.HiveCreateTableStatement;
 import com.alibaba.druid.sql.parser.*;
@@ -54,6 +55,10 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
             stmt.setType(SQLCreateTableStatement.Type.TEMPORARY);
         }
 
+        if (lexer.stringVal().equalsIgnoreCase("TRANSACTIONAL")) {
+            lexer.nextToken();
+            stmt.setType(Type.TRANSACTIONAL);
+        }
         accept(Token.TABLE);
 
         if (lexer.token() == Token.IF || lexer.identifierEquals(FnvHash.Constants.IF)) {
@@ -249,6 +254,10 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
             parseRowFormat(stmt);
         }
 
+        if (Token.LBRACKET.equals(lexer.token())) {
+            stmt.setLbracketUse(true);
+            lexer.nextToken();
+        }
         if (lexer.identifierEquals(FnvHash.Constants.STORED)) {
             lexer.nextToken();
             accept(Token.AS);
@@ -269,6 +278,10 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
             }
         }
 
+        if (Token.RBRACKET.equals(lexer.token())) {
+            stmt.setRbracketUse(true);
+            lexer.nextToken();
+        }
         if (lexer.identifierEquals(FnvHash.Constants.LOCATION)) {
             lexer.nextToken();
             SQLExpr location = this.exprParser.primary();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/stmt/HiveCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/stmt/HiveCreateTableStatement.java
@@ -39,12 +39,30 @@ public class HiveCreateTableStatement extends SQLCreateTableStatement {
     protected SQLExpr intoBuckets;
     protected SQLExpr using;
 
+    private boolean lbracketUse;
+    private boolean rbracketUse;
     public HiveCreateTableStatement() {
         this.dbType = DbType.hive;
     }
 
     public HiveCreateTableStatement(DbType dbType) {
         this.dbType = dbType;
+    }
+
+    public boolean isLbracketUse() {
+        return lbracketUse;
+    }
+
+    public void setLbracketUse(boolean lbracketUse) {
+        this.lbracketUse = lbracketUse;
+    }
+
+    public boolean isRbracketUse() {
+        return rbracketUse;
+    }
+
+    public void setRbracketUse(boolean rbracketUse) {
+        this.rbracketUse = rbracketUse;
     }
 
     protected void accept0(SQLASTVisitor v) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.ast.*;
 import com.alibaba.druid.sql.ast.expr.*;
 import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement.Type;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTriggerStatement.TriggerType;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsert;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInsertStatement;
@@ -3435,9 +3436,14 @@ public class SQLStatementParser extends SQLParser {
         }
 
         boolean temporary = false;
+        boolean transactional = false;
         if (lexer.identifierEquals(FnvHash.Constants.TEMPORARY) || lexer.token == Token.TEMPORARY) {
             lexer.nextToken();
             temporary = true;
+        }
+        if ("TRANSACTIONAL".equalsIgnoreCase(lexer.stringVal())) {
+            lexer.nextToken();
+            transactional = true;
         }
 
         boolean nonclustered = false;
@@ -3461,6 +3467,9 @@ public class SQLStatementParser extends SQLParser {
                     }
                 }
 
+                if (transactional) {
+                    stmt.setType(Type.TRANSACTIONAL);
+                }
                 if (comments != null) {
                     stmt.addBeforeComment(comments);
                 }

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.*;
 import com.alibaba.druid.sql.ast.expr.*;
 import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement.Type;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTriggerStatement.TriggerType;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement.ValuesClause;
 import com.alibaba.druid.sql.ast.statement.SQLJoinTableSource.JoinType;
@@ -3354,6 +3355,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             }
         }
 
+        if (x.isDisableNovalidate()) {
+            print0(ucase ? " DISABLE NOVALIDATE" : " disable novalidate");
+        }
         SQLExpr generatedAlawsAs = x.getGeneratedAlawsAs();
         if (generatedAlawsAs != null) {
             print0(ucase ? " GENERATED ALWAYS AS " : " generated always as ");
@@ -3691,6 +3695,8 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             print0(ucase ? "LOCAL TEMPORARY " : "local temporary ");
         } else if (SQLCreateTableStatement.Type.SHADOW.equals(tableType)) {
             print0(ucase ? "SHADOW " : "shadow ");
+        } else if (Type.TRANSACTIONAL.equals(tableType)) {
+            print0(ucase ? "TRANSACTIONAL " : "transactional ");
         }
 
         if (x.isDimension()) {
@@ -5813,6 +5819,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         print0(ucase ? "UNIQUE (" : "unique (");
         printAndAccept(x.getColumns(), ", ");
         print(')');
+        if (x.isDisableNovalidate()) {
+            print0(ucase ? " DISABLE NOVALIDATE" : " disable novalidate");
+        }
         return false;
     }
 
@@ -10693,6 +10702,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         if (SQLCreateTableStatement.Type.TEMPORARY.equals(tableType)) {
             print0(ucase ? "TEMPORARY " : "temporary ");
         }
+        if (Type.TRANSACTIONAL.equals(tableType)) {
+            print0(ucase ? "TRANSACTIONAL " : "transactional ");
+        }
         print0(ucase ? "TABLE " : "table ");
 
         if (x.isIfNotExists()) {
@@ -10858,6 +10870,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         SQLExpr storedAs = x.getStoredAs();
         if (storedAs != null) {
             println();
+            if (x.isLbracketUse()) {
+                print("[");
+            }
             print0(ucase ? "STORED AS" : "stored as");
             if (storedAs instanceof SQLIdentifierExpr) {
                 print(' ');
@@ -10867,6 +10882,10 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 println();
                 printExpr(storedAs, parameterized);
                 decrementIndent();
+            }
+
+            if (x.isRbracketUse()) {
+                print("]");
             }
         }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/hive/issues/Issue5430.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/hive/issues/Issue5430.java
@@ -1,0 +1,186 @@
+package com.alibaba.druid.bvt.sql.hive.issues;
+
+import java.util.Map;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.stat.TableStat.Name;
+import com.alibaba.druid.support.logging.Log;
+import com.alibaba.druid.support.logging.LogFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5430">Issue 5430</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL">Hive DDL</a>
+ * @todo 还有4个SQL解析存在转义字符识别的问题，暂时忽略，等温少来解决识别问题吧
+ */
+public class Issue5430 {
+
+    private static final Log log = LogFactory.getLog(Issue5430.class);
+
+    @Test
+    public void test_createTable() throws Exception {
+        DbType dbType = DbType.hive;
+        int index = 0;
+        for (String sql : new String[]{"Create table if not exists data01.test_20230830(a string ,b string) "
+            + "PARTITIONED BY (load_date date, org string) ROW FORMAT DELIMITED NULL DEFINED AS '' STORED AS ORC",
+            "Create table if not exists data01.test_20230830(a string ,b string) "
+                + "PARTITIONED BY (load_date date, org string) ROW FORMAT DELIMITED NULL DEFINED AS \"\" STORED AS ORC",
+            "Create table if not exists data01.test_20230830(a string ,b string) "
+                + "PARTITIONED BY (load_date date, org string) ROW FORMAT DELIMITED NULL DEFINED AS 'aa' STORED AS ORC",
+            "Create table if not exists data01.test_20230830(a string ,b string) "
+                + "PARTITIONED BY (load_date date, org string) ROW FORMAT DELIMITED NULL DEFINED AS \"aa\" STORED AS ORC",
+            "CREATE TABLE my_table(a string, b bigint)\n"
+                + "ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'\n"
+                + "STORED AS TEXTFILE",
+            "CREATE TABLE my_table(a string, b bigint)\n"
+                + "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.JsonSerDe'\n"
+                + "STORED AS TEXTFILE",
+            "CREATE TABLE my_table(a string, b bigint) STORED AS JSONFILE",
+            "create table table_name (\n"
+                + "  id                int,\n"
+                + "  dtDontQuery       string,\n"
+                + "  name              string\n"
+                + ")\n"
+                + "partitioned by (date string)",
+            "CREATE TABLE page_view(viewTime INT, userid BIGINT,\n"
+                + "     page_url STRING, referrer_url STRING,\n"
+                + "     ip STRING COMMENT 'IP Address of the User')\n"
+                + " COMMENT 'This is the page view table'\n"
+                + " PARTITIONED BY(dt STRING, country STRING)\n"
+                + " STORED AS SEQUENCEFILE",
+            "CREATE TABLE page_view(viewTime INT, userid BIGINT,\n"
+                + "     page_url STRING, referrer_url STRING,\n"
+                + "     ip STRING COMMENT 'IP Address of the User')\n"
+                + " COMMENT 'This is the page view table'\n"
+                + " PARTITIONED BY(dt STRING, country STRING)\n"
+                + " ROW FORMAT DELIMITED\n"
+                + "   FIELDS TERMINATED BY '\\001'\n"
+                + "STORED AS SEQUENCEFILE",
+            "CREATE EXTERNAL TABLE page_view(viewTime INT, userid BIGINT,\n"
+                + "     page_url STRING, referrer_url STRING,\n"
+                + "     ip STRING COMMENT 'IP Address of the User',\n"
+                + "     country STRING COMMENT 'country of origination')\n"
+                + " COMMENT 'This is the staging page view table'\n"
+                + " ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\054'\n"
+                + " STORED AS TEXTFILE\n"
+                + " LOCATION '<hdfs_location>'",
+            "CREATE TABLE list_bucket_single (key STRING, value STRING)\n"
+                + "  SKEWED BY (key) ON (1,5,6) [STORED AS DIRECTORIES]",
+            "CREATE TABLE list_bucket_multiple (col1 STRING, col2 int, col3 STRING)\n"
+                + "  SKEWED BY (col1, col2) ON (('s1',1), ('s3',3), ('s13',13), ('s78',78)) [STORED AS DIRECTORIES]",
+            "CREATE TEMPORARY TABLE list_bucket_multiple (col1 STRING, col2 int, col3 STRING)",
+            "CREATE TRANSACTIONAL TABLE transactional_table_test(key string, value string) PARTITIONED BY(ds string) STORED AS ORC",
+            "create table pk(id1 integer, id2 integer,\n"
+                + "  primary key(id1, id2) disable novalidate)",
+            "create table fk(id1 integer, id2 integer,\n"
+                + "  constraint c1 foreign key(id1, id2) references pk(id2, id1) disable novalidate)",
+            "create table constraints1(id1 integer UNIQUE disable novalidate, id2 integer NOT NULL,\n"
+                + "  usr string DEFAULT current_user(), price double CHECK (price > 0 AND price <= 1000))",
+            "create table constraints2(id1 integer, id2 integer,\n"
+                + "  constraint c1_unique UNIQUE(id1) disable novalidate)",
+            "create table constraints3(id1 integer, id2 integer,\n"
+                + "  constraint c1_check CHECK(id1 + id2 > 0))",
+            "CREATE TABLE apachelog (\n"
+                + "  host STRING,\n"
+                + "  identity STRING,\n"
+                + "  user STRING,\n"
+                + "  time STRING,\n"
+                + "  request STRING,\n"
+                + "  status STRING,\n"
+                + "  size STRING,\n"
+                + "  referer STRING,\n"
+                + "  agent STRING)\n"
+                + "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'\n"
+                + "WITH SERDEPROPERTIES (\n"
+                + "  \"input.regex\" = \"([^]*) ([^]*) ([^]*) (-|\\\\[^\\\\]*\\\\]) ([^ \\\"]*|\\\"[^\\\"]*\\\") (-|[0-9]*) (-|[0-9]*)(?: ([^ \\\"]*|\\\".*\\\") ([^ \\\"]*|\\\".*\\\"))?\"\n"
+                + ")\n"
+                + "STORED AS TEXTFILE;",
+
+            "CREATE TABLE my_table(a string, b string)\n"
+                + "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'\n"
+                + "WITH SERDEPROPERTIES (\n"
+                + "   \"separatorChar\" = \"\\t\",\n"
+                + "   \"quoteChar\"     = \"'\",\n"
+                + "   \"escapeChar\"    = \"\\\\\"\n"
+                + ")  \n"
+                + "STORED AS TEXTFILE",
+            "CREATE TABLE new_key_value_store\n"
+                + "   ROW FORMAT SERDE \"org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe\"\n"
+                + "   STORED AS RCFile\n"
+                + "   AS\n"
+                + "SELECT (key % 1024) new_key, concat(key, value) key_value_pair\n"
+                + "FROM key_value_store\n"
+                + "SORT BY new_key, key_value_pair",
+
+            "CREATE TABLE page_view(viewTime INT, userid BIGINT,\n"
+                + "     page_url STRING, referrer_url STRING,\n"
+                + "     ip STRING COMMENT 'IP Address of the User')\n"
+                + " COMMENT 'This is the page view table'\n"
+                + " PARTITIONED BY(dt STRING, country STRING)\n"
+                + " CLUSTERED BY(userid) SORTED BY(viewTime) INTO 32 BUCKETS\n"
+                + " ROW FORMAT DELIMITED\n"
+                + "   FIELDS TERMINATED BY '\\001'\n"
+                + "   COLLECTION ITEMS TERMINATED BY '\\002'\n"
+                + "   MAP KEYS TERMINATED BY '\\003'\n"
+                + " STORED AS SEQUENCEFILE",
+        }) {
+            index++;
+            if (index >=21) {
+                continue;
+            }
+            String normalizeSql = normalizeSql(sql);
+            System.out.println("第" + index + "条原始的sql格式归一化===" + normalizeSql);
+            SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+            SQLStatement statement = parser.parseStatement();
+            String newSql = statement.toString();
+            String normalizeNewSql = normalizeSql(newSql);
+            System.out.println("第" + index + "条生成的sql格式归一化===" + normalizeNewSql);
+            assertEquals(normalizeSql.toLowerCase(),normalizeNewSql.toLowerCase());
+            if (!normalizeSql.equalsIgnoreCase(normalizeNewSql)) {
+                System.err.println("第" + index + "条是解析失败原始的sql===" + normalizeSql);
+            }
+            //assertTrue(newSql.equalsIgnoreCase(sql));
+            SchemaStatVisitor visitor = SQLUtils.createSchemaStatVisitor(dbType);
+            statement.accept(visitor);
+            System.out.println("getTables==" + visitor.getTables());
+            Map<Name, TableStat> tableMap = visitor.getTables();
+            assertFalse(tableMap.isEmpty());
+
+        }
+    }
+
+    static String normalizeSql(String sql) {
+        sql = StringUtils.replace(sql, " ( ", "(");
+        sql = StringUtils.replace(sql, "( ", "(");
+        sql = StringUtils.replace(sql, " )", ")");
+        sql = StringUtils.replace(sql, "\t", " ");
+        sql = StringUtils.replace(sql, "\n", " ");
+        sql = StringUtils.replace(sql, "\'", "\"");
+        sql = StringUtils.replace(sql, " ( ", "(");
+        sql = StringUtils.replace(sql, " (", "(");
+        sql = StringUtils.replace(sql, "( ", "(");
+        sql = StringUtils.replace(sql, " )", ")");
+        sql = StringUtils.replace(sql, "( ", "(");
+        sql = StringUtils.replace(sql, "  ", " ");
+        sql = StringUtils.replace(sql, "  ", " ");
+        sql = StringUtils.replace(sql, "  ", " ");
+        sql = StringUtils.replace(sql, "  ", " ");
+        sql = StringUtils.replace(sql, "( ", "(");
+        sql = StringUtils.replace(sql, ", ", ",");
+        sql = StringUtils.replace(sql, " ,", ",");
+        return sql;
+    }
+}


### PR DESCRIPTION
针对Issue 5430 #5430 ，增强了hive create table sql的解析识别逻辑,但是hive官方示例中的所有sql样本，还有几个没有搞定
暂时跳过断言验证，待后续有能力搞定时候再加适配逻辑，或者等温少搞定。
hive 官方sql示例来自： https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL
