### PR TITLE
git commit -a -m '优化创建和销毁线程的退出条件，防止线程泄漏'

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -2904,7 +2904,7 @@ public class DruidDataSource extends DruidAbstractDataSource
 
             long lastDiscardCount = 0;
             int errorCount = 0;
-            while (!closing && !closed) {
+            while (!closing && !closed && !Thread.currentThread().isInterrupted()) {
                 // addLast
                 try {
                     lock.lockInterruptibly();
@@ -3023,7 +3023,7 @@ public class DruidDataSource extends DruidAbstractDataSource
         public void run() {
             initedLatch.countDown();
 
-            for (; ; ) {
+            for (; !Thread.currentThread().isInterrupted(); ) {
                 // 从前面开始删除
                 try {
                     if (closed || closing) {


### PR DESCRIPTION
优化创建和销毁线程的退出条件，防止线程泄漏。之前在生产环境中，关闭连接池的过程中，在close方法中的unregisterMbean过程出现异常，但创建和销毁线程都未退出，导致线程泄漏。