### PR TITLE
speed up connection validation by skipping all filters,  unify connection checkers by extracting common codes

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/FilterChainImpl.java
+++ b/core/src/main/java/com/alibaba/druid/filter/FilterChainImpl.java
@@ -17,6 +17,7 @@ package com.alibaba.druid.filter;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.DruidPooledConnection;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.proxy.jdbc.*;
 
 import java.io.InputStream;
@@ -78,6 +79,12 @@ public class FilterChainImpl implements FilterChain {
                     .isWrapperFor(this, wrapper, iface);
         }
 
+        if (wrapper instanceof DruidStatementConnection) {
+            if (iface.isInstance(((DruidStatementConnection) wrapper).getConnection())) {
+                return true;
+            }
+        }
+
         // // if driver is for jdbc 3.0
         if (iface.isInstance(wrapper)) {
             return true;
@@ -96,6 +103,13 @@ public class FilterChainImpl implements FilterChain {
 
         if (iface == null) {
             return null;
+        }
+
+        if (wrapper instanceof DruidStatementConnection) {
+            Connection conn = ((DruidStatementConnection) wrapper).getConnection();
+            if (iface.isAssignableFrom(conn.getClass())) {
+                return (T) conn;
+            }
         }
 
         // if driver is for jdbc 3.0
@@ -121,7 +135,9 @@ public class FilterChainImpl implements FilterChain {
             return null;
         }
 
-        return new ConnectionProxyImpl(dataSource, nativeConnection, info, dataSource.createConnectionId());
+        Statement stmt = nativeConnection.createStatement();
+        Connection conn = new DruidStatementConnection(nativeConnection, stmt);
+        return new ConnectionProxyImpl(dataSource, conn, info, dataSource.createConnectionId());
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/mock/MockStatement.java
+++ b/core/src/main/java/com/alibaba/druid/mock/MockStatement.java
@@ -21,6 +21,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MockStatement extends StatementBase implements MockStatementBase, Statement {
     public static final String ERROR_SQL = "THROW ERROR";
@@ -62,7 +64,9 @@ public class MockStatement extends StatementBase implements MockStatementBase, S
             return mockConnection.getDriver().executeQuery(this, sql);
         }
 
-        return new MockResultSet(this);
+        List<Object[]> mockRows = new ArrayList<>();
+        mockRows.add(new Object[1]);
+        return new MockResultSet(this, mockRows);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1462,6 +1462,8 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
             boolean valid;
             try {
                 valid = ValidConnectionCheckerAdapter.execValidQuery(conn, query, validationQueryTimeout);
+            } catch (SQLException ex) {
+                throw ex;
             } catch (Exception ex) {
                 throw new SQLException("validationQuery failed", ex);
             } finally {

--- a/core/src/main/java/com/alibaba/druid/pool/DruidStatementConnection.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidStatementConnection.java
@@ -106,6 +106,7 @@ public class DruidStatementConnection implements Connection {
 
     @Override
     public void close() throws SQLException {
+        statement.close();
         conn.close();
     }
 
@@ -316,6 +317,7 @@ public class DruidStatementConnection implements Connection {
 
     @Override
     public void abort(Executor executor) throws SQLException {
+        statement.close();
         conn.abort(executor);
     }
 

--- a/core/src/main/java/com/alibaba/druid/pool/DruidStatementConnection.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidStatementConnection.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.pool;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * @author zrlw [zrlw@sina.com]
+ */
+public class DruidStatementConnection implements Connection {
+    protected final Connection conn;
+    protected final Statement statement;
+
+    public DruidStatementConnection(Connection conn, Statement statement) {
+        this.conn = conn;
+        this.statement = statement;
+    }
+
+    public Connection getConnection() {
+        return conn;
+    }
+
+    public Statement getStatement() {
+        return statement;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return conn.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return conn.isWrapperFor(iface);
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        return conn.createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return conn.prepareStatement(sql);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return conn.prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        return conn.nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        conn.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return conn.getAutoCommit();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        conn.commit();
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        conn.rollback();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        conn.close();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return conn.isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return conn.getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        conn.setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return conn.isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        conn.setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+         return conn.getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        conn.setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        return conn.getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return conn.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        conn.clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return conn.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+            throws SQLException {
+        return conn.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return conn.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return conn.getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        conn.setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        conn.setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return conn.getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return conn.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return conn.setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        conn.rollback(savepoint);
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        conn.releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
+        return conn.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
+            int resultSetHoldability) throws SQLException {
+        return conn.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
+            int resultSetHoldability) throws SQLException {
+        return conn.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return conn.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return conn.prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return conn.prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return conn.createClob();
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return conn.createBlob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return conn.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return conn.createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return conn.isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        conn.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        conn.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        return conn.getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        return conn.getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return conn.createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return conn.createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        conn.setSchema(schema);
+        
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        return conn.getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        conn.abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        conn.setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        return conn.getNetworkTimeout();
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/pool/PoolableWrapper.java
+++ b/core/src/main/java/com/alibaba/druid/pool/PoolableWrapper.java
@@ -17,6 +17,7 @@ package com.alibaba.druid.pool;
 
 import com.alibaba.druid.proxy.jdbc.WrapperProxy;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Wrapper;
 
@@ -39,6 +40,12 @@ public class PoolableWrapper implements Wrapper {
 
         if (iface == null) {
             return false;
+        }
+
+        if (wrapper instanceof DruidStatementConnection) {
+            if (iface.isInstance(((DruidStatementConnection) wrapper).getConnection())) {
+                return true;
+            }
         }
 
         if (iface == wrapper.getClass()) {
@@ -68,6 +75,13 @@ public class PoolableWrapper implements Wrapper {
 
         if (iface == null) {
             return null;
+        }
+
+        if (wrapper instanceof DruidStatementConnection) {
+            Connection conn = ((DruidStatementConnection) wrapper).getConnection();
+            if (iface.isAssignableFrom(conn.getClass())) {
+                return (T) conn;
+            }
         }
 
         if (iface == wrapper.getClass()) {

--- a/core/src/main/java/com/alibaba/druid/pool/ValidConnectionCheckerAdapter.java
+++ b/core/src/main/java/com/alibaba/druid/pool/ValidConnectionCheckerAdapter.java
@@ -15,7 +15,9 @@
  */
 package com.alibaba.druid.pool;
 
+import com.alibaba.druid.proxy.jdbc.ConnectionProxyImpl;
 import com.alibaba.druid.util.JdbcUtils;
+import com.alibaba.druid.util.StringUtils;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -29,19 +31,30 @@ import java.util.Properties;
 public class ValidConnectionCheckerAdapter implements ValidConnectionChecker {
     @Override
     public boolean isValidConnection(Connection conn, String query, int validationQueryTimeout) throws Exception {
-        if (query == null || query.length() == 0) {
+        if (StringUtils.isEmpty(query)) {
             return true;
+        }
+        return execValidQuery(conn, query, validationQueryTimeout);
+    }
+
+    public static boolean execValidQuery(Connection conn, String query, int validationQueryTimeout) throws Exception {
+        // using raw connection for createStatement to speed up validation by skipping all filters.
+        Connection rawConn;
+        if (conn instanceof ConnectionProxyImpl) {
+            rawConn = ((ConnectionProxyImpl) conn).getConnectionRaw();
+        } else {
+            rawConn = conn;
         }
 
         Statement stmt = null;
         ResultSet rs = null;
         try {
-            stmt = conn.createStatement();
+            stmt = rawConn.createStatement();
             if (validationQueryTimeout > 0) {
                 stmt.setQueryTimeout(validationQueryTimeout);
             }
             rs = stmt.executeQuery(query);
-            return true;
+            return rs.next();
         } finally {
             JdbcUtils.close(rs);
             JdbcUtils.close(stmt);

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/MSSQLValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/MSSQLValidConnectionChecker.java
@@ -17,13 +17,10 @@ package com.alibaba.druid.pool.vendor;
 
 import com.alibaba.druid.pool.ValidConnectionChecker;
 import com.alibaba.druid.pool.ValidConnectionCheckerAdapter;
-import com.alibaba.druid.util.JdbcUtils;
 import com.alibaba.druid.util.StringUtils;
 
 import java.io.Serializable;
 import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 
 /**
  * A MSSQLValidConnectionChecker.
@@ -35,10 +32,10 @@ public class MSSQLValidConnectionChecker extends ValidConnectionCheckerAdapter i
     public MSSQLValidConnectionChecker() {
     }
 
-    public boolean isValidConnection(final Connection c,
+    public boolean isValidConnection(final Connection conn,
                                      String validateQuery,
                                      int validationQueryTimeout) throws Exception {
-        if (c.isClosed()) {
+        if (conn.isClosed()) {
             return false;
         }
 
@@ -46,20 +43,7 @@ public class MSSQLValidConnectionChecker extends ValidConnectionCheckerAdapter i
             validateQuery = DEFAULT_VALIDATION_QUERY;
         }
 
-        Statement stmt = null;
-
-        try {
-            stmt = c.createStatement();
-            if (validationQueryTimeout > 0) {
-                stmt.setQueryTimeout(validationQueryTimeout);
-            }
-            stmt.execute(validateQuery);
-            return true;
-        } catch (SQLException e) {
-            throw e;
-        } finally {
-            JdbcUtils.close(stmt);
-        }
+        return ValidConnectionCheckerAdapter.execValidQuery(conn, validateQuery, validationQueryTimeout);
     }
 
 }

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
@@ -18,11 +18,9 @@ package com.alibaba.druid.pool.vendor;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.pool.ValidConnectionChecker;
 import com.alibaba.druid.pool.ValidConnectionCheckerAdapter;
-import com.alibaba.druid.util.JdbcUtils;
+import com.alibaba.druid.util.StringUtils;
 
 import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 
 public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapter implements ValidConnectionChecker {
     private String commonValidateQuery = "SELECT 'x' FROM DUAL";
@@ -38,31 +36,20 @@ public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapt
         configFromProperties(System.getProperties());
     }
 
-    public boolean isValidConnection(final Connection c,
+    public boolean isValidConnection(final Connection conn,
                                      String validateQuery,
                                      int validationQueryTimeout) throws Exception {
-        if (c.isClosed()) {
+        if (conn.isClosed()) {
             return false;
         }
-        if (validateQuery == null || validateQuery.isEmpty()) {
-            if (dbType != null) {
-                validateQuery = commonValidateQuery;
+
+        if (StringUtils.isEmpty(validateQuery)) {
+            if (dbType == null) {
+                return true;
             }
+            validateQuery = commonValidateQuery;
         }
 
-        Statement stmt = null;
-
-        try {
-            stmt = c.createStatement();
-            if (validationQueryTimeout > 0) {
-                stmt.setQueryTimeout(validationQueryTimeout);
-            }
-            stmt.execute(validateQuery);
-            return true;
-        } catch (SQLException e) {
-            throw e;
-        } finally {
-            JdbcUtils.close(stmt);
-        }
+        return ValidConnectionCheckerAdapter.execValidQuery(conn, validateQuery, validationQueryTimeout);
     }
 }

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OceanBaseValidConnectionChecker.java
@@ -24,6 +24,14 @@ import java.sql.Connection;
 
 public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapter implements ValidConnectionChecker {
     private String commonValidateQuery = "SELECT 'x' FROM DUAL";
+    /**
+     * MySQL:
+     * specify a validation query in your connection pool that starts with {@literal /}* ping *{@literal /}.
+     * Note that the syntax must be exactly as specified. This will cause the driver send a ping to the server
+     * and return a dummy lightweight result set. When using a ReplicationConnection or LoadBalancedConnection,
+     * the ping will be sent across all active connections.
+     */
+    private String mysqlValidateQuery = "/* ping */ SELECT 1";
     private DbType dbType;
 
     public OceanBaseValidConnectionChecker() {
@@ -44,10 +52,11 @@ public class OceanBaseValidConnectionChecker extends ValidConnectionCheckerAdapt
         }
 
         if (StringUtils.isEmpty(validateQuery)) {
-            if (dbType == null) {
-                return true;
+            if (DbType.mysql.equals(dbType)) {
+                validateQuery = mysqlValidateQuery;
+            } else {
+                validateQuery = commonValidateQuery;
             }
-            validateQuery = commonValidateQuery;
         }
 
         return ValidConnectionCheckerAdapter.execValidQuery(conn, validateQuery, validationQueryTimeout);

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
@@ -59,9 +59,6 @@ public class OracleValidConnectionChecker extends ValidConnectionCheckerAdapter 
         }
 
         if (StringUtils.isEmpty(validateQuery)) {
-            if (StringUtils.isEmpty(this.defaultValidateQuery)) {
-                return true;
-            }
             validateQuery = this.defaultValidateQuery;
         }
 

--- a/core/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
+++ b/core/src/main/java/com/alibaba/druid/pool/vendor/OracleValidConnectionChecker.java
@@ -15,16 +15,12 @@
  */
 package com.alibaba.druid.pool.vendor;
 
-import com.alibaba.druid.pool.DruidPooledConnection;
 import com.alibaba.druid.pool.ValidConnectionChecker;
 import com.alibaba.druid.pool.ValidConnectionCheckerAdapter;
-import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
-import com.alibaba.druid.util.JdbcUtils;
+import com.alibaba.druid.util.StringUtils;
 
 import java.io.Serializable;
 import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.Properties;
 
 public class OracleValidConnectionChecker extends ValidConnectionCheckerAdapter implements ValidConnectionChecker, Serializable {
@@ -58,38 +54,19 @@ public class OracleValidConnectionChecker extends ValidConnectionCheckerAdapter 
     public boolean isValidConnection(Connection conn,
                                      String validateQuery,
                                      int validationQueryTimeout) throws Exception {
-        if (validateQuery == null || validateQuery.isEmpty()) {
-            validateQuery = this.defaultValidateQuery;
-        }
-
         if (conn.isClosed()) {
             return false;
         }
 
-        if (conn instanceof DruidPooledConnection) {
-            conn = ((DruidPooledConnection) conn).getConnection();
-        }
-
-        if (conn instanceof ConnectionProxy) {
-            conn = ((ConnectionProxy) conn).getRawObject();
-        }
-
-        if (validateQuery == null || validateQuery.isEmpty()) {
-            return true;
+        if (StringUtils.isEmpty(validateQuery)) {
+            if (StringUtils.isEmpty(this.defaultValidateQuery)) {
+                return true;
+            }
+            validateQuery = this.defaultValidateQuery;
         }
 
         int queryTimeout = validationQueryTimeout <= 0 ? timeout : validationQueryTimeout;
 
-        Statement stmt = null;
-        ResultSet rs = null;
-        try {
-            stmt = conn.createStatement();
-            stmt.setQueryTimeout(queryTimeout);
-            rs = stmt.executeQuery(validateQuery);
-            return true;
-        } finally {
-            JdbcUtils.close(rs);
-            JdbcUtils.close(stmt);
-        }
+        return ValidConnectionCheckerAdapter.execValidQuery(conn, validateQuery, queryTimeout);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest6.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest6.java
@@ -1,6 +1,7 @@
 package com.alibaba.druid.bvt.pool;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -19,6 +20,7 @@ import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
 import com.alibaba.druid.proxy.jdbc.ResultSetProxyImpl;
 import com.alibaba.druid.proxy.jdbc.StatementProxy;
 import com.alibaba.druid.util.DruidPasswordCallback;
+import com.alibaba.druid.util.JdbcUtils;
 
 public class DruidDataSourceTest6 extends TestCase {
     private DruidDataSource dataSource;
@@ -78,8 +80,29 @@ public class DruidDataSourceTest6 extends TestCase {
         } catch (SQLException e) {
             error = e;
         }
-        Assert.assertNotNull(error);
+        // 'SELECT 1' for connection validation will skip all filters, so error is null.
+        Assert.assertNull(error);
 
+        {
+            Connection conn = dataSource.getConnection();
+            Statement stmt = null;
+            ResultSet rs = null;
+            try {
+                stmt = conn.createStatement();
+                rs = stmt.executeQuery("select 1");
+                // rs.next() should return false as result set is empty.
+                if (!rs.next()) {
+                    throw new SQLException("result is empty");
+                }
+            } catch (SQLException e) {
+                error = e;
+            } finally {
+                JdbcUtils.close(rs);
+                JdbcUtils.close(stmt);
+            }
+        }
+        Assert.assertNotNull(error);
+        
         {
             returnEmptyCount.set(1);
             Connection conn = dataSource.getConnection();

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest6.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest6.java
@@ -100,6 +100,7 @@ public class DruidDataSourceTest6 extends TestCase {
                 JdbcUtils.close(rs);
                 JdbcUtils.close(stmt);
             }
+            conn.close();
         }
         Assert.assertNotNull(error);
         

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/TestOnBorrowFileAndNameTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/TestOnBorrowFileAndNameTest.java
@@ -60,18 +60,18 @@ public class TestOnBorrowFileAndNameTest extends TestCase {
         JdbcStatManager.getInstance().getDataSourceList();
         Assert.assertEquals(1, DruidDataSourceStatManager.getInstance().getDataSourceList().size());
 
-        Assert.assertEquals(2, dataSource.getDataSourceStat().getSqlList().size());
+        Assert.assertEquals(1, dataSource.getDataSourceStat().getSqlList().size());
 
         Iterator<JdbcSqlStat> iterator = dataSource.getDataSourceStat().getSqlStatMap().values().iterator();
         JdbcSqlStat sql_0 = iterator.next();
-        JdbcSqlStat sql_1 = iterator.next();
 
-        Assert.assertEquals("SELECT 1", sql_0.getSql());
-        Assert.assertNull(sql_0.getFile());
-        Assert.assertNull(sql_0.getName());
+        // there are no JdbcSqlStat of 'SELECT 1' as connection validation will skip all filters now.
+        // Assert.assertEquals("SELECT 1", sql_0.getSql());
+        // Assert.assertNull(sql_0.getFile());
+        // Assert.assertNull(sql_0.getName());
 
-        Assert.assertEquals("SELECT NOW()", sql_1.getSql());
-        Assert.assertEquals("test_file", sql_1.getFile());
-        Assert.assertEquals("select_now", sql_1.getName());
+        Assert.assertEquals("SELECT NOW()", sql_0.getSql());
+        Assert.assertEquals("test_file", sql_0.getFile());
+        Assert.assertEquals("select_now", sql_0.getName());
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/basic/ConnectionTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/basic/ConnectionTest4.java
@@ -31,6 +31,7 @@ import com.alibaba.druid.mock.MockDriver;
 import com.alibaba.druid.mock.MockPreparedStatement;
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.DruidPooledConnection;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
 import com.alibaba.druid.stat.DruidDataSourceStatManager;
 import com.alibaba.druid.stat.JdbcStatContext;
@@ -78,7 +79,9 @@ public class ConnectionTest4 extends PoolTestCase {
 
         Assert.assertEquals(null, conn.unwrap(Date.class));
         Assert.assertEquals(null, conn.unwrap(null));
-        Assert.assertEquals(((ConnectionProxy) conn.getConnection()).getRawObject(), conn.unwrap(Connection.class));
+        Connection statementConn = ((ConnectionProxy) conn.getConnection()).getRawObject();
+        Assert.assertTrue(statementConn instanceof DruidStatementConnection);
+        Assert.assertEquals(((DruidStatementConnection) statementConn).getConnection(), conn.unwrap(Connection.class));
 
         Assert.assertEquals(false, conn.isWrapperFor(null));
         Assert.assertEquals(true, conn.isWrapperFor(DruidPooledConnection.class));


### PR DESCRIPTION
see #5564 
1. validate unwrapped ConnectionProxy connection.
commit adbbdfa4a625b694a7597eb4980bd1cde8e6b846 at #5560 has a problem should be corrected:
the type of the validation connection is com.alibaba.druid.proxy.jdbc.ConnectionProxy, not javax.sql.PooledConnection.
2. unify connection checkers by extracting common codes.
3. caching connection validation query statement to speed up checking.
