### PR TITLE
增加解析字段名保留前后注释的特性 #5686

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -4927,15 +4927,20 @@ public class MySqlStatementParser extends SQLStatementParser {
                                 identName = lexer.stringVal();
                                 hash = 0;
                             }
-                            lexer.nextTokenComma();
                             SQLExpr expr = new SQLIdentifierExpr(identName, hash);
+                            if (lexer.hasComment()) {
+                                expr.addBeforeComment(lexer.readAndResetComments());
+                            }
+                            lexer.nextTokenComma();
                             while (lexer.token() == Token.DOT) {
                                 lexer.nextToken();
                                 String propertyName = lexer.stringVal();
                                 lexer.nextToken();
                                 expr = new SQLPropertyExpr(expr, propertyName);
                             }
-
+                            if (lexer.hasComment()) {
+                                expr.addAfterComment(lexer.readAndResetComments());
+                            }
                             expr.setParent(stmt);
                             columns.add(expr);
                             columnSize++;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -1211,10 +1211,20 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
                     }
 
                     SQLExpr column = columns.get(i);
+                    if (column.hasBeforeComment()) {
+                        print(' ');
+                        printlnComment(column.getBeforeCommentsDirect());
+                        println();
+                    }
                     if (column instanceof SQLIdentifierExpr) {
                         printName0(((SQLIdentifierExpr) column).getName());
                     } else {
                         printExpr(column, parameterized);
+                    }
+                    if (column.hasAfterComment()) {
+                        print(' ');
+                        printlnComment(column.getAfterCommentsDirect());
+                        println();
                     }
                 }
                 print(')');

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5686.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5686.java
@@ -1,0 +1,44 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.SQLUtils.FormatOption;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlInsertStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 验证 SQL 解析保持注释和添加注释的功能
+ *
+ * @author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5686">Issue来源</a>
+ */
+public class Issue5686 {
+
+    @Test
+    public void test_column_comment() throws Exception {
+        String sql = "INSERT INTO TABLE_TEST_1(\n" + "\tDATE_ID,-- qianzhushi\n" + "\tCUS_NO -- houzhushi\n,\n" + "\tCUS_NAME\n" + ")\n" + "SELECT A.DATE_ID,\n" + "\tA.CUS_NO,\n"
+            + "\tA.CUS_NAME\n" + "FROM TABLE_TEST_2 \n" + "WHERE COL1='1';";
+        System.out.println("原始的sql===" + sql);
+        MySqlInsertStatement sqlStatement = (MySqlInsertStatement) SQLUtils.parseSingleStatement(sql,DbType.mysql,true);
+        int ccc=0;
+        for (SQLExpr column : sqlStatement.getColumns()) {
+            column.addAfterComment("-- comment注释"+(ccc++));
+        }
+        System.out.println(sqlStatement);
+        String newSql=sqlStatement.toString();
+        System.out.println("首次解析后生成的sql===" + newSql);
+        MySqlInsertStatement  sqlStatementNew = (MySqlInsertStatement) SQLUtils.parseSingleStatement(newSql,DbType.mysql,true);
+
+        String newSql2=sqlStatement.toString();
+        System.out.println("再次解析后生成的sql===" + newSql2);
+        assertEquals(newSql,newSql2);
+
+    }
+}


### PR DESCRIPTION
增加解析字段名保留前后注释的特性 #5686  ,并在输出sql时继续带上注释