### PR TITLE
support double question mark and vertical bar token parser

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
@@ -41,6 +41,7 @@ public enum SQLBinaryOperator {
     PoundGtGt("#>>", 20),
     QuesQues("??", 20),
     QuesBar("?|", 20),
+    QuesQuesBar("??|", 20),
     QuesAmp("?&", 20),
 
     LeftShift("<<", 80),

--- a/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -1382,7 +1382,7 @@ public class Lexer {
                         scanChar();
                         if (ch == '|') {
                             scanChar();
-                            token = Token.QUESBAR;
+                            token = Token.QUESQUESBAR;
                         } else {
                             token = Token.QUESQUES;
                         }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -228,6 +228,13 @@ public class SQLExprParser extends SQLParser {
                 expr = bitXorRest(expr);
                 break;
             }
+            case QUESQUESBAR: {
+                lexer.nextToken();
+                SQLExpr rightExp = primary();
+                expr = new SQLBinaryOpExpr(expr, SQLBinaryOperator.QuesQuesBar, rightExp, dbType);
+                expr = bitXorRest(expr);
+                break;
+            }
             case QUESAMP: {
                 lexer.nextToken();
                 SQLExpr rightExp = primary();

--- a/core/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -328,6 +328,7 @@ public enum Token {
     QUES("?"),
     QUESQUES("??"),
     QUESBAR("?|"),
+    QUESQUESBAR("??|"),
     QUESAMP("?&"),
     COLON(":"),
     COLONCOLON("::"),

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/select/PGSelectTest58.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/select/PGSelectTest58.java
@@ -50,7 +50,7 @@ public class PGSelectTest58 extends TestCase {
         assertEquals("SELECT id, sum(uv[1]) AS uv1, sum(uv[2]) AS uv2\n" +
                 "FROM xxxxx\n" +
                 "WHERE a IN (?)\n" +
-                "\tAND ta -> 'taAge' ?| '{  \n" +
+                "\tAND ta -> 'taAge' ??| '{  \n" +
                 "                            1\n" +
                 "                         , \n" +
                 "                            2\n" +
@@ -62,7 +62,7 @@ public class PGSelectTest58 extends TestCase {
         assertEquals("select id, sum(uv[1]) as uv1, sum(uv[2]) as uv2\n" +
                 "from xxxxx\n" +
                 "where a in (?)\n" +
-                "\tand ta -> 'taAge' ?| '{  \n" +
+                "\tand ta -> 'taAge' ??| '{  \n" +
                 "                            1\n" +
                 "                         , \n" +
                 "                            2\n" +


### PR DESCRIPTION
see #5034
```
at com.alibaba.druid.sql.parser.Lexer#nextToken:
                ...
                case '?':
                    scanChar();
                    if (ch == '?' && DbType.postgresql == dbType) {
                        scanChar();
                        if (ch == '|') {
                            // <== the current token value should be "??|" instead of "?|"
```