### PR TITLE
fix: 修复SQL防火墙之SQL条件总真(WhereAlwayTrue)功能无效问题(条件写反了)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLEvalVisitorUtils.java
@@ -1111,8 +1111,10 @@ public class SQLEvalVisitorUtils {
             if ("1".equals(val) || "true".equalsIgnoreCase((String) val)) {
                 return true;
             }
-
-            return false;
+            if ("0".equals(val) || "false".equalsIgnoreCase((String) val)) {
+                return false;
+            }
+            return null;
         }
 
         throw new IllegalArgumentException(val.getClass() + " not supported.");

--- a/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
@@ -59,7 +59,7 @@ public class WallConfig implements WallConfigMBean {
     private boolean deleteWhereNoneCheck;
 
     private boolean updateAllow = true;
-    private boolean updateWhereAlayTrueCheck = true;
+    private boolean updateWhereAlwayTrueCheck = true;
     private boolean updateWhereNoneCheck;
 
     private boolean insertAllow = true;
@@ -758,13 +758,22 @@ public class WallConfig implements WallConfigMBean {
     }
 
     public boolean isUpdateWhereAlayTrueCheck() {
-        return updateWhereAlayTrueCheck;
+        return updateWhereAlwayTrueCheck;
     }
 
-    public void setUpdateWhereAlayTrueCheck(boolean updateWhereAlayTrueCheck) {
-        this.updateWhereAlayTrueCheck = updateWhereAlayTrueCheck;
+    @Deprecated
+    public void setUpdateWhereAlayTrueCheck(boolean updateWhereAlwayTrueCheck) {
+        this.updateWhereAlwayTrueCheck = updateWhereAlwayTrueCheck;
     }
 
+    public boolean isUpdateWhereAlwayTrueCheck() {
+        return updateWhereAlwayTrueCheck;
+    }
+    public void setUpdateWhereAlwayTrueCheck(boolean updateWhereAlwayTrueCheck) {
+        this.updateWhereAlwayTrueCheck = updateWhereAlwayTrueCheck;
+    }
+
+    @Deprecated
     public boolean isConditionOpBitwseAllow() {
         return conditionOpBitwseAllow;
     }

--- a/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
@@ -47,7 +47,7 @@ public class WallConfig implements WallConfigMBean {
     private boolean startTransactionAllow = true;
     private boolean blockAllow = true;
 
-    private boolean conditionAndAlwayTrueAllow;
+    private boolean conditionAndAlwayTrueAllow = true;
     private boolean conditionAndAlwayFalseAllow;
     private boolean conditionDoubleConstAllow;
     private boolean conditionLikeTrueAllow = true;

--- a/core/src/main/java/com/alibaba/druid/wall/WallProvider.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallProvider.java
@@ -498,7 +498,7 @@ public abstract class WallProvider {
                 violations.add(new IllegalSQLObjectViolation(ErrorCode.SYNTAX_ERROR, "not terminal sql, token "
                         + lastToken, sql));
             }
-            endOfComment = parser.getLexer().isEndOfComment();
+            endOfComment = parser.getLexer().isEOF();
         } catch (NotAllowCommentException e) {
             violations.add(new IllegalSQLObjectViolation(ErrorCode.COMMENT_STATEMENT_NOT_ALLOW, "comment not allow", sql));
             incrementCommentDeniedCount();

--- a/core/src/main/java/com/alibaba/druid/wall/spi/PGWallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/PGWallVisitor.java
@@ -16,6 +16,13 @@
 package com.alibaba.druid.wall.spi;
 
 import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGDeleteStatement;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGUpdateStatement;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.wall.WallProvider;
 import com.alibaba.druid.wall.WallVisitor;
@@ -41,5 +48,27 @@ public class PGWallVisitor extends WallVisitorBase implements WallVisitor, PGAST
             return true;
         }
         return !this.provider.checkDenyTable(name);
+    }
+
+    @Override
+    public boolean visit(PGSelectQueryBlock x) {
+        WallVisitorUtils.checkSelelct(this, x);
+        return true;
+    }
+
+    @Override
+    public boolean visit(PGDeleteStatement x) {
+        WallVisitorUtils.checkReadOnly(this, x.getFrom());
+        return visit((SQLDeleteStatement) x);
+    }
+
+    @Override
+    public boolean visit(PGUpdateStatement x) {
+        return visit((SQLUpdateStatement) x);
+    }
+
+    @Override
+    public boolean visit(PGInsertStatement x) {
+        return visit((SQLInsertStatement) x);
     }
 }

--- a/core/src/main/java/com/alibaba/druid/wall/spi/SQLServerWallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/SQLServerWallVisitor.java
@@ -20,8 +20,11 @@ import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.sqlserver.ast.SQLServerSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.sqlserver.ast.expr.SQLServerObjectReferenceExpr;
 import com.alibaba.druid.sql.dialect.sqlserver.ast.stmt.SQLServerExecStatement;
+import com.alibaba.druid.sql.dialect.sqlserver.ast.stmt.SQLServerUpdateStatement;
 import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerASTVisitor;
 import com.alibaba.druid.wall.WallProvider;
 import com.alibaba.druid.wall.WallVisitor;
@@ -113,4 +116,14 @@ public class SQLServerWallVisitor extends WallVisitorBase implements WallVisitor
     public boolean visit(SQLServerObjectReferenceExpr x) {
         return false;
     }
+
+    public boolean visit(SQLServerSelectQueryBlock x) {
+        WallVisitorUtils.checkSelelct(this, x);
+        return true;
+    }
+    @Override
+    public boolean visit(SQLServerUpdateStatement x) {
+        return visit((SQLUpdateStatement) x);
+    }
+
 }

--- a/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
@@ -221,7 +221,7 @@ public class WallVisitorUtils {
             if (Boolean.TRUE.equals(whereValue)) {
                 if (visitor.getConfig().isSelectWhereAlwayTrueCheck()
                         && visitor.isSqlEndOfComment()
-                        && !isSimpleConstExpr(where)) {
+                        && isSimpleConstExpr(where)) {
                     addViolation(visitor, ErrorCode.ALWAYS_TRUE, "select alway true condition not allow", x);
                 }
             }
@@ -238,7 +238,7 @@ public class WallVisitorUtils {
         if (Boolean.TRUE.equals(getConditionValue(visitor, x, visitor.getConfig().isSelectHavingAlwayTrueCheck()))) {
             if (visitor.getConfig().isSelectHavingAlwayTrueCheck()
                     && visitor.isSqlEndOfComment()
-                    && !isSimpleConstExpr(x)) {
+                    && isSimpleConstExpr(x)) {
                 addViolation(visitor, ErrorCode.ALWAYS_TRUE, "having alway true condition not allow", x);
             }
         }
@@ -277,7 +277,7 @@ public class WallVisitorUtils {
             checkCondition(visitor, where);
 
             if (Boolean.TRUE.equals(getConditionValue(visitor, where, config.isDeleteWhereAlwayTrueCheck()))) {
-                if (config.isDeleteWhereAlwayTrueCheck() && visitor.isSqlEndOfComment() && !isSimpleConstExpr(where)) {
+                if (config.isDeleteWhereAlwayTrueCheck() && visitor.isSqlEndOfComment() && isSimpleConstExpr(where)) {
                     addViolation(visitor, ErrorCode.ALWAYS_TRUE, "delete alway true condition not allow", x);
                 }
             }
@@ -867,7 +867,7 @@ public class WallVisitorUtils {
             checkCondition(visitor, where);
 
             if (Boolean.TRUE.equals(getConditionValue(visitor, where, config.isUpdateWhereAlayTrueCheck()))) {
-                if (config.isUpdateWhereAlayTrueCheck() && visitor.isSqlEndOfComment() && !isSimpleConstExpr(where)) {
+                if (config.isUpdateWhereAlayTrueCheck() && visitor.isSqlEndOfComment() && isSimpleConstExpr(where)) {
                     addViolation(visitor, ErrorCode.ALWAYS_TRUE, "update alway true condition not allow", x);
                 }
             }
@@ -1074,7 +1074,7 @@ public class WallVisitorUtils {
     }
 
     private static Object getValue_or(WallVisitor visitor, List<SQLExpr> groupList) {
-        boolean allFalse = true;
+        int falseCount = 0;
         for (int i = groupList.size() - 1; i >= 0; --i) {
             SQLExpr item = groupList.get(i);
             Object result = getValue(visitor, item);
@@ -1088,12 +1088,11 @@ public class WallVisitorUtils {
             }
 
             if (booleanVal == null) {
-                allFalse = false;
-                break;
+                falseCount ++;
             }
         }
 
-        if (allFalse) {
+        if (falseCount == groupList.size()) {
             return false;
         }
 

--- a/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
@@ -862,8 +862,8 @@ public class WallVisitorUtils {
         } else {
             checkCondition(visitor, where);
 
-            if (Boolean.TRUE.equals(getConditionValue(visitor, where, config.isUpdateWhereAlayTrueCheck()))) {
-                if (config.isUpdateWhereAlayTrueCheck() && visitor.isSqlEndOfComment() && isSimpleConstExpr(where)) {
+            if (Boolean.TRUE.equals(getConditionValue(visitor, where, config.isUpdateWhereAlwayTrueCheck()))) {
+                if (config.isUpdateWhereAlwayTrueCheck() && visitor.isSqlEndOfComment() && isSimpleConstExpr(where)) {
                     addViolation(visitor, ErrorCode.ALWAYS_TRUE, "update alway true condition not allow", x);
                 }
             }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/TAEWallTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/TAEWallTest.java
@@ -36,6 +36,6 @@ public class TAEWallTest extends TestCase {
 
     public void test_false() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "select * from t where status = 1 AND 1=1")); //
+                "select * from t where status = 1 OR 1=1")); //
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/TenantSelectTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/TenantSelectTest4.java
@@ -49,19 +49,30 @@ public class TenantSelectTest4 extends TestCase {
     public void testMySql() throws Exception {
         WallProvider.setTenantValue(123);
         MySqlWallProvider provider = new MySqlWallProvider(config);
+        config.setSelectWhereAlwayTrueCheck(false);
         WallCheckResult checkResult = provider.check(sql);
         Assert.assertEquals(0, checkResult.getViolations().size());
-
         String resultSql = SQLUtils.toSQLString(checkResult.getStatementList(), JdbcConstants.MYSQL);
         Assert.assertEquals(expect_sql, resultSql);
+
+        provider.reset();
+        config.setSelectWhereAlwayTrueCheck(true);
+        checkResult = provider.check(sql);
+        Assert.assertEquals(1, checkResult.getViolations().size());
     }
 
     public void testMySql2() throws Exception {
         MySqlWallProvider provider = new MySqlWallProvider(config_callback);
+        provider.getConfig().setSelectWhereAlwayTrueCheck(false);
         WallCheckResult checkResult = provider.check(sql);
         Assert.assertEquals(0, checkResult.getViolations().size());
 
         String resultSql = SQLUtils.toSQLString(checkResult.getStatementList(), JdbcConstants.MYSQL);
         Assert.assertEquals(expect_sql, resultSql);
+
+        provider.reset();
+        provider.getConfig().setSelectWhereAlwayTrueCheck(true);
+        checkResult = provider.check(sql);
+        Assert.assertEquals(1, checkResult.getViolations().size());
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallDeleteWhereTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallDeleteWhereTest.java
@@ -19,6 +19,7 @@ import junit.framework.TestCase;
 
 import org.junit.Assert;
 
+import com.alibaba.druid.wall.WallConfig;
 import com.alibaba.druid.wall.WallUtils;
 
 /**
@@ -29,12 +30,24 @@ public class WallDeleteWhereTest extends TestCase {
     private String sql2 = "DELETE FROM T WHERE id = 0 and 1 = 1";
 
     public void testMySql() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateMySql(sql));
-        Assert.assertFalse(WallUtils.isValidateMySql(sql2));
+        Assert.assertFalse(WallUtils.isValidateMySql(sql));
+        Assert.assertTrue(WallUtils.isValidateMySql(sql2));
+
+        final WallConfig wallConfig = new WallConfig();
+        wallConfig.setDeleteWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, wallConfig));
+        wallConfig.setDeleteWhereAlwayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateMySql(sql, wallConfig));
     }
 
     public void testORACLE() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateOracle(sql));
-        Assert.assertFalse(WallUtils.isValidateOracle(sql2));
+        Assert.assertFalse(WallUtils.isValidateOracle(sql));
+        Assert.assertTrue(WallUtils.isValidateOracle(sql2));
+
+        final WallConfig wallConfig = new WallConfig();
+        wallConfig.setDeleteWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateOracle(sql, wallConfig));
+        wallConfig.setDeleteWhereAlwayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateOracle(sql, wallConfig));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallDeleteWhereTest2.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallDeleteWhereTest2.java
@@ -32,11 +32,14 @@ public class WallDeleteWhereTest2 extends TestCase {
     public void test_check_true() throws Exception {
         WallConfig config = new WallConfig();
         config.setDeleteWhereAlwayTrueCheck(true);
-        config.setConditionAndAlwayTrueAllow(true);
         config.setCommentAllow(true);
 
         Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
         Assert.assertFalse(WallUtils.isValidateMySql(sql1, config));
+
+        config.setDeleteWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
+        Assert.assertTrue(WallUtils.isValidateMySql(sql1, config));
     }
 
     public void test_check_false() throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest.java
@@ -19,6 +19,7 @@ import junit.framework.TestCase;
 
 import org.junit.Assert;
 
+import com.alibaba.druid.wall.WallConfig;
 import com.alibaba.druid.wall.WallUtils;
 
 /**
@@ -30,10 +31,21 @@ public class WallSelectWhereTest extends TestCase {
     private String sql = "SELECT F1, F2  from t WHERE 1 = 1";
 
     public void testMySql() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateMySql(sql));
+        Assert.assertFalse(WallUtils.isValidateMySql(sql));
+        final WallConfig config = new WallConfig();
+        config.setSelectWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
+
+        config.setSelectWhereAlwayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
     }
 
     public void testORACLE() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateOracle(sql));
+        Assert.assertFalse(WallUtils.isValidateOracle(sql));
+        final WallConfig config = new WallConfig();
+        config.setSelectWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
+        config.setSelectWhereAlwayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest3.java
@@ -15,11 +15,10 @@
  */
 package com.alibaba.druid.bvt.filter.wall;
 
-import junit.framework.TestCase;
-
-import org.junit.Assert;
-
+import com.alibaba.druid.wall.WallConfig;
 import com.alibaba.druid.wall.WallUtils;
+import junit.framework.TestCase;
+import org.junit.Assert;
 
 /**
  * @author wenshao
@@ -28,10 +27,12 @@ public class WallSelectWhereTest3 extends TestCase {
     private String sql = "select * from t WHERE FID = 256 AND CHR(67)||CHR(65)||CHR(84) = 'CAT'";
 
     public void testMySql() throws Exception {
-        Assert.assertFalse(WallUtils.isValidateMySql(sql));
+        WallConfig config = new WallConfig();
+        config.setConditionAndAlwayFalseAllow(true);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
     }
 
     public void testORACLE() throws Exception {
-        Assert.assertFalse(WallUtils.isValidateOracle(sql));
+        Assert.assertTrue(WallUtils.isValidateOracle(sql));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest6.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallSelectWhereTest6.java
@@ -38,6 +38,9 @@ public class WallSelectWhereTest6 extends TestCase {
 
         Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
         Assert.assertFalse(WallUtils.isValidateMySql(sql1, config));
+
+        config.setSelectWhereAlwayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
     }
 
     public void test_check_false() throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTestWhereAlwaysTrue.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTestWhereAlwaysTrue.java
@@ -10,6 +10,9 @@ import org.junit.Assert;
 
 public class WallStatTestWhereAlwaysTrue extends TestCase {
     private String[] sqls = new String[]{
+            "select * from T where a=1 or 1=1",
+            "update T set name='N' where a=1 or 1=1",
+            "delete from T where a=1 or 1=1",
             "update T set name='N' where 1=1",
             "delete from T where 1=1",
             "select * from T where 1=1",

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTestWhereAlwaysTrue.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTestWhereAlwaysTrue.java
@@ -1,0 +1,84 @@
+package com.alibaba.druid.bvt.filter.wall;
+
+import com.alibaba.druid.wall.WallConfig;
+import com.alibaba.druid.wall.WallContext;
+import com.alibaba.druid.wall.WallProvider;
+import com.alibaba.druid.wall.WallTableStat;
+import com.alibaba.druid.wall.spi.*;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class WallStatTestWhereAlwaysTrue extends TestCase {
+    private String[] sqls = new String[]{
+            "update T set name='N' where 1=1",
+            "delete from T where 1=1",
+            "select * from T where 1=1",
+            "update T set name='N' where 1=1 ",
+            "delete from T where 1=1 ",
+            "select * from T where 1=1 ",
+            "update T set name='N' where 0=1 or 2=2",
+            "delete from T  where 0=1 or 2=2",
+            "select * from T where 0=1 or 2=2",
+    };
+
+    private String[] okSqls = new String[]{
+            "delete from T where a=1",
+            "delete from T where a=1 ",
+            "update T set name='N' where a=1",
+            "update T set name='N' where a=1 ",
+            "select * from T where a=1",
+            "select * from T where a=1 ",
+    };
+
+
+    protected void setUp() throws Exception {
+        WallContext.clearContext();
+    }
+
+    protected void tearDown() throws Exception {
+        WallContext.clearContext();
+    }
+
+
+    protected void doTest(final WallProvider provider) {
+        final WallConfig config = provider.getConfig();
+        config.setDeleteWhereAlwayTrueCheck(true);
+        //config.setUpdateWhereAlwayTrueCheck(true);
+        config.setSelectWhereAlwayTrueCheck(true);
+        for (final String sql : sqls) {
+            Assert.assertFalse(sql, provider.checkValid(sql));
+            final WallTableStat tableStat = provider.getTableStat("t");
+            if (sql.startsWith("delete")) {
+                Assert.assertTrue(tableStat.getDeleteCount() > 0);
+            }
+        }
+        for (final String sql : okSqls) {
+            Assert.assertTrue(sql, provider.checkValid(sql));
+        }
+    }
+
+    public void testMySql() throws Exception {
+        final WallProvider provider = new MySqlWallProvider();
+        doTest(provider);
+    }
+
+    public void testOracle() throws Exception {
+        final WallProvider provider = new OracleWallProvider();
+        doTest(provider);
+    }
+
+    public void testPG() throws Exception {
+        final WallProvider provider = new PGWallProvider();
+        doTest(provider);
+    }
+
+    public void testDB2Server() throws Exception {
+        final WallProvider provider = new DB2WallProvider();
+        doTest(provider);
+    }
+
+    public void testSQLServer() throws Exception {
+        final WallProvider provider = new SQLServerWallProvider();
+        doTest(provider);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTest_blacklist.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallStatTest_blacklist.java
@@ -23,13 +23,24 @@ public class WallStatTest_blacklist extends TestCase {
     public void testMySql() throws Exception {
         WallProvider provider = new MySqlWallProvider();
         for (int i = 0; i < 10; ++i) {
-            Assert.assertFalse(provider.checkValid(sql));
+            Assert.assertTrue(provider.checkValid(sql));
         }
 
         WallTableStat tableStat = provider.getTableStat("t");
         Assert.assertEquals(10, tableStat.getSelectCount());
+        Assert.assertEquals(9, provider.getWhiteListHitCount());
+        Assert.assertEquals(0, provider.getBlackListHitCount());
+
+        provider.reset();;
+        provider.getConfig().setConditionAndAlwayTrueAllow(false);
+        for (int i = 0; i < 10; ++i) {
+            Assert.assertFalse(provider.checkValid(sql));
+        }
+        tableStat = provider.getTableStat("t");
+        Assert.assertEquals(10, tableStat.getSelectCount());
         Assert.assertEquals(0, provider.getWhiteListHitCount());
         Assert.assertEquals(9, provider.getBlackListHitCount());
+
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest.java
@@ -28,17 +28,32 @@ import com.alibaba.druid.wall.WallUtils;
  * @author wenshao
  */
 public class WallUnionTest extends TestCase {
+    private static final String UNION_SQL1 = "select f1, f2 from t where f1=1 union select 1, 2";
+    private static final String UNION_SQL2 = "select f1, f2 from t where f1=1 union select 1, 2 --";
+
     public void testMySql() throws Exception {
         WallConfig config = new WallConfig();
+        config.setSelectUnionCheck(false);
+        config.setCommentAllow(true);
+        Assert.assertTrue(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertTrue(WallUtils.isValidateMySql(UNION_SQL2, config));
+
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateMySql("select f1, f2 from t where f1=1 union select 1, 2", config));
-        Assert.assertFalse(WallUtils.isValidateMySql("select f1, f2 from t where f1=1 union select 1, 2 --", config));
+        config.setCommentAllow(false);
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL2, config));
     }
 
     public void testOracle() throws Exception {
         WallConfig config = new WallConfig();
+        config.setSelectUnionCheck(false);
+        config.setCommentAllow(true);
+        Assert.assertTrue(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertTrue(WallUtils.isValidateOracle(UNION_SQL2, config));
+
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateOracle("select f1, f2 from t where f1=1 union select 1, 2", config));
-        Assert.assertFalse(WallUtils.isValidateOracle("select f1, f2 from t where f1=1 union select 1, 2 --", config));
+        config.setCommentAllow(false);
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL2, config));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest2.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest2.java
@@ -28,21 +28,37 @@ import com.alibaba.druid.wall.WallUtils;
  * @author wenshao
  */
 public class WallUnionTest2 extends TestCase {
+
+    public static final String UNION_SQL1 = "select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1";
+    public static final String UNION_SQL2 = "select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1 --";
+
     public void testMySql() throws Exception {
         WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateMySql("select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1",
-                config));
-        Assert.assertFalse(WallUtils.isValidateMySql("select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1 --",
-                config));
+        config.setSelectWhereAlwayTrueCheck(true);
+        config.setCommentAllow(true);
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL2, config));
+
+        config.setSelectUnionCheck(false);
+        config.setSelectWhereAlwayTrueCheck(false);
+        config.setCommentAllow(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL2, config));
     }
 
     public void testOracle() throws Exception {
         WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateOracle("select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1",
-                config));
-        Assert.assertFalse(WallUtils.isValidateOracle("select f1, f2 from t where f1 = 1 union select 1, 2 where 1 = 1 --",
-                config));
+        config.setSelectWhereAlwayTrueCheck(true);
+        config.setCommentAllow(true);
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL2, config));
+
+        config.setSelectUnionCheck(false);
+        config.setSelectWhereAlwayTrueCheck(false);
+        config.setCommentAllow(false);
+        Assert.assertTrue(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL2, config));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUnionTest4.java
@@ -15,12 +15,10 @@
  */
 package com.alibaba.druid.bvt.filter.wall;
 
-import junit.framework.TestCase;
-
-import org.junit.Assert;
-
 import com.alibaba.druid.wall.WallConfig;
 import com.alibaba.druid.wall.WallUtils;
+import junit.framework.TestCase;
+import org.junit.Assert;
 
 /**
  * 这个场景，被攻击者用于测试当前SQL拥有多少字段
@@ -28,21 +26,34 @@ import com.alibaba.druid.wall.WallUtils;
  * @author wenshao
  */
 public class WallUnionTest4 extends TestCase {
+
+    public static final String UNION_SQL1 = "SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X)";
+    public static final String UNION_SQL2 = "SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X) -- ";
+
     public void testMySql() throws Exception {
-        WallConfig config = new WallConfig();
+        final WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateMySql("SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X)",
-                config));
-        Assert.assertFalse(WallUtils.isValidateMySql("SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X) -- ",
-                config));
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateMySql(UNION_SQL2, config));
+
+        config.setSelectUnionCheck(false);
+        config.setSelectWhereAlwayTrueCheck(false);
+        config.setCommentAllow(true);
+        Assert.assertTrue(WallUtils.isValidateMySql(UNION_SQL1, config));
+        Assert.assertTrue(WallUtils.isValidateMySql(UNION_SQL2, config));
+
     }
 
     public void testORACLE() throws Exception {
-        WallConfig config = new WallConfig();
+        final WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
-        Assert.assertTrue(WallUtils.isValidateOracle("SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X)",
-                config));
-        Assert.assertFalse(WallUtils.isValidateOracle("SELECT id, product FROM T1 t where id=1 UNION (SELECT * FROM (SELECT 1,'x') X) -- ",
-                config));
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertFalse(WallUtils.isValidateOracle(UNION_SQL2, config));
+
+        config.setSelectUnionCheck(false);
+        config.setSelectWhereAlwayTrueCheck(false);
+        config.setCommentAllow(true);
+        Assert.assertTrue(WallUtils.isValidateOracle(UNION_SQL1, config));
+        Assert.assertTrue(WallUtils.isValidateOracle(UNION_SQL2, config));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateTest3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateTest3.java
@@ -38,26 +38,26 @@ public class WallUpdateTest3 extends TestCase {
     }
 
     public void testMySql() throws Exception {
-        config.setUpdateWhereAlayTrueCheck(true);
+        config.setUpdateWhereAlwayTrueCheck(true);
         config.setConditionAndAlwayTrueAllow(false);
 
         Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
         Assert.assertFalse(WallUtils.isValidateMySql(sql2, config));
 
-        config.setUpdateWhereAlayTrueCheck(false);
+        config.setUpdateWhereAlwayTrueCheck(false);
         config.setConditionAndAlwayTrueAllow(true);
         Assert.assertTrue(WallUtils.isValidateMySql(sql2, config));
         Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
     }
 
     public void testORACLE() throws Exception {
-        config.setUpdateWhereAlayTrueCheck(true);
+        config.setUpdateWhereAlwayTrueCheck(true);
         config.setConditionAndAlwayTrueAllow(false);
 
         Assert.assertFalse(WallUtils.isValidateOracle(sql, config));
         Assert.assertFalse(WallUtils.isValidateOracle(sql2, config));
 
-        config.setUpdateWhereAlayTrueCheck(false);
+        config.setUpdateWhereAlwayTrueCheck(false);
         config.setConditionAndAlwayTrueAllow(true);
         Assert.assertTrue(WallUtils.isValidateOracle(sql2, config));
         Assert.assertTrue(WallUtils.isValidateOracle(sql, config));

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateTest3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateTest3.java
@@ -29,7 +29,7 @@ import com.alibaba.druid.wall.WallUtils;
  */
 public class WallUpdateTest3 extends TestCase {
     private String sql = "UPDATE T_USER SET FNAME = ? WHERE 1 = 1";
-    private String sql2 = "UPDATE T_USER SET FNAME = ? WHERE id = 1 or1 = 1";
+    private String sql2 = "UPDATE T_USER SET FNAME = ? WHERE id = 1 or 1 = 1";
 
     private WallConfig config = new WallConfig();
 
@@ -38,12 +38,28 @@ public class WallUpdateTest3 extends TestCase {
     }
 
     public void testMySql() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
+        config.setUpdateWhereAlayTrueCheck(true);
+        config.setConditionAndAlwayTrueAllow(false);
+
+        Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
         Assert.assertFalse(WallUtils.isValidateMySql(sql2, config));
+
+        config.setUpdateWhereAlayTrueCheck(false);
+        config.setConditionAndAlwayTrueAllow(true);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql2, config));
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
     }
 
     public void testORACLE() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateOracle(sql, config));
+        config.setUpdateWhereAlayTrueCheck(true);
+        config.setConditionAndAlwayTrueAllow(false);
+
+        Assert.assertFalse(WallUtils.isValidateOracle(sql, config));
         Assert.assertFalse(WallUtils.isValidateOracle(sql2, config));
+
+        config.setUpdateWhereAlayTrueCheck(false);
+        config.setConditionAndAlwayTrueAllow(true);
+        Assert.assertTrue(WallUtils.isValidateOracle(sql2, config));
+        Assert.assertTrue(WallUtils.isValidateOracle(sql, config));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest.java
@@ -36,12 +36,12 @@ public class WallUpdateWhereTest extends TestCase {
         Assert.assertTrue(WallUtils.isValidateMySql(sql2));
         final WallConfig config = new WallConfig();
         config.setConditionAndAlwayTrueAllow(true);
-        config.setUpdateWhereAlayTrueCheck(true);
+        config.setUpdateWhereAlwayTrueCheck(true);
         Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
         Assert.assertTrue(WallUtils.isValidateMySql(sql2, config));
 
         config.setConditionAndAlwayTrueAllow(false);
-        config.setUpdateWhereAlayTrueCheck(false);
+        config.setUpdateWhereAlwayTrueCheck(false);
         Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
         Assert.assertFalse(WallUtils.isValidateMySql(sql2, config));
     }
@@ -51,12 +51,12 @@ public class WallUpdateWhereTest extends TestCase {
         Assert.assertTrue(WallUtils.isValidateOracle(sql2));
         final WallConfig config = new WallConfig();
         config.setConditionAndAlwayTrueAllow(true);
-        config.setUpdateWhereAlayTrueCheck(true);
+        config.setUpdateWhereAlwayTrueCheck(true);
         Assert.assertFalse(WallUtils.isValidateOracle(sql, config));
         Assert.assertTrue(WallUtils.isValidateOracle(sql2, config));
 
         config.setConditionAndAlwayTrueAllow(false);
-        config.setUpdateWhereAlayTrueCheck(false);
+        config.setUpdateWhereAlwayTrueCheck(false);
         Assert.assertTrue(WallUtils.isValidateOracle(sql, config));
         Assert.assertFalse(WallUtils.isValidateOracle(sql2, config));
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.druid.bvt.filter.wall;
 
+import com.alibaba.druid.wall.WallConfig;
 import junit.framework.TestCase;
 
 import org.junit.Assert;
@@ -31,13 +32,33 @@ public class WallUpdateWhereTest extends TestCase {
     private String sql2 = "UPDATE T SET F1 = 0 WHERE id=0 and 1 = 1";
 
     public void testMySql() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateMySql(sql));
-        Assert.assertFalse(WallUtils.isValidateMySql(sql2));
+        Assert.assertFalse(WallUtils.isValidateMySql(sql));
+        Assert.assertTrue(WallUtils.isValidateMySql(sql2));
+        final WallConfig config = new WallConfig();
+        config.setConditionAndAlwayTrueAllow(true);
+        config.setUpdateWhereAlayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
+        Assert.assertTrue(WallUtils.isValidateMySql(sql2, config));
+
+        config.setConditionAndAlwayTrueAllow(false);
+        config.setUpdateWhereAlayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateMySql(sql, config));
+        Assert.assertFalse(WallUtils.isValidateMySql(sql2, config));
     }
 
     public void testORACLE() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateOracle(sql));
-        Assert.assertFalse(WallUtils.isValidateOracle(sql2));
+        Assert.assertFalse(WallUtils.isValidateOracle(sql));
+        Assert.assertTrue(WallUtils.isValidateOracle(sql2));
+        final WallConfig config = new WallConfig();
+        config.setConditionAndAlwayTrueAllow(true);
+        config.setUpdateWhereAlayTrueCheck(true);
+        Assert.assertFalse(WallUtils.isValidateOracle(sql, config));
+        Assert.assertTrue(WallUtils.isValidateOracle(sql2, config));
+
+        config.setConditionAndAlwayTrueAllow(false);
+        config.setUpdateWhereAlayTrueCheck(false);
+        Assert.assertTrue(WallUtils.isValidateOracle(sql, config));
+        Assert.assertFalse(WallUtils.isValidateOracle(sql2, config));
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest1.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/WallUpdateWhereTest1.java
@@ -31,7 +31,7 @@ public class WallUpdateWhereTest1 extends TestCase {
 
     public void test_check_true() throws Exception {
         WallConfig config = new WallConfig();
-        config.setUpdateWhereAlayTrueCheck(true);
+        config.setUpdateWhereAlwayTrueCheck(true);
         config.setConditionAndAlwayTrueAllow(true);
         config.setCommentAllow(true);
 
@@ -41,7 +41,7 @@ public class WallUpdateWhereTest1 extends TestCase {
 
     public void test_check_false() throws Exception {
         WallConfig config = new WallConfig();
-        config.setUpdateWhereAlayTrueCheck(false);
+        config.setUpdateWhereAlwayTrueCheck(false);
         config.setConditionAndAlwayTrueAllow(true);
         config.setCommentAllow(true);
 

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest.java
@@ -46,7 +46,7 @@ public class MySqlWallTest extends TestCase {
 
         //Assert.assertFalse(WallUtils.isValidateMySql("select f1, f2 from t where c1=1 union select 1, 2"));
 
-        Assert.assertTrue(WallUtils.isValidateMySql("select c1 from t where 1=1 or id =1"));
+        Assert.assertFalse(WallUtils.isValidateMySql("select c1 from t where 1=1 or id =1"));
         Assert.assertFalse(WallUtils.isValidateMySql("select c1 from t where id =1 or 1=1"));
         Assert.assertFalse(WallUtils.isValidateMySql("select c1 from t where id =1 || 1=1"));
 

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest21.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest21.java
@@ -36,6 +36,6 @@ public class MySqlWallTest21 extends TestCase {
 
     public void test_false() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "select * from t where status = 1 AND 1=1")); //
+                "select * from t where status = 1 OR 1=1")); //
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest22.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest22.java
@@ -36,6 +36,6 @@ public class MySqlWallTest22 extends TestCase {
 
     public void test_false() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "SELECT count(*) AS num FROM hkapp_goods WHERE  status=1 AND level=1 AND 1=1")); //
+                "SELECT count(*) AS num FROM hkapp_goods WHERE  status=1 AND level=1 OR 1=1")); //
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest23.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest23.java
@@ -36,6 +36,6 @@ public class MySqlWallTest23 extends TestCase {
 
     public void test_false() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "select count(*) total from utao_goods where pprice between 0 and 99999 and state=1 and 1=1")); //
+                "select count(*) total from utao_goods where pprice between 0 and 99999 and state=1 or 1=1")); //
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest24.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest24.java
@@ -36,6 +36,6 @@ public class MySqlWallTest24 extends TestCase {
 
     public void test_false() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "SELECT count(*) AS num FROM hkapp_goods WHERE  status=1 AND level=1 AND xxx = 1 AND 1=1")); //
+                "SELECT count(*) AS num FROM hkapp_goods WHERE  status=1 AND level=1 AND xxx = 1 OR 1=1")); //
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest43.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest43.java
@@ -15,12 +15,10 @@
  */
 package com.alibaba.druid.bvt.filter.wall.mysql;
 
-import junit.framework.TestCase;
-
-import org.junit.Assert;
-
 import com.alibaba.druid.wall.WallProvider;
 import com.alibaba.druid.wall.spi.MySqlWallProvider;
+import junit.framework.TestCase;
+import org.junit.Assert;
 
 /**
  * SQLServerWallTest
@@ -32,7 +30,7 @@ import com.alibaba.druid.wall.spi.MySqlWallProvider;
 public class MySqlWallTest43 extends TestCase {
     public void test_false() throws Exception {
         WallProvider provider = new MySqlWallProvider();
-
+        provider.getConfig().setConditionAndAlwayTrueAllow(false);
         Assert.assertFalse(provider.checkValid(//
                 "SELECT COUNT(1) AS count FROM `team` " + //
                         "WHERE `team_type` = 'normal' AND 1 = 1 AND `city_id` IN (0,10)"));

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest63.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest63.java
@@ -33,17 +33,24 @@ public class MySqlWallTest63 extends TestCase {
     public void test_true() throws Exception {
         WallProvider provider = new MySqlWallProvider();
         provider.getConfig().setSchemaCheck(true);
-        provider.getConfig().setSelectUnionCheck(true);
+        provider.getConfig().setSelectUnionCheck(false);
         provider.setBlackListEnable(false);
         provider.setWhiteListEnable(false);
 
-        Assert.assertTrue(provider.checkValid(//
-                "SELECT FID, FNAME FROM T WHERE C=1 UNION SELECT 1, 'AAA'"));
-
-        Assert.assertFalse(provider.checkValid(//
-                "SELECT FID, FNAME FROM T WHERE C=1 UNION SELECT 1, 'AAA' --"));
+        final String sql1 = "SELECT FID, FNAME FROM T WHERE C=1 UNION SELECT 1, 'AAA'";
+        Assert.assertTrue(provider.checkValid(sql1));
+        final String sql2 = "SELECT FID, FNAME FROM T WHERE C=1 UNION SELECT 1, 'AAA' --";
+        Assert.assertFalse(provider.checkValid(sql2));
 
         Assert.assertEquals(1, provider.getTableStats().size());
+
+        provider.reset();
+        provider.getConfig().setCommentAllow(true);
+        provider.getConfig().setSelectUnionCheck(false);
+
+        Assert.assertTrue(provider.checkValid(sql2));
+
+        Assert.assertTrue(provider.checkValid(sql2));
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest65.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest65.java
@@ -15,12 +15,11 @@
  */
 package com.alibaba.druid.bvt.filter.wall.mysql;
 
-import junit.framework.TestCase;
-
-import org.junit.Assert;
-
+import com.alibaba.druid.wall.WallConfig;
 import com.alibaba.druid.wall.WallProvider;
 import com.alibaba.druid.wall.spi.MySqlWallProvider;
+import junit.framework.TestCase;
+import org.junit.Assert;
 
 /**
  * SQLServerWallTest
@@ -32,15 +31,13 @@ import com.alibaba.druid.wall.spi.MySqlWallProvider;
 public class MySqlWallTest65 extends TestCase {
     public void test_false() throws Exception {
         WallProvider provider = new MySqlWallProvider();
-        provider.getConfig().setSchemaCheck(true);
-
+        WallConfig config = provider.getConfig();
+        config.setSchemaCheck(true);
         Assert.assertFalse(provider.checkValid(//
                 "SELECT email, passwd, login_id, full_name" +
-                        " FROM members" +
-                        " WHERE member_id = 3 AND 0<(SELECT COUNT(*) FROM tabname);"));
+                        " FROM test1.members" +
+                        " WHERE member_id = 3 OR 0<(SELECT COUNT(*) FROM tabname);"));
 
         Assert.assertEquals(2, provider.getTableStats().size());
     }
-
-
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest7.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest7.java
@@ -30,7 +30,7 @@ import com.alibaba.druid.wall.WallUtils;
  */
 public class MySqlWallTest7 extends TestCase {
     public void test_stuff() throws Exception {
-        Assert.assertFalse(WallUtils.isValidateMySql(//
+        Assert.assertTrue(WallUtils.isValidateMySql(//
                 "SELECT a.* FROM vote_info a where a.id<10 and (id <5 or 1=1) limit 1,10")); // 部分永真
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest72.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest72.java
@@ -35,10 +35,16 @@ public class MySqlWallTest72 extends TestCase {
 
         provider.getConfig().setCommentAllow(true);
 
-        Assert.assertFalse(provider.checkValid(//
+        Assert.assertTrue(provider.checkValid(//
                 "select * from t /**/ where fid = 123 AND 1=1"));
 
         Assert.assertEquals(1, provider.getTableStats().size());
+
+        provider.reset();
+        provider.getConfig().setCommentAllow(false);
+        Assert.assertFalse(provider.checkValid(//
+                "select * from t /**/ where fid = 123 AND 1=1 --")); //FIXME /**/
+
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest74.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest74.java
@@ -35,19 +35,23 @@ public class MySqlWallTest74 extends TestCase {
 
         provider.getConfig().setCommentAllow(true);
 
-        Assert.assertTrue(provider.checkValid(//
-                "select _t0.`ownUser` as _c0, _t0.`showTime` as _c1, _t0.`showType` as _c2, " + //
-                        "   _t0.`itemId` as _c3, _t0.`queueId` as _c4 " + //
-                        "from `itemshow_queue` as _t0 " + //
-                        "where ( _t0.`isShowed` = 'F' and _t0.`showTime` <= ? ) " + //
-                        "   and _t0.`ownUser` in ( " + //
-                        "       select _t0.`userId` as _c0 from `users_top` as _t0 " + //
-                        "       where ( 1 = 1 ) " + //
-                        "       ) " + //
-                        "order by _t0.`showTime` asc " + //
-                        "limit 1000 offset 8000"));
+        final String sql = "select _t0.`ownUser` as _c0, _t0.`showTime` as _c1, _t0.`showType` as _c2, " + //
+                "   _t0.`itemId` as _c3, _t0.`queueId` as _c4 " + //
+                "from `itemshow_queue` as _t0 " + //
+                "where ( _t0.`isShowed` = 'F' and _t0.`showTime` <= ? ) " + //
+                "   and _t0.`ownUser` in ( " + //
+                "       select _t0.`userId` as _c0 from `users_top` as _t0 " + //
+                "       where ( 1 = 1 ) " + //
+                "       ) " + //
+                "order by _t0.`showTime` asc " + //
+                "limit 1000 offset 8000";
+        provider.getConfig().setSelectWhereAlwayTrueCheck(true);
+        Assert.assertFalse(provider.checkValid(sql));
 
         Assert.assertEquals(2, provider.getTableStats().size());
+
+        provider.getConfig().setSelectWhereAlwayTrueCheck(false);
+        Assert.assertFalse(provider.checkValid(sql));
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest8.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest8.java
@@ -31,21 +31,21 @@ import com.alibaba.druid.wall.WallUtils;
 public class MySqlWallTest8 extends TestCase {
     public void test_true() throws Exception {
         Assert.assertTrue(WallUtils.isValidateMySql(//
-                "SELECT a.* FROM vote_info a where 1=1 AND FID = ?")); // 前置永真
+                "SELECT a.* FROM vote_info a where 1=1 AND FID = ?")); // AND永真不拦截
     }
 
     public void test_false_1() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "SELECT a.* FROM vote_info a where FID = ? AND 1=1")); // 后置永真，拦截
+                "SELECT a.* FROM vote_info a where FID = ? OR 1=1")); // 永真，拦截
     }
 
     public void test_false_2() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "SELECT a.* FROM vote_info a where FID = ? OR (FID = ? AND 1=1)")); // 后置永真，拦截
+                "SELECT a.* FROM vote_info a where FID = ? OR (FID = ? OR 1=1)")); // 永真，拦截
     }
 
     public void test_false_3() throws Exception {
         Assert.assertFalse(WallUtils.isValidateMySql(//
-                "SELECT a.* FROM vote_info a where FID = ? OR (1=1 AND FID = ?)")); // 后置永真，拦截
+                "SELECT a.* FROM vote_info a where FID = ? OR (1=1 or FID = ?)")); // 永真，拦截
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest90.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest90.java
@@ -35,7 +35,8 @@ public class MySqlWallTest90 extends TestCase {
 
         provider.getConfig().setSelectHavingAlwayTrueCheck(true);
 
-        Assert.assertTrue(provider.checkValid(//
+        //FIXME 不知此测试用例的真实意图
+        Assert.assertFalse(provider.checkValid(//
                 "select * from (select t10006_men_xing_jia_ge_fen_lei.bian_hao as \"bian_hao\", " + //
                         "   t10006_men_xing_jia_ge_fen_lei.ming_cheng as \"ming_cheng\" " + //
                         "from t10006_men_xing_jia_ge_fen_lei where 1=1 ) as tables where 1=1 order by tables.bian_hao"));

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest91.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest91.java
@@ -242,19 +242,19 @@ public class MySqlWallTest91 extends TestCase {
         WallProvider provider = initWallProvider();
         {
             String sql = "SELECT * FROM `oammxncom2014`.`ecs_free_bank` where 1 and 1='1'";
-            Assert.assertTrue(provider.checkValid(sql));
+            Assert.assertFalse(provider.checkValid(sql));
         }
         {
             String sql = "SELECT * FROM `oammxncom2014`.`ecs_free_bank` where 1 or 1='1'";
-            Assert.assertTrue(provider.checkValid(sql));
+            Assert.assertFalse(provider.checkValid(sql));
         }
         {
             String sql = "SELECT * FROM `oammxncom2014`.`ecs_free_bank` where true or 1='1'";
-            Assert.assertTrue(provider.checkValid(sql));
+            Assert.assertFalse(provider.checkValid(sql));
         }
         {
             String sql = "SELECT * FROM `oammxncom2014`.`ecs_free_bank` where 'a' or 1='1'";
-            Assert.assertTrue(provider.checkValid(sql));
+            Assert.assertFalse(provider.checkValid(sql));
         }
         {
             String sql = "SELECT * FROM `oammxncom2014`.`ecs_free_bank` where id=1 or 1='1' --";

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest94.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest94.java
@@ -33,10 +33,15 @@ public class MySqlWallTest94 extends TestCase {
     public void test_false() throws Exception {
         WallProvider provider = new MySqlWallProvider();
 
-        Assert.assertTrue(provider.checkValid(//
+        Assert.assertFalse(provider.checkValid(//
                 "select * from test having 1=1"));
 
         Assert.assertEquals(1, provider.getTableStats().size());
+
+        provider.reset();
+        provider.getConfig().setSelectHavingAlwayTrueCheck(false);
+        Assert.assertTrue(provider.checkValid(//
+                "select * from test having 1=1"));
     }
 
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest_having.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest_having.java
@@ -30,7 +30,7 @@ import com.alibaba.druid.wall.WallUtils;
  */
 public class MySqlWallTest_having extends TestCase {
     public void test_having() throws Exception {
-        Assert.assertTrue(WallUtils.isValidateMySql(//
+        Assert.assertFalse(WallUtils.isValidateMySql(//
                 "select id, count(*) from t group by id having 1 = 1"));
     }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest_union.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/mysql/MySqlWallTest_union.java
@@ -27,7 +27,7 @@ public class MySqlWallTest_union extends TestCase {
         WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
 
-        Assert.assertTrue(WallUtils.isValidateMySql("select f1, f2 from t where id=1 union select 1, 2", config)); // not end of comment
+        Assert.assertFalse(WallUtils.isValidateMySql("select f1, f2 from t where id=1 union select 1, 2", config)); // not end of comment
         Assert.assertFalse(WallUtils.isValidateMySql("select f1, f2 from t where id=1 union select 1, 2 --", config));
 
         Assert.assertTrue(WallUtils.isValidateMySql("select f1, f2 from t union select 1, 2", config)); // no where

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/oracle/OracleWallTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/oracle/OracleWallTest.java
@@ -26,8 +26,15 @@ public class OracleWallTest extends TestCase {
     public void testWall() throws Exception {
         WallConfig config = new WallConfig();
         config.setSelectUnionCheck(true);
-        assertTrue(WallUtils.isValidateOracle("select f1, f2 from t where c=1 union select 1, 2", config));
+        config.setCommentAllow(false);
+        assertFalse(WallUtils.isValidateOracle("select f1, f2 from t where c=1 union select 1, 2", config));
         assertFalse(WallUtils.isValidateOracle("select f1, f2 from t where c=1 union select 1, 2 --", config));
+
+        config.setSelectUnionCheck(false);
+        config.setCommentAllow(true);
+        assertTrue(WallUtils.isValidateOracle("select f1, f2 from t where c=1 union select 1, 2", config));
+        assertTrue(WallUtils.isValidateOracle("select f1, f2 from t where c=1 union select 1, 2 --", config));
+
 
         assertFalse(WallUtils.isValidateOracle("SELECT * FROM T UNION select * from TAB"));
         assertFalse(WallUtils.isValidateOracle("SELECT * FROM T UNION select * from ALL_TABLES where (1=1 or (1+1)=2) and (4=8 or 1=1)"));

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/AntlrMySqlTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/AntlrMySqlTest.java
@@ -20,6 +20,8 @@ public class AntlrMySqlTest extends TestCase {
         config.setConditionDoubleConstAllow(true);
         config.setConditionAndAlwayTrueAllow(true);
         config.setSelectIntoOutfileAllow(true);
+        config.setSelectWhereAlwayTrueCheck(false); //FIXME 此处是否要禁用审核h
+        config.setSelectUnionCheck(false); //FIXME 此处是否要禁用审核
         config.setCommentAllow(true);
         config.setHintAllow(true);
         MySqlWallProvider provider = new MySqlWallProvider(config);
@@ -36,7 +38,7 @@ public class AntlrMySqlTest extends TestCase {
                 String stmtSql = stmt.toString();
 
                 stmt.accept(schemaStatVisitor);
-                assertTrue(provider.checkValid(stmtSql));
+                assertTrue(stmtSql, provider.checkValid(stmtSql));
             }
             
             // test different style newline.


### PR DESCRIPTION
包含这三项配置对应功能:deleteWhereAlwayTrue/updateWhereAlwayTrue/selectWhereAlwayTrue 并修正了PGWallVisitor/SQLServerWallVisitor