### PR TITLE
针对mysql loadbalance格式的url，加上connectTimeout等属性的识别支持 #5396

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1012,7 +1012,7 @@ public class DruidDataSource extends DruidAbstractDataSource
     }
 
     private void initFromUrlOrProperties() {
-        if (jdbcUrl.startsWith("jdbc:mysql://")) {
+        if (jdbcUrl.startsWith("jdbc:mysql://") || jdbcUrl.startsWith("jdbc:mysql:loadbalance://")) {
             if (jdbcUrl.indexOf("connectTimeout=") != -1 || jdbcUrl.indexOf("socketTimeout=") != -1) {
                 String[] items = jdbcUrl.split("(\\?|&)");
                 for (int i = 0; i < items.length; i++) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -53,7 +53,7 @@ public class PGExprParser extends SQLExprParser {
     }
 
     public PGExprParser(String sql, SQLParserFeature... features) {
-        this(new PGLexer(sql));
+        this(new PGLexer(sql, features));
         this.lexer.nextToken();
         this.dbType = DbType.postgresql;
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
@@ -57,6 +57,19 @@ public class DruidDataSourceTest10 {
         assertEquals(-1, ds.getConnectTimeout());
         assertEquals(-1, ds.getSocketTimeout());
     }
+
+    /**
+     * @throws Exception
+     * @see https://github.com/alibaba/druid/issues/5396
+     */
+    @Test
+    public void test_timeout_in_loadbalance() throws Exception {
+        ds.setUrl(
+            "jdbc:mysql:loadbalance://localhost:3306,localhost:3310/test?connectTimeout=0&socketTimeout=0&loadBalanceConnectionGroup=first&ha.enableJMX=true");
+        ds.init();
+        assertEquals(0, ds.getConnectTimeout());
+        assertEquals(0, ds.getSocketTimeout());
+    }
     @Test
     public void test2() throws Exception {
         Properties properties = new Properties();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5287.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5287.java
@@ -1,0 +1,59 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import java.util.Map;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLOrderBy;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
+import com.alibaba.druid.sql.parser.SQLParserFeature;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.stat.TableStat;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 验证 Postgresql 没有解析行号的问题 #5287
+ *
+ * @author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5287">增强 #5287</a>
+ */
+public class Issue5287 {
+
+    @Test
+    public void test_get_source_location() throws Exception {
+        for (DbType dbType : new DbType[]{DbType.postgresql}) {
+            String sql =
+                "select * from t1 \n"
+                    + " where a=1 \n"
+                    + " and b =2 \n"
+                    + " order by c desc;";
+            SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+            PGSelectStatement statement = (PGSelectStatement) parser.parseStatement();
+            SQLOrderBy orderBy = statement.getSelect().getQueryBlock().getOrderBy();
+            SQLExpr cExpr = orderBy.getItems().get(0).getExpr();
+            SQLIdentifierExpr si = (SQLIdentifierExpr) cExpr;
+            int sourceLine1 = si.getSourceLine();
+            System.out.println(" statement.getSourceLine()===" + orderBy.getSourceLine() + "||" + sourceLine1);
+            assertEquals(0, sourceLine1);
+            parser = SQLParserUtils.createSQLStatementParser(sql, dbType, SQLParserFeature.KeepSourceLocation);
+            statement = (PGSelectStatement) parser.parseStatement();
+            orderBy = statement.getSelect().getQueryBlock().getOrderBy();
+            cExpr = orderBy.getItems().get(0).getExpr();
+            si = (SQLIdentifierExpr) cExpr;
+            int sourceLine2 = si.getSourceLine();
+            System.out.println(" statement.getSourceLine()===" + orderBy.getSourceLine() + "||" + sourceLine2);
+            assertEquals(4, sourceLine2);
+
+        }
+    }
+}


### PR DESCRIPTION
针对mysql loadbalance格式的url，加上connectTimeout等属性的识别支持 #5396
 if (jdbcUrl.startsWith("jdbc:mysql://") || jdbcUrl.startsWith("jdbc:mysql:loadbalance://")) {
配套单侧验证ok，mvn validate验证ok，mvn clean install 无新增错误