### PR TITLE
return directly if StatViewFilter calls sendRedirect

### DIFF
--- a/core/src/main/java/com/alibaba/druid/support/http/StatViewFilter.java
+++ b/core/src/main/java/com/alibaba/druid/support/http/StatViewFilter.java
@@ -121,6 +121,7 @@ public class StatViewFilter implements Filter {
         }
         if (requestURI.equals(servletPath)) {
             httpResp.sendRedirect(httpReq.getRequestURI() + '/');
+            return;
         }
 
         handler.service(httpReq, httpResp, servletPath, new ResourceServlet.ProcessCallback() {

--- a/core/src/main/java/com/alibaba/druid/support/jakarta/StatViewFilter.java
+++ b/core/src/main/java/com/alibaba/druid/support/jakarta/StatViewFilter.java
@@ -120,6 +120,7 @@ public class StatViewFilter implements Filter {
         }
         if (requestURI.equals(servletPath)) {
             httpResp.sendRedirect(httpReq.getRequestURI() + '/');
+            return;
         }
 
         handler.service(httpReq, httpResp, servletPath, new ProcessCallback() {


### PR DESCRIPTION
see #4398
the HttpServletResponse should not be rewrited after calling it's sendRedirect method.