### PR TITLE
add keepConnectionUnderlyingTransactionIsolation attribute

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -256,6 +256,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
     private Boolean useUnfairLock;
     private boolean useLocalSessionState = true;
+    private boolean keepConnectionUnderlyingTransactionIsolation;
 
     protected long timeBetweenLogStatsMillis;
     protected DruidDataSourceStatLogger statLogger = new DruidDataSourceStatLoggerImpl();
@@ -314,6 +315,14 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
 
     public void setUseLocalSessionState(boolean useLocalSessionState) {
         this.useLocalSessionState = useLocalSessionState;
+    }
+
+    public boolean isKeepConnectionUnderlyingTransactionIsolation() {
+        return keepConnectionUnderlyingTransactionIsolation;
+    }
+
+    public void setKeepConnectionUnderlyingTransactionIsolation(boolean keepConnectionUnderlyingTransactionIsolation) {
+        this.keepConnectionUnderlyingTransactionIsolation = keepConnectionUnderlyingTransactionIsolation;
     }
 
     public DruidDataSourceStatLogger getStatLogger() {

--- a/core/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
@@ -378,7 +378,8 @@ public final class DruidConnectionHolder {
             underlyingHoldability = defaultHoldability;
         }
 
-        if (underlyingTransactionIsolation != defaultTransactionIsolation) {
+        if (!dataSource.isKeepConnectionUnderlyingTransactionIsolation()
+                && underlyingTransactionIsolation != defaultTransactionIsolation) {
             conn.setTransactionIsolation(defaultTransactionIsolation);
             underlyingTransactionIsolation = defaultTransactionIsolation;
         }

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidPooledConnectionTest2.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidPooledConnectionTest2.java
@@ -10,7 +10,7 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.DruidPooledConnection;
 import com.alibaba.druid.pool.DruidPooledPreparedStatement;
 
-public class DruidPooledConnectionTest1 extends TestCase {
+public class DruidPooledConnectionTest2 extends TestCase {
     private DruidDataSource dataSource;
 
     protected void setUp() throws Exception {
@@ -19,7 +19,7 @@ public class DruidPooledConnectionTest1 extends TestCase {
         dataSource.setTestOnBorrow(false);
         dataSource.setFilters("stat");
         dataSource.setPoolPreparedStatements(true);
-
+        dataSource.setKeepConnectionUnderlyingTransactionIsolation(true);
     }
 
     protected void tearDown() throws Exception {
@@ -97,7 +97,7 @@ public class DruidPooledConnectionTest1 extends TestCase {
         Assert.assertEquals(0, dataSource.getActiveCount());
 
         conn = (DruidPooledConnection) dataSource.getConnection();
-        Assert.assertEquals(defaultIsolation, conn.getTransactionIsolation());
+        Assert.assertEquals(defaultIsolation + 1, conn.getTransactionIsolation());
         conn.close();
     }
 
@@ -116,7 +116,7 @@ public class DruidPooledConnectionTest1 extends TestCase {
         Assert.assertEquals(0, dataSource.getActiveCount());
 
         conn = (DruidPooledConnection) dataSource.getConnection();
-        Assert.assertEquals(defaultIsolation, conn.getTransactionIsolation());
+        Assert.assertEquals(defaultIsolation + 1, conn.getTransactionIsolation());
         conn.close();
     }
 }


### PR DESCRIPTION
see #4243 
add a new DruidDataSource attribute ```keepConnectionUnderlyingTransactionIsolation```  which default value is false.
if the attribute is true, the underlyingTransactionIsolation will not be reset when the connection is recycled.