### PR TITLE
Fix shrink with on fatal error

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1990,6 +1990,8 @@ public class DruidDataSource extends DruidAbstractDataSource
             ReentrantLock dataSourceLock = holder.getDataSource().lock;
             dataSourceLock.lock();
             try {
+                // increase fatalErrorCountLastShrink otherwise emptySignal will be called again at shrink method.
+                fatalErrorCountLastShrink++;
                 emptySignal();
             } finally {
                 dataSourceLock.unlock();
@@ -3417,7 +3419,7 @@ public class DruidDataSource extends DruidAbstractDataSource
             } finally {
                 lock.unlock();
             }
-        } else if (onFatalError || fatalErrorIncrement > 0) {
+        } else if (fatalErrorIncrement > 0) {
             lock.lock();
             try {
                 emptySignal();

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/exception/OracleExceptionSorterTest_setSavepoint.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/exception/OracleExceptionSorterTest_setSavepoint.java
@@ -67,6 +67,9 @@ public class OracleExceptionSorterTest_setSavepoint extends TestCase {
         }
         Assert.assertNotNull(setError);
 
+        // assert that shrink will not call emptySignal at this time.
+        dataSource.shrink(true, false);
+        
         conn.close();
 
         {


### PR DESCRIPTION
see #5542
1. increase fatalErrorCountLastShrink at handleFatalError(), otherwise emptySignal will be called again at shrink().
2. remove onFatalError from  emptySignal judging condition of shrink(), otherwise emptySignal will be always called by shrink() when onFatalError is true.