### PR TITLE
修复Web Session Stat中提交事务数一直是0的bug #516 #3821

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -282,6 +282,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
 
         JdbcDataSourceStat dataSourceStat = chain.getDataSource().getDataSourceStat();
         dataSourceStat.getConnectionStat().incrementConnectionCommitCount();
+        StatFilterContext.getInstance().commit();
     }
 
     @Override
@@ -290,6 +291,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
 
         JdbcDataSourceStat dataSourceStat = chain.getDataSource().getDataSourceStat();
         dataSourceStat.getConnectionStat().incrementConnectionRollbackCount();
+        StatFilterContext.getInstance().rollback();
     }
 
     @Override


### PR DESCRIPTION
核实了确实是漏了调用相应方法，现在补上了，不方便单测验证，以工程中实际验证效果图为证
日志核实触发了两次事务提交

![image](https://github.com/alibaba/druid/assets/1670666/f2c2140b-3846-45cb-b18d-9b45f868dd94)

Web Session Stat中提交事务数不再是空白了。

![image](https://github.com/alibaba/druid/assets/1670666/a795ab6b-5a13-4a3b-9dec-210691b16ddd)

