### PR TITLE
spring.datasource.druid.filter.stat.enabled 的 defaultValue 修改为 false

### DIFF
--- a/druid-spring-boot-3-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/druid-spring-boot-3-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -15,7 +15,7 @@
       "type": "java.lang.Boolean",
       "sourceType": "com.mmtrix.base.druid.spring.boot3.autoconfigure.stat.DruidFilterConfiguration",
       "description": "Enable StatFilter.",
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "name": "spring.datasource.druid.filter.config.enabled",

--- a/druid-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/druid-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -15,7 +15,7 @@
       "type": "java.lang.Boolean",
       "sourceType": "com.alibaba.druid.spring.boot.autoconfigure.stat.DruidFilterConfiguration",
       "description": "Enable StatFilter.",
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "name": "spring.datasource.druid.filter.config.enabled",


### PR DESCRIPTION
因为 StatFilter 默认禁用，所以 spring.datasource.druid.filter.stat.enabled 的 defaultValue 应为 false