### PR TITLE
确实应该调用jdbc驱动的setSchema #5166 #3932 #3718 #893

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidPooledConnection.java
@@ -1215,7 +1215,7 @@ public class DruidPooledConnection extends PoolableWrapper implements javax.sql.
             }
             return;
         }
-        throw new SQLFeatureNotSupportedException();
+        conn.setSchema(schema);
     }
 
     public String getSchema() throws SQLException {


### PR DESCRIPTION
确实应该调用jdbc驱动的setSchema #5166 #3932 #3718 #893
setSchema 方法的调用是业务方决定的，且业务方使用的jdbc驱动已经支持该特性，druid不能阻拦其使用
业务方需要谨慎调用该方法。