### PR TITLE
useUnfairLock默认设为true、setMaxWait不替换成公平锁

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,6 @@
 	<properties>
 		<spring.version>4.3.20.RELEASE</spring.version>
 		<junit.version>4.13.1</junit.version>
-		<jmh.version>1.19</jmh.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jdk.version>1.8</jdk.version>

--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -254,7 +254,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     static final AtomicLongFieldUpdater<DruidAbstractDataSource> destroyCountUpdater = AtomicLongFieldUpdater.newUpdater(DruidAbstractDataSource.class, "destroyCount");
     static final AtomicLongFieldUpdater<DruidAbstractDataSource> createStartNanosUpdater = AtomicLongFieldUpdater.newUpdater(DruidAbstractDataSource.class, "createStartNanos");
 
-    private Boolean useUnfairLock;
+    private Boolean useUnfairLock = true;
     private boolean useLocalSessionState = true;
     private boolean keepConnectionUnderlyingTransactionIsolation;
 
@@ -368,7 +368,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     }
 
     public void setUseUnfairLock(boolean useUnfairLock) {
-        if (lock.isFair() == !useUnfairLock && this.useUnfairLock != null) {
+        if (lock.isFair() == !useUnfairLock) {
             return;
         }
 
@@ -1085,20 +1085,6 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     public void setMaxWait(long maxWaitMillis) {
         if (maxWaitMillis == this.maxWait) {
             return;
-        }
-
-        if (maxWaitMillis > 0 && useUnfairLock == null && !this.inited) {
-            final ReentrantLock lock = this.lock;
-            lock.lock();
-            try {
-                if ((!this.inited) && (!lock.isFair())) {
-                    this.lock = new ReentrantLock(true);
-                    this.notEmpty = this.lock.newCondition();
-                    this.empty = this.lock.newCondition();
-                }
-            } finally {
-                lock.unlock();
-            }
         }
 
         if (inited) {

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/LockFairTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/LockFairTest.java
@@ -25,14 +25,14 @@ public class LockFairTest extends TestCase {
         Assert.assertEquals(false, ((ReentrantLock) dataSource.getLock()).isFair());
         dataSource.setMaxWait(100);
 
-        Assert.assertEquals(true, ((ReentrantLock) dataSource.getLock()).isFair());
+        Assert.assertEquals(false, ((ReentrantLock) dataSource.getLock()).isFair());
         {
             Connection conn = dataSource.getConnection();
             conn.close();
         }
         dataSource.setMaxWait(110);
 
-        Assert.assertEquals(true, ((ReentrantLock) dataSource.getLock()).isFair());
+        Assert.assertEquals(false, ((ReentrantLock) dataSource.getLock()).isFair());
         {
             Connection conn = dataSource.getConnection();
             conn.close();
@@ -40,7 +40,7 @@ public class LockFairTest extends TestCase {
 
         dataSource.setMaxWait(0);
 
-        Assert.assertEquals(true, ((ReentrantLock) dataSource.getLock()).isFair());
+        Assert.assertEquals(false, ((ReentrantLock) dataSource.getLock()).isFair());
         {
             Connection conn = dataSource.getConnection();
             conn.close();

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/UsingDefaultLockModeBenchmarkTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/UsingDefaultLockModeBenchmarkTest.java
@@ -1,0 +1,101 @@
+package com.alibaba.druid.bvt.pool;
+
+import com.alibaba.druid.mock.MockConnection;
+import com.alibaba.druid.mock.MockDriver;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.stat.DruidDataSourceStatManager;
+import org.junit.Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 1, time = 3)
+@Measurement(iterations = 3, time = 3)
+// Threads.MAX means using Runtime.getRuntime().availableProcessors().
+@Threads(Threads.MAX)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class UsingDefaultLockModeBenchmarkTest {
+    private DruidDataSource dataSource;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        DruidDataSourceStatManager.clear();
+
+        dataSource = new DruidDataSource();
+        dataSource.setRemoveAbandoned(true);
+        dataSource.setRemoveAbandonedTimeoutMillis(100);
+        dataSource.setLogAbandoned(true);
+        dataSource.setTimeBetweenEvictionRunsMillis(10);
+        dataSource.setMinEvictableIdleTimeMillis(300 * 1000);
+        dataSource.setUrl("jdbc:mock:xxx");
+        dataSource.setDriver(new SlowDriver());
+        int poolSize = Runtime.getRuntime().availableProcessors() / 2;
+        dataSource.setMaxActive(poolSize);
+        dataSource.setInitialSize(poolSize);
+        dataSource.setMaxWait(2000);
+        dataSource.init();
+    }
+
+    public static class SlowDriver extends MockDriver {
+        public MockConnection createMockConnection(MockDriver driver, String url, Properties connectProperties) {
+            try {
+                Thread.sleep(1000 * 1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return super.createMockConnection(driver, url, connectProperties);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        dataSource.close();
+        Assert.assertEquals(0, DruidDataSourceStatManager.getInstance().getDataSourceList().size());
+    }
+
+    @Benchmark
+    public void test_activeTrace() throws Exception {
+        int count = 1000_00;
+        int i = 0;
+        try {
+            for (; i < count; ++i) {
+                Connection conn = dataSource.getConnection();
+                Assert.assertNotNull(conn);
+                conn.close();
+                Assert.assertTrue(conn.isClosed());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            Assert.assertEquals(count, i);
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include(UsingDefaultLockModeBenchmarkTest.class.getSimpleName())
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/UsingFairLockBenchmarkTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/UsingFairLockBenchmarkTest.java
@@ -1,0 +1,102 @@
+package com.alibaba.druid.bvt.pool;
+
+import com.alibaba.druid.mock.MockConnection;
+import com.alibaba.druid.mock.MockDriver;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.stat.DruidDataSourceStatManager;
+import org.junit.Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 1, time = 3)
+@Measurement(iterations = 3, time = 3)
+// Threads.MAX means using Runtime.getRuntime().availableProcessors().
+@Threads(Threads.MAX)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class UsingFairLockBenchmarkTest {
+    private DruidDataSource dataSource;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        DruidDataSourceStatManager.clear();
+
+        dataSource = new DruidDataSource();
+        dataSource.setRemoveAbandoned(true);
+        dataSource.setRemoveAbandonedTimeoutMillis(100);
+        dataSource.setLogAbandoned(true);
+        dataSource.setTimeBetweenEvictionRunsMillis(10);
+        dataSource.setMinEvictableIdleTimeMillis(300 * 1000);
+        dataSource.setUrl("jdbc:mock:xxx");
+        dataSource.setDriver(new SlowDriver());
+        int poolSize = Runtime.getRuntime().availableProcessors() / 2;
+        dataSource.setMaxActive(poolSize);
+        dataSource.setInitialSize(poolSize);
+        dataSource.setMaxWait(2000);
+        dataSource.setUseUnfairLock(false);
+        dataSource.init();
+    }
+
+    public static class SlowDriver extends MockDriver {
+        public MockConnection createMockConnection(MockDriver driver, String url, Properties connectProperties) {
+            try {
+                Thread.sleep(1000 * 1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return super.createMockConnection(driver, url, connectProperties);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        dataSource.close();
+        Assert.assertEquals(0, DruidDataSourceStatManager.getInstance().getDataSourceList().size());
+    }
+
+    @Benchmark
+    public void test_activeTrace() throws Exception {
+        int count = 1000_00;
+        int i = 0;
+        try {
+            for (; i < count; ++i) {
+                Connection conn = dataSource.getConnection();
+                Assert.assertNotNull(conn);
+                conn.close();
+                Assert.assertTrue(conn.isClosed());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            Assert.assertEquals(count, i);
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include(UsingFairLockBenchmarkTest.class.getSimpleName())
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/UsingUnfairLockBenchmarkTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/UsingUnfairLockBenchmarkTest.java
@@ -1,0 +1,102 @@
+package com.alibaba.druid.bvt.pool;
+
+import com.alibaba.druid.mock.MockConnection;
+import com.alibaba.druid.mock.MockDriver;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.stat.DruidDataSourceStatManager;
+import org.junit.Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 1, time = 3)
+@Measurement(iterations = 3, time = 3)
+// Threads.MAX means using Runtime.getRuntime().availableProcessors().
+@Threads(Threads.MAX)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class UsingUnfairLockBenchmarkTest {
+    private DruidDataSource dataSource;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        DruidDataSourceStatManager.clear();
+
+        dataSource = new DruidDataSource();
+        dataSource.setRemoveAbandoned(true);
+        dataSource.setRemoveAbandonedTimeoutMillis(100);
+        dataSource.setLogAbandoned(true);
+        dataSource.setTimeBetweenEvictionRunsMillis(10);
+        dataSource.setMinEvictableIdleTimeMillis(300 * 1000);
+        dataSource.setUrl("jdbc:mock:xxx");
+        dataSource.setDriver(new SlowDriver());
+        int poolSize = Runtime.getRuntime().availableProcessors() / 2;
+        dataSource.setMaxActive(poolSize);
+        dataSource.setInitialSize(poolSize);
+        dataSource.setMaxWait(2000);
+        dataSource.setUseUnfairLock(true);
+        dataSource.init();
+    }
+
+    public static class SlowDriver extends MockDriver {
+        public MockConnection createMockConnection(MockDriver driver, String url, Properties connectProperties) {
+            try {
+                Thread.sleep(1000 * 1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return super.createMockConnection(driver, url, connectProperties);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        dataSource.close();
+        Assert.assertEquals(0, DruidDataSourceStatManager.getInstance().getDataSourceList().size());
+    }
+
+    @Benchmark
+    public void test_activeTrace() throws Exception {
+        int count = 1000_00;
+        int i = 0;
+        try {
+            for (; i < count; ++i) {
+                Connection conn = dataSource.getConnection();
+                Assert.assertNotNull(conn);
+                conn.close();
+                Assert.assertTrue(conn.isClosed());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            Assert.assertEquals(count, i);
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include(UsingUnfairLockBenchmarkTest.class.getSimpleName())
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<springboot3.version>3.0.6</springboot3.version>
 
 		<junit.version>4.13.1</junit.version>
-		<jmh.version>1.19</jmh.version>
+		<jmh.version>1.37</jmh.version>
 
 		<gpg.skip>false</gpg.skip>
 		<javadoc.skip>false</javadoc.skip>
@@ -110,6 +110,13 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.openjdk.jmh</groupId>
+							<artifactId>jmh-generator-annprocess</artifactId>
+							<version>${jmh.version}</version>
+						</path>
+					</annotationProcessorPaths>
 					<parameters>true</parameters>
 				</configuration>
 				<executions>
@@ -486,9 +493,6 @@
 				<jdk>[17,)</jdk>
 			</activation>
 			<modules>
-				<!--
-                <module>example-graalvm-native</module>
-                -->
 				<module>druid-spring-boot-3-starter</module>
 			</modules>
 		</profile>


### PR DESCRIPTION
修改内容：
1. useUnfairLock默认设为true
2. setMaxWait不替换成公平锁
3. 重构了takeLast和pollLast，统一了处理流程，仅在await等待处理存在有无超时参数的差异，以验证二者性能在此PR下无本质差异。

JMH测试结果显示，无论是否mock创建连接耗时，采用公平锁的测试平均耗时均显著超过非公平锁的平均耗时，在cpu核数较多场景下，非公平锁的耗时增长倍数随应用线程数线性增长。
测试结果显示有必要将useUnfairLock默认值设为true，setMaxWait时不强制将lock替换为公平锁。
PR新增了3个JMH基准测试应用类，测试方法：
1. core模块执行mvn install，执行完毕后，core\target\generated-test-sources\test-annotations\com\alibaba\druid\bvt\pool\jmh_generated目录下应该能看到自动生成的jmh测试类。
3. Eclipse或IDEA下直接JMH测试类，对比UsingFairLockBenchmarkTest、UsingUnfairLockBenchmarkTest两种锁模式的性能差异。