### PR TITLE
feat:  增加访问安全检查SPI, 以便应用扩展来集成监控页面的SSO

### DIFF
--- a/core/src/main/java/com/alibaba/druid/support/http/DruidWebSecurityProvider.java
+++ b/core/src/main/java/com/alibaba/druid/support/http/DruidWebSecurityProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.support.http;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Druid web console安全性控制SPI.
+ *
+ * 扩展此接口以匹配项目内的认证机制, 实现SSO.
+ * 需要将实现类配置在META-INF/services/com.alibaba.druid.support.http.DruidWebSecurityProvider.
+ */
+public interface DruidWebSecurityProvider {
+    /**
+     * 检查用户是否未授权访问.
+     *
+     * @param request 请求
+     * @return 如果用户未授权访问true, 否则返回false。
+     */
+    boolean isNotPermit(HttpServletRequest request);
+}

--- a/core/src/test/java/com/alibaba/druid/support/http/ResourceServletSsoTestCase.java
+++ b/core/src/test/java/com/alibaba/druid/support/http/ResourceServletSsoTestCase.java
@@ -1,0 +1,52 @@
+package com.alibaba.druid.support.http;
+
+import junit.framework.TestCase;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.lang.reflect.Field;
+
+public class ResourceServletSsoTestCase extends TestCase {
+
+
+    public void testSso() throws Exception {
+        final File file = new File("target/test-classes/META-INF/services/com.alibaba.druid.support.http.DruidWebSecurityProvider");
+        FileUtils.write(file, DruidWebSecurityProviderMockSsoOk.class.getName());
+        ResourceServlet servlet = new ResourceServlet("/test") {
+            protected String process(String url) {
+                return "mock:" + url;
+            }
+        };
+        final Field securitySpiFld = ResourceServletTestCase.getToNotFinal();
+        final DruidWebSecurityProvider spi = (DruidWebSecurityProvider) securitySpiFld.get(null);
+        if (spi == null || !(spi instanceof DruidWebSecurityProviderMockSsoOk)) {
+            securitySpiFld.set(null, new DruidWebSecurityProviderMockSsoOk());
+        }
+        final MockServletConfig config = new MockServletConfig();
+        config.addInitParameter(ResourceServlet.PARAM_NAME_USERNAME, "user");
+        servlet.init(config);
+        final MockHttpServletRequest req = new MockHttpServletRequest();
+
+        req.setMethod("GET");
+        req.setRequestURI("/test");
+        final MockHttpServletResponse res = new MockHttpServletResponse();
+        try {
+            servlet.service(req, res);
+            Assert.assertEquals(200, res.getStatus());
+        } catch (final Exception ex) {
+            ex.printStackTrace();
+        }
+        file.delete();
+    }
+
+    public static final class DruidWebSecurityProviderMockSsoOk implements DruidWebSecurityProvider {
+        public boolean isNotPermit(final HttpServletRequest request) {
+            return false;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/support/http/ResourceServletTestCase.java
+++ b/core/src/test/java/com/alibaba/druid/support/http/ResourceServletTestCase.java
@@ -1,0 +1,46 @@
+package com.alibaba.druid.support.http;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class ResourceServletTestCase extends TestCase {
+
+    public void testNotLogin() throws Exception {
+        final Field securitySpiFld = getToNotFinal();
+        securitySpiFld.set(null, null);
+        ResourceServlet servlet = new ResourceServlet("/test") {
+            protected String process(String url) {
+                return "mock:" + url;
+            }
+        };
+        final MockServletConfig config = new MockServletConfig();
+        config.addInitParameter(ResourceServlet.PARAM_NAME_USERNAME, "user");
+        servlet.init(config);
+        final MockHttpServletRequest req = new MockHttpServletRequest();
+
+        req.setMethod("GET");
+        req.setRequestURI("/test");
+        final MockHttpServletResponse res = new MockHttpServletResponse();
+        try {
+            servlet.service(req, res);
+            Assert.assertEquals(302, res.getStatus());
+        } catch (final Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    static Field getToNotFinal() throws NoSuchFieldException, IllegalAccessException {
+        final Field securitySpiFld = ResourceServlet.class.getDeclaredField("SECURITY_SPI");
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(securitySpiFld, securitySpiFld.getModifiers() & ~Modifier.FINAL);
+        securitySpiFld.setAccessible(true);
+        return securitySpiFld;
+    }
+}


### PR DESCRIPTION
通过实现DruidWebSecurityProvider SPI来集成SSO
 需要将实现类配置在META-INF/services/com.alibaba.druid.support.http.DruidWebSecurityProvider.