### PR TITLE
修复 MySQL8.0 ALTER TABLE t1 ALTER INDEX i_idx INVISIBLE解析失败的问题 #5650

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -6613,11 +6613,12 @@ public class MySqlStatementParser extends SQLStatementParser {
 
                     SQLName indexName = this.exprParser.name();
 
-                    if (lexer.identifierEquals("VISIBLE")) {
+                    if (lexer.identifierEquals("VISIBLE") || lexer.identifierEquals("INVISIBLE")) {
                         SQLAlterTableAlterIndex alterIndex = new SQLAlterTableAlterIndex();
                         alterIndex.setName(indexName);
+                        alterIndex.getIndexDefinition().getOptions().setVisible(lexer.identifierEquals("VISIBLE"));
+                        alterIndex.getIndexDefinition().getOptions().setInvisible(lexer.identifierEquals("INVISIBLE"));
                         lexer.nextToken();
-                        alterIndex.getIndexDefinition().getOptions().setVisible(true);
                         stmt.addItem(alterIndex);
                         break;
                     }

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -6465,7 +6465,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLAlterTableAlterIndex x) {
-        print0(ucase ? "ALTER " : "alter ");
+        print0(ucase ? "ALTER INDEX " : "alter index ");
 
         visit(x.getIndexDefinition());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5650.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5650.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 验证 ALTER TABLE t1 ALTER INDEX i_idx INVISIBLE语法
+ *
+ * @author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5650">Issue来源</a>
+ */
+public class Issue5650 {
+
+    @Test
+    public void test_alter_index() throws Exception {
+        for (DbType dbType : new DbType[]{DbType.mysql}) {
+            for (String sql : new String[]{
+                "ALTER TABLE t1 ALTER INDEX i_idx INVISIBLE;",
+                "ALTER TABLE t1 ALTER INDEX i_idx VISIBLE;",
+            }) {
+                SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                SQLStatement statement = parser.parseStatement();
+                System.out.println(dbType + "原始的sql===" + sql);
+                System.out.println(dbType + "归一化的sql===" + Issue5421.normalizeSql(sql));
+                String newSql = statement.toString() + ";";
+                System.out.println(dbType + "生成的sql===" + newSql);
+                System.out.println(dbType + "生成的sql归一化===" + Issue5421.normalizeSql(newSql));
+                parser = SQLParserUtils.createSQLStatementParser(newSql, dbType);
+                statement = parser.parseStatement();
+                System.out.println(dbType + "再次解析对象得到sql===" + Issue5421.normalizeSql(statement.toString()));
+                assertEquals(sql, Issue5421.normalizeSql(statement.toString()) + ";");
+            }
+        }
+    }
+}

--- a/core/src/test/resources/bvt/parser/mysql-31.txt
+++ b/core/src/test/resources/bvt/parser/mysql-31.txt
@@ -1,4 +1,4 @@
 ALTER TABLE t1 ALTER INDEX i_idx VISIBLE;
 ---------------------------
 ALTER TABLE t1
-	ALTER i_idx  VISIBLE;
+	ALTER INDEX i_idx  VISIBLE;


### PR DESCRIPTION
修复 MySQL8.0 ALTER TABLE t1 ALTER INDEX i_idx INVISIBLE解析失败的问题