### PR TITLE
单测出错时增加initStackTrace信息方便定位未关闭的数据源

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -3733,6 +3733,7 @@ public class DruidDataSource extends DruidAbstractDataSource
             map.put("ExecuteQueryCount", this.getExecuteQueryCount());
 
             map.put("ExecuteUpdateCount", this.getExecuteUpdateCount());
+            map.put("InitStackTrace", this.getInitStackTrace());
 
             return map;
         } catch (JMException ex) {

--- a/core/src/main/java/com/alibaba/druid/stat/DruidDataSourceStatManager.java
+++ b/core/src/main/java/com/alibaba/druid/stat/DruidDataSourceStatManager.java
@@ -340,6 +340,7 @@ public class DruidDataSourceStatManager implements DruidDataSourceStatManagerMBe
 
                 // 45
                 SimpleType.LONG, //
+                SimpleType.STRING, //
                 //
         };
 
@@ -409,6 +410,7 @@ public class DruidDataSourceStatManager implements DruidDataSourceStatManagerMBe
 
                 // 45 -
                 "ExecuteUpdateCount",
+                "InitStackTrace",
         };
 
         String[] indexDescriptions = indexNames;

--- a/core/src/test/java/com/alibaba/druid/PoolTestCase.java
+++ b/core/src/test/java/com/alibaba/druid/PoolTestCase.java
@@ -18,8 +18,9 @@ public class PoolTestCase extends TestCase {
             CompositeData compositeData = (CompositeData) DruidDataSourceStatManager.getInstance().getDataSourceList().values().iterator().next();
             String name = (String) compositeData.get("Name");
             String url = (String) compositeData.get("URL");
+            String initStackTrace = (String) compositeData.get("InitStackTrace");
 
-            errorInfo = "Name " + name + ", URL " + url;
+            errorInfo = "Name " + name + ", URL " + url + ", initStackTrace=" + initStackTrace;
         }
         Assert.assertEquals(errorInfo, 0, size);
     }


### PR DESCRIPTION
先前没有堆栈信息，不知道未关闭的数据源是哪里创建的，因此针对单测出错时增加initStackTrace信息方便定位未关闭的数据源
在修改完善测试用例之前，先把没风险的代码修改提交上去