### PR TITLE
support parse partitioning syntax for global index of polarDB-X

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLIndexDefinition.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLIndexDefinition.java
@@ -16,6 +16,8 @@ import java.util.List;
  * Date 2019-06-04 11:27
  */
 public class SQLIndexDefinition extends SQLObjectImpl implements SQLIndex {
+    // for polardb-x partition manage
+    protected SQLPartitionBy partitioning;
     /**
      * [CONSTRAINT [symbol]] [GLOBAL|LOCAL] [FULLTEXT|SPATIAL|UNIQUE|PRIMARY] [INDEX|KEY]
      * [index_name] [index_type] (key_part,...) [COVERING (col_name,...)] [index_option] ...
@@ -294,6 +296,14 @@ public class SQLIndexDefinition extends SQLObjectImpl implements SQLIndex {
         this.withDicName = withDicName;
     }
 
+    public SQLPartitionBy getPartitioning() {
+        return partitioning;
+    }
+
+    public void setPartitioning(SQLPartitionBy partitioning) {
+        this.partitioning = partitioning;
+    }
+
     public List<SQLAssignItem> getCompatibleOptions() {
         return compatibleOptions;
     }
@@ -364,6 +374,10 @@ public class SQLIndexDefinition extends SQLObjectImpl implements SQLIndex {
         if (tbPartitions != null) {
             definition.tbPartitions = tbPartitions.clone();
             definition.tbPartitions.setParent(parent);
+        }
+        if (partitioning != null) {
+            definition.partitioning = partitioning.clone();
+            definition.partitioning.setParent(parent);
         }
         for (SQLName name : covering) {
             SQLName name1 = name.clone();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlTableIndex.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlTableIndex.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLIndex;
 import com.alibaba.druid.sql.ast.SQLIndexDefinition;
 import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLPartitionBy;
 import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
 import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
 import com.alibaba.druid.sql.ast.statement.*;
@@ -246,6 +247,14 @@ public class MySqlTableIndex extends SQLConstraintImpl implements SQLTableElemen
 
     public void setQueryAnalyzerName(SQLName queryAnalyzerName) {
         this.indexDefinition.setQueryAnalyzerName(queryAnalyzerName);
+    }
+
+    public void setPartitioning(SQLPartitionBy sqlPartitioning) {
+        this.indexDefinition.setPartitioning(sqlPartitioning);
+    }
+
+    public SQLPartitionBy getPartitioning() {
+        return this.indexDefinition.getPartitioning();
     }
 
     public SQLName getWithDicName() {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -632,6 +632,12 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             tablePartitions.accept(this);
         }
 
+        final SQLPartitionBy partitionBy = x.getPartitioning();
+        if (partitionBy != null) {
+            print0(ucase ? " PARTITION BY " : " partitions by ");
+            partitionBy.accept(this);
+        }
+
         /*
         final List<SQLAssignItem> options = x.getOptions();
         if (options.size() > 0) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.sql.ast.*;
 import com.alibaba.druid.sql.ast.expr.*;
 import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlCharExpr;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlCreateTableParser;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleArgumentExpr;
 import com.alibaba.druid.sql.dialect.postgresql.ast.expr.PGTypeCastExpr;
 import com.alibaba.druid.sql.parser.Lexer.SavePoint;
@@ -5646,7 +5647,10 @@ public class SQLExprParser extends SQLParser {
                             break _opts;
                         }
                         break;
-
+                    case PARTITION:
+                        SQLPartitionBy partitionBy = new MySqlCreateTableParser(this).parsePartitionBy();
+                        indexDefinition.setPartitioning(partitionBy);
+                        break;
                     default:
                         break _opts;
                 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/polardbx/PolarDBXTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/polardbx/PolarDBXTest.java
@@ -105,4 +105,47 @@ public class PolarDBXTest extends TestCase {
         Assert.assertTrue(table != null);
         System.out.println(table.getStatement());
     }
+
+    public void test_polardb_x_6(){
+        // test for global index with partition by
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        String sql6 = "CREATE TABLE `test6` (\n"
+            + "\t`Id` varchar(32) NOT NULL COMMENT '',\n"
+            + "\t`ExitId` varchar(32) NOT NULL COMMENT '',\n"
+            + "\t`CreateTime` datetime NOT NULL COMMENT '创建时间',\n"
+            + "\t`archive_date` datetime NOT NULL DEFAULT '2099-01-01 00:00:00',\n"
+            + "\tPRIMARY KEY (`Id`, `archive_date`),\n"
+            + "\tGLOBAL INDEX `g_i_id` (`id`) COVERING (`ExitId`) \n"
+            + "\t\tPARTITION BY KEY(`Id`)\n"
+            + "\t\tPARTITIONS 16,\n"
+            + "\tKEY `ExitId` USING BTREE (`ExitId`),\n"
+            + "\tKEY `CreateTime` (`CreateTime`),\n"
+            + "\tKEY `i_id_ExitId` USING BTREE (`Id`, `ExitId`),\n"
+            + "\tKEY `auto_shard_key_ExitId_id` USING BTREE (`ExitId`, `Id`)\n"
+            + ") ENGINE = InnoDB DEFAULT CHARSET = utf8\n"
+            + "PARTITION BY KEY(`ExitId`,`Id`)\n"
+            + "PARTITIONS 16\n"
+            + "LOCAL PARTITION BY RANGE (archive_date)\n"
+            + "INTERVAL 1 MONTH\n"
+            + "EXPIRE AFTER 27\n"
+            + "PRE ALLOCATE 2\n"
+            + "PIVOTDATE NOW()";
+        repository.console(sql6);
+        SchemaObject table = repository.findTable("test6");
+        Assert.assertNotNull(table);
+        System.out.println(table.getStatement());
+        Assert.assertEquals("CREATE TABLE test6 (\n"
+            + "\tId varchar(32) NOT NULL COMMENT '',\n"
+            + "\tExitId varchar(32) NOT NULL COMMENT '',\n"
+            + "\tCreateTime datetime NOT NULL COMMENT '创建时间',\n"
+            + "\tarchive_date datetime NOT NULL DEFAULT '2099-01-01 00:00:00',\n"
+            + "\tPRIMARY KEY (Id, archive_date),\n"
+            + "\tGLOBAL INDEX g_i_id(id) COVERING (ExitId) PARTITION BY KEY (Id) PARTITIONS 16,\n"
+            + "\tKEY ExitId USING BTREE (ExitId),\n"
+            + "\tKEY CreateTime (CreateTime),\n"
+            + "\tKEY i_id_ExitId USING BTREE (Id, ExitId),\n"
+            + "\tKEY auto_shard_key_ExitId_id USING BTREE (ExitId, Id)\n"
+            + ") ENGINE = InnoDB CHARSET = utf8\n"
+            + "PARTITION BY KEY (ExitId, Id) PARTITIONS 16",table.getStatement().toString());
+    }
 }


### PR DESCRIPTION
support parse partitioning syntax for global index of polarDB-X
like this
GLOBAL INDEX g_i_id(id) COVERING (ExitId) PARTITION BY KEY (Id) PARTITIONS 16