### PR TITLE
针对合并pr的mysql jdbc url密码掩码特性，优化加固逻辑

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -4047,12 +4047,20 @@ public class DruidDataSource extends DruidAbstractDataSource
         return fillCount;
     }
 
-    private String sanitizedUrl(String url) {
+    static String sanitizedUrl(String url) {
         if (url == null) {
             return null;
         }
-
-        return url.replaceAll("([?&;]password=)[^&#;]*(.*)", "$1<masked>$2");
+        for (String pwdKeyNamesInMysql : new String[]{
+            "password=", "password1=", "password2=", "password3=",
+            "trustCertificateKeyStorePassword=",
+            "clientCertificateKeyStorePassword=",
+        }) {
+            if (url.contains(pwdKeyNamesInMysql)) {
+                url = url.replaceAll("([?&;]" + pwdKeyNamesInMysql + ")[^&#;]*(.*)", "$1<masked>$2");
+            }
+        }
+        return url;
     }
 
     private boolean isFillable(int toCount) {

--- a/core/src/test/java/com/alibaba/druid/pool/DruidDataSourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/pool/DruidDataSourceTest.java
@@ -1,0 +1,87 @@
+package com.alibaba.druid.pool;
+
+import junit.framework.TestCase;
+
+public class DruidDataSourceTest extends TestCase {
+
+    /**
+     * 验证将mysql jdbc url中可能出现的密码信息全都掩码的效果，目前会出现的密码key名有password,password1,password2,password3,trustCertificateKeyStorePassword,clientCertificateKeyStorePassword
+     * @see  <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-authentication.html">...</a>
+     * @see <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-security.html">...</a>
+     */
+    public void test_sanitizedUrl() {
+        String url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        String expectedUrl = url;
+        String urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password";
+        expectedUrl = url;
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=<masked>";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=12345678";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=<masked>";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password1=12345678&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password1=<masked>&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password2=12345678&password1=12345678&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password2=<masked>&password1=<masked>&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password3=12345678&password2=12345678&password1=12345678&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?useUnicode=true&user=root&password3=<masked>&password2=<masked>&password1=<masked>&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?clientCertificateKeyStorePassword=12345678&useUnicode=true&user=root&password3=12345678&password2=12345678&password1=12345678&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?clientCertificateKeyStorePassword=<masked>&useUnicode=true&user=root&password3=<masked>&password2=<masked>&password1=<masked>&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+        url = "jdbc:mysql://127.0.0.1:3306/druid?trustCertificateKeyStorePassword=12345678&useUnicode=true&user=root&password3=12345678&password2=12345678&password1=12345678&password=12345678&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        expectedUrl = "jdbc:mysql://127.0.0.1:3306/druid?trustCertificateKeyStorePassword=<masked>&useUnicode=true&user=root&password3=<masked>&password2=<masked>&password1=<masked>&password=<masked>&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowMultiQueries=true";
+        urlNew = DruidDataSource.sanitizedUrl(url);
+        System.out.println("原始url=" + url);
+        System.out.println("掩码后url=" + urlNew);
+        assertEquals(expectedUrl, urlNew);
+
+
+    }
+}


### PR DESCRIPTION
针对合并pr的mysql jdbc url密码掩码特性，优化加固逻辑
mysql官方支持的表示密码信息的key有多个，一起识别处理，并补充单测用例进行验证
原始pr来自 https://github.com/alibaba/druid/pull/4843
mysql的url参数支持的密码含义字段详情在：
https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-authentication.html
https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-security.html
mvn validate 验证ok
mvn clean install验证通过