### PR TITLE
support MySQL create database with character set and collate hint

### DIFF
--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySqlCreateDatabaseTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/create/MySqlCreateDatabaseTest.java
@@ -69,4 +69,46 @@ public class MySqlCreateDatabaseTest extends MysqlTest {
                 + " STORED BY 'OTS'\n"
                 + " WITH (column_mapping = 'pk:pk,a:col1,b:col2', serializer = 'default')", output);
     }
+
+    @Test
+    public void test_4() throws Exception {
+        String sql = "create database /*!32312 if  not  exists */ test4 /*!40100 default  character  set  utf8 */;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        SQLStatement stmt = parser.parseStatement();
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        String output = SQLUtils.toMySqlString(stmt);
+        Assert.assertEquals("CREATE DATABASE IF NOT EXISTS test4 CHARACTER SET utf8", output);
+    }
+
+    @Test
+    public void test_5() throws Exception {
+        String sql = "create database /*!32312 if  not  exists */ test5 /*!40100 default  character  set  utf8  collate  utf8_general_ci */;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        SQLStatement stmt = parser.parseStatement();
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        String output = SQLUtils.toMySqlString(stmt);
+        Assert.assertEquals("CREATE DATABASE IF NOT EXISTS test5 CHARACTER SET utf8 COLLATE utf8_general_ci", output);
+    }
+
+    @Test
+    public void test_6() throws Exception {
+        String sql = "create database /*!32312 if  not  exists */ test6 /*!40100 collate  utf8_general_ci  character  set  utf8  */;";
+
+        MySqlStatementParser parser = new MySqlStatementParser(sql);
+        SQLStatement stmt = parser.parseStatement();
+
+        MySqlSchemaStatVisitor visitor = new MySqlSchemaStatVisitor();
+        stmt.accept(visitor);
+
+        String output = SQLUtils.toMySqlString(stmt);
+        Assert.assertEquals("CREATE DATABASE IF NOT EXISTS test6 CHARACTER SET utf8 COLLATE utf8_general_ci", output);
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/visitor/MySqlResourceTest.java
@@ -51,7 +51,7 @@ public class MySqlResourceTest extends TestCase {
 
 
     public void test_14() throws Exception {
-        exec_test("bvt/parser/mysql-16.txt");
+        exec_test("bvt/parser/mysql-14.txt");
     }
 
     public void test_16() throws Exception {

--- a/core/src/test/resources/bvt/parser/mysql-14.txt
+++ b/core/src/test/resources/bvt/parser/mysql-14.txt
@@ -46,6 +46,28 @@ WHERE  collect_date >= '2012-04-08'
 AND pageId= 'SOURCING_HOME'
 GROUP  BY pageId
 ---------------------------
-SELECT 'Monty!' REGEXP '.*'
----------------------------
-SELECT ? REGEXP ?
+INSERT INTO m_browser_common_base_aggr (gmt_create, gmt_modify, collect_date_str, page_id, geo_type
+	, geo_value, count_load_time, min_load_time, max_load_time, avg_load_time)
+SELECT Now() AS gmt_create, Now() AS gmt_modify, '2012-04-08' AS collect_date_str, pageId AS page_id, 'all_country' AS geo_type
+	, '(ALLCOUNTRIES)' AS geo_value
+	, Count(IF(loadTime IS NULL
+		OR loadTime < 0
+		OR loadTime >= 30000, NULL, loadTime)) AS count_load_time
+	, Min(IF(loadTime IS NULL
+		OR loadTime < 0
+		OR loadTime >= 30000, NULL, loadTime)) AS min_load_time
+	, Max(IF(loadTime IS NULL
+		OR loadTime < 0
+		OR loadTime >= 30000, NULL, loadTime)) AS max_load_time
+	, Sum(IF(loadTime IS NULL
+		OR loadTime < 0
+		OR loadTime >= 30000, NULL, loadTime)) / Count(IF(loadTime IS NULL
+		OR loadTime < 0
+		OR loadTime >= 30000, NULL, loadTime)) AS avg_load_time
+FROM m_browser_common
+WHERE collect_date >= '2012-04-08'
+	AND collect_date < '2012-04-09'
+	AND pageId IS NOT NULL
+	AND country_code IS NOT NULL
+	AND pageId = 'SOURCING_HOME'
+GROUP BY pageId

--- a/core/src/test/resources/bvt/parser/mysql-16.txt
+++ b/core/src/test/resources/bvt/parser/mysql-16.txt
@@ -1,3 +1,3 @@
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `druidtestdb` /*!40100 DEFAULT CHARACTER SET utf8 COLLATE utf8_bin */;
 ---------------------------
-CREATE DATABASE IF NOT EXISTS `druidtestdb`;
+CREATE DATABASE IF NOT EXISTS `druidtestdb` CHARACTER SET utf8 COLLATE utf8_bin;


### PR DESCRIPTION
see #3872, but the sql of the issue should be:
```
CREATE DATABASE /*!32312 IF NOT EXISTS*/ xwiki /*!40100 DEFAULT CHARACTER SET utf8 */;
```
this PR refers to #3875, support such sqls,
```
CREATE DATABASE /*!32312 IF NOT EXISTS*/ xwiki /*!40100 [DEFAULT] CHARACTER SET utf8*/;
CREATE DATABASE /*!32312 IF NOT EXISTS*/ xwiki /*!40100 [DEFAULT] COLLATE utf8_general_ci */;
CREATE DATABASE /*!32312 IF NOT EXISTS*/ xwiki /*!40100 [DEFAULT] CHARACTER SET utf8 [DEFAULT] COLLATE utf8_general_ci */;
```
```DEFAULT``` is optional, the order of ```CHARACTER SET``` and ```COLLATE``` could be exchanged.