### PR TITLE
feat: LogFilter/WallFilter 支持初始化时构建对象时外部传入配置属性

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/logging/LogFilter.java
@@ -79,7 +79,11 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
     protected DataSourceProxy dataSource;
 
     public LogFilter() {
-        configFromProperties(System.getProperties());
+        this(System.getProperties());
+    }
+
+    public LogFilter(final Properties properties) {
+        configFromProperties(properties);
     }
 
     public void configFromProperties(Properties properties) {
@@ -145,11 +149,13 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
         }
     }
 
+    private DbType dbType;
     @Override
     public void init(DataSourceProxy dataSource) {
         this.dataSource = dataSource;
+        dbType = DbType.of(dataSource.getDbType());
         configFromProperties(dataSource.getConnectProperties());
-        configFromProperties(System.getProperties());
+        //configFromProperties(System.getProperties());
     }
 
     public boolean isConnectionLogErrorEnabled() {
@@ -397,7 +403,7 @@ public abstract class LogFilter extends FilterEventAdapter implements LogFilterM
                     .append(connection.getId());
 
             Connection impl = connection.getRawObject();
-            if (DbType.mysql == DbType.of(dataSource.getDbType())) {
+            if (DbType.mysql.equals(dbType)) {
                 Long procId = MySqlUtils.getId(impl);
                 if (procId != null) {
                     msg.append(",procId-").append(procId);

--- a/core/src/main/java/com/alibaba/druid/filter/logging/Slf4jLogFilter.java
+++ b/core/src/main/java/com/alibaba/druid/filter/logging/Slf4jLogFilter.java
@@ -18,11 +18,20 @@ package com.alibaba.druid.filter.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Properties;
+
 public class Slf4jLogFilter extends LogFilter {
     private Logger dataSourceLogger = LoggerFactory.getLogger(dataSourceLoggerName);
     private Logger connectionLogger = LoggerFactory.getLogger(connectionLoggerName);
     private Logger statementLogger = LoggerFactory.getLogger(statementLoggerName);
     private Logger resultSetLogger = LoggerFactory.getLogger(resultSetLoggerName);
+
+    public Slf4jLogFilter(final Properties properties) {
+        super(properties);
+    }
+
+    public Slf4jLogFilter() {
+    }
 
     @Override
     public String getDataSourceLoggerName() {

--- a/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
@@ -59,7 +59,13 @@ public class WallFilter extends FilterAdapter implements WallFilterMBean {
     public static final String ATTR_UPDATE_CHECK_ITEMS = "wall.updateCheckItems";
 
     public WallFilter() {
-        configFromProperties(System.getProperties());
+        this(System.getProperties());
+    }
+
+    public WallFilter(final Properties properties) {
+        if (properties != null) {
+            configFromProperties(properties);
+        }
     }
 
     @Override


### PR DESCRIPTION
目的以便扩展集成时使用统一的外部配置, 而不是系统属性