### PR TITLE
remove useless code

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/encoding/CharsetConvert.java
+++ b/core/src/main/java/com/alibaba/druid/filter/encoding/CharsetConvert.java
@@ -23,18 +23,16 @@ import java.io.UnsupportedEncodingException;
  * @author xianmao.hexm 2007-3-5 09:51:33
  */
 public class CharsetConvert {
-    private String clientEncoding;
+    private final String clientEncoding;
 
-    private String serverEncoding;
+    private final String serverEncoding;
 
-    private boolean enable;
+    private final boolean enable;
 
     public CharsetConvert(String clientEncoding, String serverEncoding) {
         this.clientEncoding = clientEncoding;
         this.serverEncoding = serverEncoding;
-        if (clientEncoding != null && serverEncoding != null && !clientEncoding.equalsIgnoreCase(serverEncoding)) {
-            enable = true;
-        }
+        this.enable = clientEncoding != null && serverEncoding != null && !clientEncoding.equalsIgnoreCase(serverEncoding);
     }
 
     /**
@@ -72,7 +70,7 @@ public class CharsetConvert {
      * @return boolean
      */
     public boolean isEmpty(String s) {
-        return s == null || "".equals(s);
+        return s == null || s.isEmpty();
     }
 
 }

--- a/core/src/main/java/com/alibaba/druid/filter/encoding/CharsetParameter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/encoding/CharsetParameter.java
@@ -16,13 +16,18 @@
 package com.alibaba.druid.filter.encoding;
 
 /**
- * 类URLParameter.java的实现描述：JDBC 参数类
- *
- * @author hexianmao 2007-5-24 上午11:21:59
+ * 已过期,后续版本考虑直接下线该代码. {@link EncodingConvertFilter}
  */
+@Deprecated
 public class CharsetParameter {
+    /**
+     * {@link EncodingConvertFilter#CLIENT_ENCODING_KEY}
+     */
     public static final String CLIENTENCODINGKEY = "clientEncoding";
 
+    /**
+     * {@link EncodingConvertFilter#SERVER_ENCODING_KEY}
+     */
     public static final String SERVERENCODINGKEY = "serverEncoding";
 
     // 数据库客户端编码

--- a/core/src/main/java/com/alibaba/druid/filter/encoding/EncodingConvertFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/encoding/EncodingConvertFilter.java
@@ -33,27 +33,20 @@ import java.util.Properties;
  * @author wenshao [szujobs@hotmail.com]
  */
 public class EncodingConvertFilter extends FilterAdapter {
-    public static final String ATTR_CHARSET_PARAMETER = "ali.charset.param";
     public static final String ATTR_CHARSET_CONVERTER = "ali.charset.converter";
-    private String clientEncoding;
-    private String serverEncoding;
 
+    public static final String CLIENT_ENCODING_KEY = "clientEncoding";
+
+    public static final String SERVER_ENCODING_KEY = "serverEncoding";
+
+    @Override
     public ConnectionProxy connection_connect(FilterChain chain, Properties info) throws SQLException {
         ConnectionProxy conn = chain.connection_connect(info);
 
-        CharsetParameter param = new CharsetParameter();
-        param.setClientEncoding(info.getProperty(CharsetParameter.CLIENTENCODINGKEY));
-        param.setServerEncoding(info.getProperty(CharsetParameter.SERVERENCODINGKEY));
+        String clientEncoding = info.getProperty(CLIENT_ENCODING_KEY);
+        String serverEncoding = info.getProperty(SERVER_ENCODING_KEY);
 
-        if (param.getClientEncoding() == null || "".equalsIgnoreCase(param.getClientEncoding())) {
-            param.setClientEncoding(clientEncoding);
-        }
-        if (param.getServerEncoding() == null || "".equalsIgnoreCase(param.getServerEncoding())) {
-            param.setServerEncoding(serverEncoding);
-        }
-        conn.putAttribute(ATTR_CHARSET_PARAMETER, param);
-        conn.putAttribute(ATTR_CHARSET_CONVERTER,
-                new CharsetConvert(param.getClientEncoding(), param.getServerEncoding()));
+        conn.putAttribute(ATTR_CHARSET_CONVERTER, new CharsetConvert(clientEncoding, serverEncoding));
 
         return conn;
     }

--- a/core/src/main/java/com/alibaba/druid/pool/ha/HighAvailableDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/ha/HighAvailableDataSource.java
@@ -196,9 +196,7 @@ public class HighAvailableDataSource extends WrapperAdapter implements DataSourc
     public Map<String, DataSource> getAvailableDataSourceMap() {
         Map<String, DataSource> map = new ConcurrentHashMap<String, DataSource>(this.dataSourceMap);
         for (String n : blacklist) {
-            if (map.containsKey(n)) {
-                map.remove(n);
-            }
+            map.remove(n);
         }
         return map;
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/proxy/filter/encoding/CharsetParameterTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/proxy/filter/encoding/CharsetParameterTest.java
@@ -23,6 +23,7 @@ import com.alibaba.druid.filter.encoding.CharsetParameter;
 /**
  * @author gang.su
  */
+@Deprecated
 public class CharsetParameterTest extends TestCase {
     public void testQ() {
         CharsetParameter c = new CharsetParameter();


### PR DESCRIPTION
EncodingConvertFilter 中有一段奇奇怪怪的代码，这两个变量从始至终都没有被赋值，直接删了吧。

<img width="302" alt="image" src="https://github.com/alibaba/druid/assets/30279020/3e8e1f45-f5cf-4239-ba1f-08c9e1340e20">

另外，为了升级友好，CharsetParameter 类代码暂时不删除，先标记过期，待后续几个版本之后再彻底删除。