### PR TITLE
always using latest OS for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-latest ]
         java: [ 8, 17 ]
       fail-fast: false
       max-parallel: 16


### PR DESCRIPTION
the ubuntu version in ci.yaml should be updated, otherwise the result  of github action will always be  "Waiting for a runner to pick up this job..."
Set it to ubuntu-latest to avoid updating in the future.