### PR TITLE
合并pr 4535 反而导致不再负负得正的问题，修复之 #4535

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -3492,22 +3492,9 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             final String keyStringLowerCase = keyString.toLowerCase();
             final String keyStringUpperCase = keyString.toUpperCase();
             print0(ucase ? keyStringUpperCase : keyStringLowerCase);
-
-            switch (keyStringUpperCase) {
-                case "TABLESPACE":
-                    print(' ');
-                    item.getValue().accept(this);
-                    continue;
-                case "UNION":
-                    print0(" = (");
-                    item.getValue().accept(this);
-                    print(')');
-                    continue;
-                default:
-                    print0(" = ");
-                    item.getValue().accept(this);
-                    i++;
-            }
+            print0(" = ");
+            item.getValue().accept(this);
+            i++;
         }
 
         SQLPartitionBy partitionBy = x.getPartition();


### PR DESCRIPTION
合并pr 4535 反而导致不再负负得正的问题，4个单测报错，因此修复之 #4535，经核实直接清理不需要的逻辑即可
出错单测如下：
```

[ERROR] Failures:
[ERROR]   MySqlAlterTable_refactor_test.test_0:75 expected:<...GES = 10 TABLESPACE [= `tbs_name` STORAGE memory UNION = (tb1, tb2, tb3]) AUTO_INCREMENT = 1> but was:<...GES = 10 TABLESPACE [`tbs_name` STORAGE memory UNION = ((tb1, tb2, tb3)]) AUTO_INCREMENT = 1>
[ERROR]   MySqlAlterTableTest26.test_alter_add_key:32 expected:<...ABLE xxxx
        UNION = ([t1, t2]);> but was:<...ABLE xxxx
        UNION = ([(t1, t2)]);>
		
[ERROR]   MySqlAlterTableTest51_table_options.test_0_options_comma_eq:77 expected:<...AGES = 2 TABLESPACE [= `tbs_name` UNION = (tb1, tb2, tb3]);> but was:<...AGES = 2 TABLESPACE [`tbs_name` UNION = ((tb1, tb2, tb3)]);>

[ERROR]   MySqlAlterTableTest51_table_options.test_0_options_no_comma_no_eq:42 expected:<...GES = 10 TABLESPACE [= `tbs_name` STORAGE memory UNION = (tb1, tb2, tb3]) AUTO_INCREMENT = 1> but was:<...GES = 10 TABLESPACE [`tbs_name` STORAGE memory UNION = ((tb1, tb2, tb3)]) AUTO_INCREMENT = 1>


```