### PR TITLE
initialize data source at DruidDataSourceWrapper#afterPropertiesSet

### DIFF
--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -49,7 +49,14 @@ import javax.sql.DataSource;
 public class DruidDataSourceAutoConfigure {
     private static final Logger LOGGER = LoggerFactory.getLogger(DruidDataSourceAutoConfigure.class);
 
-    @Bean(initMethod = "init")
+    /**
+     * Not setting initMethod of annotation {@code @Bean} is to avoid failure when inspecting
+     * the bean definition at the build time. The {@link DruidDataSource#init()} will be called
+     * at the end of {@link DruidDataSourceWrapper#afterPropertiesSet()}.
+     *
+     * @return druid data source wrapper
+     */
+    @Bean
     @ConditionalOnMissingBean
     public DataSource dataSource() {
         LOGGER.info("Init DruidDataSource");

--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
@@ -47,6 +47,8 @@ public class DruidDataSourceWrapper extends DruidDataSource implements Initializ
         if (super.getDriverClassName() == null) {
             super.setDriverClassName(basicProperties.getDriverClassName());
         }
+
+        init();
     }
 
     @Autowired(required = false)

--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
@@ -17,6 +17,8 @@ package com.alibaba.druid.spring.boot3.autoconfigure;
 
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
+
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -28,7 +30,7 @@ import java.util.List;
  * @author lihengming [89921218@qq.com]
  */
 @ConfigurationProperties("spring.datasource.druid")
-public class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean {
+public class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean, DisposableBean {
     @Autowired
     private DataSourceProperties basicProperties;
 
@@ -71,5 +73,10 @@ public class DruidDataSourceWrapper extends DruidDataSource implements Initializ
         } catch (IllegalArgumentException ignore) {
             super.maxEvictableIdleTimeMillis = maxEvictableIdleTimeMillis;
         }
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        close();
     }
 }

--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceWrapper.java
@@ -17,7 +17,6 @@ package com.alibaba.druid.spring.boot3.autoconfigure;
 
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -49,7 +49,7 @@ import javax.sql.DataSource;
 public class DruidDataSourceAutoConfigure {
     private static final Logger LOGGER = LoggerFactory.getLogger(DruidDataSourceAutoConfigure.class);
 
-    @Bean(initMethod = "init")
+    @Bean
     @ConditionalOnMissingBean
     public DataSource dataSource() {
         LOGGER.info("Init DruidDataSource");

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -49,6 +49,13 @@ import javax.sql.DataSource;
 public class DruidDataSourceAutoConfigure {
     private static final Logger LOGGER = LoggerFactory.getLogger(DruidDataSourceAutoConfigure.class);
 
+    /**
+     * Not setting initMethod of annotation {@code @Bean} is to avoid failure when inspecting
+     * the bean definition at the build time. The {@link DruidDataSource#init()} will be called
+     * at the end of {@link DruidDataSourceWrapper#afterPropertiesSet()}.
+     *
+     * @return druid data source wrapper
+     */
     @Bean
     @ConditionalOnMissingBean
     public DataSource dataSource() {

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
@@ -17,6 +17,8 @@ package com.alibaba.druid.spring.boot.autoconfigure;
 
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
+
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -28,7 +30,7 @@ import java.util.List;
  * @author lihengming [89921218@qq.com]
  */
 @ConfigurationProperties("spring.datasource.druid")
-public class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean {
+public class DruidDataSourceWrapper extends DruidDataSource implements InitializingBean, DisposableBean {
     @Autowired
     private DataSourceProperties basicProperties;
 
@@ -47,6 +49,8 @@ public class DruidDataSourceWrapper extends DruidDataSource implements Initializ
         if (super.getDriverClassName() == null) {
             super.setDriverClassName(basicProperties.getDriverClassName());
         }
+
+        init();
     }
 
     @Autowired(required = false)
@@ -69,5 +73,10 @@ public class DruidDataSourceWrapper extends DruidDataSource implements Initializ
         } catch (IllegalArgumentException ignore) {
             super.maxEvictableIdleTimeMillis = maxEvictableIdleTimeMillis;
         }
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        close();
     }
 }

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceWrapper.java
@@ -17,7 +17,6 @@ package com.alibaba.druid.spring.boot.autoconfigure;
 
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
see #4673 
1. call DruidDataSource#init at the end of DruidDataSourceWrapper#afterPropertiesSet;
2. call DruidDataSource#close at DruidDataSourceWrapper#destroy.

A custom init method is an alternative to implementing InitializingBean, but DruidDataSourceWrapper is already a InitializingBean, so the initialization of  DruidDataSource could be done at DruidDataSourceWrapper#afterPropertiesSet by calling init method directly instead of setting initMethod attribute of ```@Bean``` annotation on it's  auto configuration method.