### PR TITLE
修复bug：socketTimeout参数不支持mysql jdbcurl里设置socketTimeout=0的场景 #5451

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -830,19 +830,18 @@ public class DruidDataSource extends DruidAbstractDataSource
                 this.transactionIdSeedUpdater.addAndGet(this, delta);
             }
 
-            if (this.jdbcUrl != null) {
-                this.jdbcUrl = this.jdbcUrl.trim();
-                initFromWrapDriverUrl();
-
-                initFromUrlOrProperties();
-            }
-
             if (connectTimeout == 0) {
                 connectTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
             }
 
             if (socketTimeout == 0) {
                 socketTimeout = DEFAULT_TIME_SOCKET_TIMEOUT_MILLIS;
+            }
+
+            if (this.jdbcUrl != null) {
+                this.jdbcUrl = this.jdbcUrl.trim();
+                initFromWrapDriverUrl();
+                initFromUrlOrProperties();
             }
 
             for (Filter filter : filters) {

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
@@ -41,7 +41,22 @@ public class DruidDataSourceTest10 {
         assertEquals(3000, ds.getConnectTimeout());
         assertEquals(6000, ds.getSocketTimeout());
     }
-
+    @Test
+    public void test_timeout_is_zero() throws Exception {
+        ds.setUrl("jdbc:mysql://127.0.0.1:3306/xxx?connectTimeout=0&socketTimeout=0");
+        ds.init();
+        assertEquals(0, ds.getConnectTimeout());
+        assertEquals(0, ds.getSocketTimeout());
+    }
+    @Test
+    public void test_timeout_is_zero2() throws Exception {
+        ds.setUrl("jdbc:mysql://127.0.0.1:3306/xxx");
+        ds.setConnectTimeout(-1);
+        ds.setSocketTimeout(-1);
+        ds.init();
+        assertEquals(-1, ds.getConnectTimeout());
+        assertEquals(-1, ds.getSocketTimeout());
+    }
     @Test
     public void test2() throws Exception {
         Properties properties = new Properties();


### PR DESCRIPTION
socketTimeout参数不支持mysql jdbcurl里设置socketTimeout=0的场景
mvn validate通过
mvn clean install未新增错误。