### PR TITLE
validate mysql connection using ping SELECT 1 which is recommended by MySQL

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1387,7 +1387,7 @@ public class DruidDataSource extends DruidAbstractDataSource
 
         String realDriverClassName = driver.getClass().getName();
         if (JdbcUtils.isMySqlDriver(realDriverClassName)) {
-            this.validConnectionChecker = new MySqlValidConnectionChecker(usePingMethod);
+            this.validConnectionChecker = new MySqlValidConnectionChecker();
 
         } else if (realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER)
                 || realDriverClassName.equals(JdbcConstants.ORACLE_DRIVER2)) {

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -85,10 +85,16 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
             query = validateQuery;
         }
 
+        // using internal connection for createStatement to avoid unnecessary operations.
+        Connection internalConn = conn;
+        while (internalConn instanceof javax.sql.PooledConnection) {
+            internalConn = ((javax.sql.PooledConnection) internalConn).getConnection();
+        }
+
         Statement stmt = null;
         ResultSet rs = null;
         try {
-            stmt = conn.createStatement();
+            stmt = internalConn.createStatement();
             if (validationQueryTimeout > 0) {
                 stmt.setQueryTimeout(validationQueryTimeout);
             }

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -82,10 +82,11 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
         if (usePingMethod) {
             query = DEFAULT_VALIDATION_QUERY;
         } else {
-            query = validateQuery;
-        }
-        if (validateQuery == null || validateQuery.isEmpty()) {
-            query = DEFAULT_VALIDATION_QUERY;
+            if (validateQuery == null || validateQuery.isEmpty()) {
+                query = DEFAULT_VALIDATION_QUERY;
+            } else {
+                query = validateQuery;
+            }
         }
 
         Statement stmt = null;

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -56,7 +56,9 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
         }
 
         String property = properties.getProperty("druid.mysql.usePingMethod");
-        if ("false".equals(property)) {
+        if ("true".equals(property)) {
+            setUsePingMethod(true);
+        } else if ("false".equals(property)) {
             setUsePingMethod(false);
         }
     }

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/MySqlValidConnectionChecker.java
@@ -79,14 +79,10 @@ public class MySqlValidConnectionChecker extends ValidConnectionCheckerAdapter i
         }
 
         String query;
-        if (usePingMethod) {
+        if (usePingMethod || validateQuery == null || validateQuery.isEmpty()) {
             query = DEFAULT_VALIDATION_QUERY;
         } else {
-            if (validateQuery == null || validateQuery.isEmpty()) {
-                query = DEFAULT_VALIDATION_QUERY;
-            } else {
-                query = validateQuery;
-            }
+            query = validateQuery;
         }
 
         Statement stmt = null;

--- a/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
@@ -383,6 +383,14 @@ public class MySqlUtils {
         return null;
     }
 
+    /**
+     * The <b>lastQueryFinishedTime</b>, returned from mysql8 <b>com.mysql.cj.jdbc.JdbcConnection#getIdleFor</b>,
+     * does not be updated by method <b>pingInternal</b> running for connection validation if option <b>usePingMethod</b>
+     * is true.<br>
+     * More troublesome is that <b>lastQueryFinishedTime</b> will not be set if option <b>maintainTimeStats</b>
+     * is false, so does mysql5 <b>lastPacketReceivedTimeMs<b>.
+     */
+    @Deprecated
     public static long getLastPacketReceivedTimeMs(Connection conn) throws SQLException {
         if (class_connectionImpl == null && !class_connectionImpl_Error) {
             try {

--- a/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
@@ -388,7 +388,7 @@ public class MySqlUtils {
      * does not be updated by method <b>pingInternal</b> running for connection validation if option <b>usePingMethod</b>
      * is true.<br>
      * More troublesome is that <b>lastQueryFinishedTime</b> will not be set if option <b>maintainTimeStats</b>
-     * is false, so does mysql5 <b>lastPacketReceivedTimeMs<b>.
+     * is false, so does mysql5 <b>lastPacketReceivedTimeMs</b>.
      */
     @Deprecated
     public static long getLastPacketReceivedTimeMs(Connection conn) throws SQLException {

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/basic/DataSourceTest3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/basic/DataSourceTest3.java
@@ -238,7 +238,7 @@ public class DataSourceTest3 extends PoolTestCase {
 
     public void test_ValidConnectionChecker() throws Exception {
         dataSource.getValidConnectionCheckerClassName();
-        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker(false));
+        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker());
         Assert.assertEquals(MySqlValidConnectionChecker.class.getName(),
                 dataSource.getValidConnectionCheckerClassName());
     }
@@ -324,7 +324,7 @@ public class DataSourceTest3 extends PoolTestCase {
 
     public void test_error_validateConnection_3() throws Exception {
         dataSource.setValidationQuery(null);
-        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker(false));
+        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker());
 
         DruidPooledConnection conn = dataSource.getConnection().unwrap(DruidPooledConnection.class);
         dataSource.validateConnection(conn);

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySQLValidConnectionCheckerTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/vendor/MySQLValidConnectionCheckerTest.java
@@ -20,7 +20,7 @@ public class MySQLValidConnectionCheckerTest extends PoolTestCase {
         dataSource.setUrl("jdbc:mock:xxx");
         dataSource.setDbType("mysql");
         dataSource.setValidationQuery("select 1");
-        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker(false));
+        dataSource.setValidConnectionChecker(new MySqlValidConnectionChecker());
         dataSource.setInitialSize(1);
         dataSource.setTestOnBorrow(true);
     }


### PR DESCRIPTION
see #5559 #5148
1. MySqlValidConnectionChecker validates mysql connection using ping SELECT 1 and set usePingMethod to true by default.
2. remove connection validation double check from DruidAbstractDataSource#testConnectionInternal.
3. fix unit tests to match MySqlValidConnectionChecker constructor.

this PR refers to #5156