### PR TITLE
解析update 带limit不支持的问题优化 #5078

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
@@ -31,6 +31,7 @@ public class SQLUpdateStatement extends SQLStatementImpl implements SQLReplaceab
 
     protected final List<SQLUpdateSetItem> items = new ArrayList<SQLUpdateSetItem>();
     protected SQLExpr where;
+    protected SQLLimit limit;
     protected SQLTableSource from;
 
     protected SQLTableSource tableSource;
@@ -43,7 +44,16 @@ public class SQLUpdateStatement extends SQLStatementImpl implements SQLReplaceab
 
     public SQLUpdateStatement() {
     }
+    public SQLLimit getLimit() {
+        return limit;
+    }
 
+    public void setLimit(SQLLimit limit) {
+        if (limit != null) {
+            limit.setParent(this);
+        }
+        this.limit = limit;
+    }
     public void cloneTo(SQLUpdateStatement x) {
         x.dbType = dbType;
         x.afterSemi = afterSemi;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlUpdateStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlUpdateStatement.java
@@ -18,7 +18,6 @@ package com.alibaba.druid.sql.dialect.mysql.ast.statement;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.ast.SQLCommentHint;
 import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateSetItem;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
@@ -29,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MySqlUpdateStatement extends SQLUpdateStatement implements MySqlStatement {
-    private SQLLimit limit;
 
     private boolean lowPriority;
     private boolean ignore;
@@ -48,16 +46,6 @@ public class MySqlUpdateStatement extends SQLUpdateStatement implements MySqlSta
         super(DbType.mysql);
     }
 
-    public SQLLimit getLimit() {
-        return limit;
-    }
-
-    public void setLimit(SQLLimit limit) {
-        if (limit != null) {
-            limit.setParent(this);
-        }
-        this.limit = limit;
-    }
 
     @Override
     protected void accept0(SQLASTVisitor visitor) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -4500,7 +4500,7 @@ public class SQLStatementParser extends SQLParser {
             lexer.nextToken();
             updateStatement.setWhere(this.exprParser.expr());
         }
-
+        updateStatement.setLimit(this.exprParser.parseLimit());
         return updateStatement;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -3625,6 +3625,10 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             printExpr(where, parameterized);
             indentCount--;
         }
+        if (x.getLimit() != null) {
+            println();
+            x.getLimit().accept(this);
+        }
 
         return false;
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oceanbase/issues/Issue5078.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oceanbase/issues/Issue5078.java
@@ -1,0 +1,45 @@
+package com.alibaba.druid.bvt.sql.oceanbase.issues;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.bvt.sql.mysql.issues.Issue5421;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.util.JdbcUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 验证 update ant.t1 set name=10 where id >100 limit 1语法
+ *
+ * @author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5078">Issue来源</a>
+ */
+public class Issue5078 {
+
+    @Test
+    public void test_update_limit() throws Exception {
+        for (DbType dbType : new DbType[]{DbType.oceanbase}) {
+            for (String sql : new String[]{
+                "UPDATE ant.t1 SET name = 10 WHERE id > 200;",
+                "UPDATE ant.t1 SET name = 10 WHERE id > 100 LIMIT 2024;",
+            }) {
+                SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                SQLStatement statement = parser.parseStatement();
+                System.out.println(dbType + "原始的sql===" + sql);
+                System.out.println(dbType + "归一化的sql===" + Issue5421.normalizeSql(sql));
+                String newSql = statement.toString() + ";";
+                System.out.println(dbType + "生成的sql===" + newSql);
+                System.out.println(dbType + "生成的sql归一化===" + Issue5421.normalizeSql(newSql));
+                parser = SQLParserUtils.createSQLStatementParser(newSql, dbType);
+                statement = parser.parseStatement();
+                System.out.println(dbType + "再次解析对象得到sql===" + Issue5421.normalizeSql(statement.toString()));
+                assertEquals(sql, Issue5421.normalizeSql(statement.toString()) + ";");
+            }
+        }
+    }
+}


### PR DESCRIPTION
1.2.X版本后解析按oceanbase模式解析update 带limit不支持 #5078
是走到了默认的SQLStatementParser的逻辑，因此统一优化