### PR TITLE
fix CPU full usage, max active control algorithm, single createSchedulerFuture overwritten by multiple tasks

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1792,9 +1792,9 @@ public class DruidDataSource extends DruidAbstractDataSource
                 }
 
                 if (maxWait > 0) {
-                    long waitNanos = nanos - TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis() - startTime);
-                    if (waitNanos > 0) {
-                        holder = pollLast(waitNanos);
+                    long maxWaitNanos = nanos - TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis() - startTime);
+                    if (maxWaitNanos > 0) {
+                        holder = pollLast(maxWaitNanos);
                     } else {
                         holder = null;
                         break;
@@ -2366,8 +2366,8 @@ public class DruidDataSource extends DruidAbstractDataSource
         return last;
     }
 
-    private DruidConnectionHolder pollLast(long nanos) throws InterruptedException, SQLException {
-        long estimate = nanos;
+    private DruidConnectionHolder pollLast(long maxWaitNanos) throws InterruptedException, SQLException {
+        long estimate = maxWaitNanos;
 
         for (; ; ) {
             if (poolingCount == 0) {
@@ -2423,7 +2423,7 @@ public class DruidDataSource extends DruidAbstractDataSource
             DruidConnectionHolder last = connections[poolingCount];
             connections[poolingCount] = null;
 
-            long waitNanos = nanos - estimate;
+            long waitNanos = maxWaitNanos - estimate;
             last.setLastNotEmptyWaitNanos(waitNanos);
 
             return last;

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1690,7 +1690,6 @@ public class DruidDataSource extends DruidAbstractDataSource
 
         DruidConnectionHolder holder;
 
-        long startTime = System.currentTimeMillis();  //进入循环等待之前，先记录开始尝试获取连接的时间
         for (boolean createDirect = false; ; ) {
             if (createDirect) {
                 createStartNanosUpdater.set(this, System.nanoTime());
@@ -1740,19 +1739,6 @@ public class DruidDataSource extends DruidAbstractDataSource
             }
 
             try {
-                if (activeCount >= maxActive) {
-                    long waitedTime = System.currentTimeMillis() - startTime;
-                    if (maxWait > 0 && waitedTime > maxWait) {
-                        //连接池已满时，如果最大等待时间大于0，且循环等待时间已经大于最大等待时间，则需要抛出异常
-                        connectErrorCountUpdater.incrementAndGet(this);
-                        throw new GetConnectionTimeoutException(
-                            "activeCount(" + activeCount + ")>= maxActive(" + maxActive + ") and waitedTime(" + waitedTime + "ms) > maxWait("
-                                + maxWait + "ms)");
-                    }
-                    createDirect = false;
-                    continue;
-                }
-
                 if (maxWaitThreadCount > 0
                         && notEmptyWaitThreadCount >= maxWaitThreadCount) {
                     connectErrorCountUpdater.incrementAndGet(this);

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -971,7 +971,7 @@ public class DruidDataSource extends DruidAbstractDataSource
             if (keepAlive) {
                 // async fill to minIdle
                 if (createScheduler != null) {
-                    for (int i = 0; i < minIdle; ++i) {
+                    for (int i = 0; i < minIdle - initialSize; ++i) {
                         submitCreateTask(true);
                     }
                 } else {


### PR DESCRIPTION
see #5495 #5500 #5510
1. revert commit 39e8b59 to fix cpu 100% caused by getting connection under activeCount >= maxActive condition.
2. optimize max waiting control algorithm.
3. fix max active control algorithm.
4. store all create scheduler futures.

[the codes of commit 39e8b59](https://github.com/alibaba/druid/commit/39e8b59a77d038a4668f5d0b2ba80c228c8c71a0):
```
for (boolean createDirect = false; ; ) {
    ... ...
    if (activeCount >= maxActive) {
        createDirect = false;
        continue;
    }
    ... ...
}
```
it will cause current application runs into continuous loop when try to get connection under activeCount >= maxActive condition, the cpu usage will soar to 100% during the loop. 