### PR TITLE
 合并pr5276 支持limit offset传0之后，配套用例需要调整

### DIFF
--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectLimitTest_2.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectLimitTest_2.java
@@ -38,7 +38,7 @@ public class WallSelectLimitTest_2 extends TestCase {
         System.out.println(resultSql);
         assertEquals("SELECT *\n" +
                 "FROM t\n" +
-                "LIMIT 10", resultSql);
+                "LIMIT 0, 10", resultSql);
     }
 
     public void testMySql_0() throws Exception {
@@ -70,7 +70,7 @@ public class WallSelectLimitTest_2 extends TestCase {
         System.out.println(resultSql);
         assertEquals("SELECT *\n" +
                 "FROM t\n" +
-                "LIMIT 10", resultSql);
+                "LIMIT 10 OFFSET 0", resultSql);
     }
 
     public void testDB2() throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_0.java
@@ -68,7 +68,7 @@ public class PagerUtilsTest_Limit_mysql_0 extends TestCase {
         String result = PagerUtils.limit(sql, JdbcConstants.MYSQL, 0, 100, true);
         assertEquals("SELECT *\n" +
                 "FROM t\n" +
-                "LIMIT 10", result);
+                "LIMIT 0, 10", result);
     }
 
     public void test_mysql_7() throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_question_placeholder.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/PagerUtilsTest_Limit_mysql_question_placeholder.java
@@ -15,15 +15,17 @@ import java.util.List;
 public class PagerUtilsTest_Limit_mysql_question_placeholder extends TestCase {
     public void testQuestionLimitPlaceholder1() {
         String sql = "select * from test_table limit ?";
-        testQuestionLimitPlaceholderInternal(sql);
+        String expected = "select * from test_table limit 0, ?";
+        testQuestionLimitPlaceholderInternal(expected, sql);
     }
 
     public void testQuestionLimitPlaceholder2() {
         String sql = "select * from test_table limit 0, ?";
-        testQuestionLimitPlaceholderInternal(sql);
+        String expected = "select * from test_table limit 0, ?";
+        testQuestionLimitPlaceholderInternal(expected, sql);
     }
 
-    private void testQuestionLimitPlaceholderInternal(String sql) {
+    private void testQuestionLimitPlaceholderInternal(String expected, String sql) {
         List<SQLStatement> statements;
         try {
             statements = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
@@ -49,7 +51,7 @@ public class PagerUtilsTest_Limit_mysql_question_placeholder extends TestCase {
         SQLUtils.FormatOption options = new SQLUtils.FormatOption();
         options.setPrettyFormat(false);
         options.setUppCase(false);
-        assertEquals(sql, SQLUtils.toSQLString(select, JdbcConstants.MYSQL, options));
+        assertEquals(expected, SQLUtils.toSQLString(select, JdbcConstants.MYSQL, options));
     }
 
 }


### PR DESCRIPTION
 合并pr5276 支持limit offset传0之后，配套用例需要调整
因为offset 0会被输出到sql语句里了。

影响来自 https://github.com/alibaba/druid/pull/5276