### PR TITLE
fix DOTDOTDOT token name attribute

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/Token.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Token.java
@@ -313,7 +313,7 @@ public enum Token {
     COMMA(","),
     DOT("."),
     DOTDOT(".."),
-    DOTDOTDOT("..,"),
+    DOTDOTDOT("..."),
     EQ("="),
     GT(">"),
     LT("<"),


### PR DESCRIPTION
see #3502 
```
                case '.':
                    scanChar();
                    if (isDigit(ch)
                            && (pos == 1 || token != IDENTIFIER)
                    ) {
                        unscan();
                        scanNumber();
                        return;
                    } else if (ch == '.') {
                        scanChar();
                        if (ch == '.') {
                            scanChar();
                            token = Token.DOTDOTDOT;   <==  it's name attribute should be "..." instead of "..,"
```