### PR TITLE
慢SQL日志增加java8时间类的参数解析支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -93,18 +93,22 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         this.dbType = DbType.of(dbType);
     }
 
+    @Override
     public long getSlowSqlMillis() {
         return slowSqlMillis;
     }
 
+    @Override
     public void setSlowSqlMillis(long slowSqlMillis) {
         this.slowSqlMillis = slowSqlMillis;
     }
 
+    @Override
     public boolean isLogSlowSql() {
         return logSlowSql;
     }
 
+    @Override
     public void setLogSlowSql(boolean logSlowSql) {
         this.logSlowSql = logSlowSql;
     }
@@ -117,10 +121,12 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         this.connectionStackTraceEnable = connectionStackTraceEnable;
     }
 
+    @Override
     public boolean isMergeSql() {
         return mergeSql;
     }
 
+    @Override
     public void setMergeSql(boolean mergeSql) {
         this.mergeSql = mergeSql;
     }
@@ -138,6 +144,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         return this.mergeSql(sql, dbType);
     }
 
+    @Override
     public String mergeSql(String sql, String dbType) {
         return mergeSql(sql, DbType.of(dbType));
     }
@@ -171,6 +178,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         }
     }
 
+    @Override
     public void configFromProperties(Properties properties) {
         if (properties == null) {
             return;
@@ -220,6 +228,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
         }
     }
 
+    @Override
     public ConnectionProxy connection_connect(FilterChain chain, Properties info) throws SQLException {
         ConnectionProxy connection = null;
 

--- a/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -503,7 +503,7 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
 
                 String lastExecSql = statement.getLastExecuteSql();
                 if (logSlowSql) {
-                    String msg = "slow sql " + millis + " millis. " + lastExecSql + "" + slowParameters;
+                    String msg = "slow sql " + millis + " millis. " + lastExecSql + " " + slowParameters;
                     switch (slowSqlLogLevel) {
                         case "WARN":
                             LOG.warn(msg);

--- a/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/stat/StatFilter.java
@@ -33,6 +33,9 @@ import com.alibaba.druid.support.profile.Profiler;
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.locks.Lock;
@@ -575,6 +578,12 @@ public class StatFilter extends FilterEventAdapter implements StatFilterMBean {
             } else if (value instanceof java.util.Date) {
                 out.writeObject(value);
             } else if (value instanceof Boolean) {
+                out.writeObject(value);
+            } else if (value instanceof LocalDate) {
+                out.writeObject(value);
+            } else if (value instanceof LocalTime) {
+                out.writeObject(value);
+            } else if (value instanceof LocalDateTime) {
                 out.writeObject(value);
             } else if (value instanceof InputStream) {
                 out.writeString("<InputStream>");

--- a/core/src/main/java/com/alibaba/druid/support/json/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/druid/support/json/JSONWriter.java
@@ -20,14 +20,17 @@ import com.alibaba.druid.util.Utils;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
-
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
 public class JSONWriter {
-    private StringBuilder out;
+    private final StringBuilder out;
 
     public JSONWriter() {
         this.out = new StringBuilder();
@@ -73,6 +76,21 @@ public class JSONWriter {
 
         if (o instanceof Date) {
             writeDate((Date) o);
+            return;
+        }
+
+        if (o instanceof LocalDate) {
+            writeLocalDate((LocalDate) o);
+            return;
+        }
+
+        if (o instanceof LocalTime) {
+            writeLocalTime((LocalTime) o);
+            return;
+        }
+
+        if (o instanceof LocalDateTime) {
+            writeLocalDateTime((LocalDateTime) o);
             return;
         }
 
@@ -143,6 +161,42 @@ public class JSONWriter {
         //SimpleDataFormat is not thread-safe, we need to make it local.
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         writeString(dateFormat.format(date));
+    }
+
+    /**
+     * 写 local date
+     */
+    public void writeLocalDate(LocalDate date) {
+        if (date == null) {
+            writeNull();
+            return;
+        }
+        String formatDate = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(date);
+        writeString(formatDate);
+    }
+
+    /**
+     * 写 LocalTime
+     */
+    public void writeLocalTime(LocalTime time) {
+        if (time == null) {
+            writeNull();
+            return;
+        }
+        String formatTime = DateTimeFormatter.ofPattern("HH:mm:ss").format(time);
+        writeString(formatTime);
+    }
+
+    /**
+     * 写 LocalTime
+     */
+    public void writeLocalDateTime(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            writeNull();
+            return;
+        }
+        String formatDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(dateTime);
+        writeString(formatDateTime);
     }
 
     public void writeError(Throwable error) {
@@ -316,6 +370,7 @@ public class JSONWriter {
         out.append(c);
     }
 
+    @Override
     public String toString() {
         return out.toString();
     }

--- a/core/src/main/java/com/alibaba/druid/support/json/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/druid/support/json/JSONWriter.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.util.Utils;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
+
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/core/src/test/java/com/alibaba/druid/bvt/utils/JSONWriterTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/utils/JSONWriterTest.java
@@ -1,6 +1,9 @@
 package com.alibaba.druid.bvt.utils;
 
 import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import junit.framework.TestCase;
 
@@ -24,4 +27,28 @@ public class JSONWriterTest extends TestCase {
         Assert.assertEquals("{\"Class\":\"com.alibaba.druid.bvt.utils.JSONWriterTest$1\",\"Message\":null,\"StackTrace\":\"\"}",
                 writer.toString());
     }
+
+    public void test_localDate() {
+        JSONWriter writer = new JSONWriter();
+        LocalDate localDate = LocalDate.of(2023, 12, 21);
+        writer.writeObject(localDate);
+        Assert.assertEquals("\"2023-12-21\"", writer.toString());
+    }
+
+    public void test_localTime() {
+        JSONWriter writer = new JSONWriter();
+        LocalTime localTime = LocalTime.of(12, 0,1);
+        writer.writeObject(localTime);
+        Assert.assertEquals("\"12:00:01\"", writer.toString());
+    }
+
+    public void test_localDateTime() {
+        JSONWriter writer = new JSONWriter();
+        LocalDate localDate = LocalDate.of(2023, 12, 21);
+        LocalTime localTime = LocalTime.of(12, 0,1);
+        LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+        writer.writeObject(localDateTime);
+        Assert.assertEquals("\"2023-12-21 12:00:01\"", writer.toString());
+    }
+
 }


### PR DESCRIPTION
1. JSONWriter 增加对java8本地时间类的解析 
2. StatFilter 增加对java8本地时间类的解析 
3. StatFilter 打印慢SQL日志的内容中sql 与参数之间增加空格隔开 
4. StatFilter 覆盖父类的方法增加Override标记 