### PR TITLE
Fix nested table type creation parsing in declaration

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -1985,7 +1985,7 @@ public class OracleStatementParser extends SQLStatementParser {
                     lexer.nextToken();
                     accept(Token.OF);
 
-                    name = this.exprParser.name();
+                    SQLName sqlName = this.exprParser.name();
 
                     if (lexer.token() == Token.PERCENT) {
                         lexer.nextToken();
@@ -1993,16 +1993,16 @@ public class OracleStatementParser extends SQLStatementParser {
                         String typeName;
                         if (lexer.identifierEquals(FnvHash.Constants.ROWTYPE)) {
                             lexer.nextToken();
-                            typeName = "TABLE OF " + name.toString() + "%ROWTYPE";
+                            typeName = "TABLE OF " + sqlName.toString() + "%ROWTYPE";
                         } else {
                             acceptIdentifier("TYPE");
-                            typeName = "TABLE OF " + name.toString() + "%TYPE";
+                            typeName = "TABLE OF " + sqlName.toString() + "%TYPE";
                         }
 
                         dataType = new SQLDataTypeImpl(typeName);
                     } else if (lexer.token() == Token.LPAREN) {
                         lexer.nextToken();
-                        String typeName = name.toString();
+                        String typeName = "TABLE OF " + sqlName.toString();
 
                         SQLIntegerExpr lenExpr = (SQLIntegerExpr) this.exprParser.expr();
                         int len = lenExpr.getNumber().intValue();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/pl/Oracle_pl_for_1.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/pl/Oracle_pl_for_1.java
@@ -80,8 +80,8 @@ public class Oracle_pl_for_1 extends OracleTest {
             System.out.println(output);
             assertEquals("DECLARE\n" +
                             "\tTYPE empcurtyp IS REF CURSOR;\n" +
-                            "\tTYPE employees.last_name IS TABLE OF employees.last_name%TYPE;\n" +
-                            "\tTYPE employees.salary IS TABLE OF employees.salary%TYPE;\n" +
+                            "\tTYPE namelist IS TABLE OF employees.last_name%TYPE;\n" +
+                            "\tTYPE sallist IS TABLE OF employees.salary%TYPE;\n" +
                             "\temp_cv empcurtyp;\n" +
                             "\tnames namelist;\n" +
                             "\tsals sallist;\n" +
@@ -104,8 +104,8 @@ public class Oracle_pl_for_1 extends OracleTest {
             String output = SQLUtils.toOracleString(stmt, SQLUtils.DEFAULT_LCASE_FORMAT_OPTION);
             assertEquals("declare\n" +
                             "\ttype empcurtyp is REF CURSOR;\n" +
-                            "\ttype employees.last_name is TABLE OF employees.last_name%TYPE;\n" +
-                            "\ttype employees.salary is TABLE OF employees.salary%TYPE;\n" +
+                            "\ttype namelist is TABLE OF employees.last_name%TYPE;\n" +
+                            "\ttype sallist is TABLE OF employees.salary%TYPE;\n" +
                             "\temp_cv empcurtyp;\n" +
                             "\tnames namelist;\n" +
                             "\tsals sallist;\n" +

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -21,7 +21,6 @@ public class OracleParameterParserTest {
 			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
 			"	END LOOP;\n" +
 			"END;\n";
-
 		String expectedSql = "[DECLARE\n" +
 			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
 			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -1,0 +1,43 @@
+package com.alibaba.druid.sql.dialect.oracle.parser;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class OracleParameterParserTest {
+	@Test
+	public void testTableOfParameter() {
+		String sql = """
+					DECLARE
+						TYPE Foursome IS TABLE OF VARCHAR2(15);
+						team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');
+					BEGIN
+						DBMS_OUTPUT.PUT_LINE('2001 Team:');
+						FOR i IN 1..4
+						LOOP
+							DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));
+					  	END LOOP;
+					END;
+				""";
+		String expectedSql = """
+					[DECLARE
+						TYPE Foursome IS TABLE OF VARCHAR2(15);
+						team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');
+					BEGIN
+						DBMS_OUTPUT.PUT_LINE('2001 Team:');
+						FOR i IN 1..4
+						LOOP
+							DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));
+						END LOOP;
+					END;]\
+					""";
+		List<SQLStatement> stat = SQLUtils.parseStatements(sql, DbType.oracle);
+		System.out.println(stat.toString());
+		Assert.assertEquals(expectedSql, stat.toString());
+		System.out.println("=============");
+	}
+}

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -6,8 +6,6 @@ import com.alibaba.druid.sql.ast.SQLStatement;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.List;
-
 public class OracleParameterParserTest {
 	@Test
 	public void testTableOfParameter() {
@@ -21,7 +19,7 @@ public class OracleParameterParserTest {
 			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
 			"	END LOOP;\n" +
 			"END;\n";
-		String expectedSql = "[DECLARE\n" +
+		String expectedSql = "DECLARE\n" +
 			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
 			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +
 			"BEGIN\n" +
@@ -30,8 +28,8 @@ public class OracleParameterParserTest {
 			"	LOOP\n" +
 			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
 			"	END LOOP;\n" +
-			"END;]";
-		List<SQLStatement> stat = SQLUtils.parseStatements(sql, DbType.oracle);
+			"END;";
+		SQLStatement stat = SQLUtils.parseSingleStatement(sql, DbType.oracle, false);
 		System.out.println(stat);
 		Assert.assertEquals(expectedSql, stat.toString());
 		System.out.println("=============");

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -8,18 +8,8 @@ import org.junit.Test;
 
 public class OracleParameterParserTest {
 	@Test
-	public void testTableOfParameter() {
+	public void testNestedParameter() {
 		String sql = "DECLARE\n" +
-			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
-			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +
-			"BEGIN\n" +
-			"	DBMS_OUTPUT.PUT_LINE('2001 Team:');\n" +
-			"	FOR i IN 1..4\n" +
-			"	LOOP\n" +
-			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
-			"	END LOOP;\n" +
-			"END;\n";
-		String expectedSql = "DECLARE\n" +
 			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
 			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +
 			"BEGIN\n" +
@@ -31,7 +21,7 @@ public class OracleParameterParserTest {
 			"END;";
 		SQLStatement stat = SQLUtils.parseSingleStatement(sql, DbType.oracle, false);
 		System.out.println(stat);
-		Assert.assertEquals(expectedSql, stat.toString());
+		Assert.assertEquals(sql, stat.toString());
 		System.out.println("=============");
 	}
 }

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -11,32 +11,29 @@ import java.util.List;
 public class OracleParameterParserTest {
 	@Test
 	public void testTableOfParameter() {
-		String sql = """
-					DECLARE
-						TYPE Foursome IS TABLE OF VARCHAR2(15);
-						team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');
-					BEGIN
-						DBMS_OUTPUT.PUT_LINE('2001 Team:');
-						FOR i IN 1..4
-						LOOP
-							DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));
-					  	END LOOP;
-					END;
-				""";
-		String expectedSql = """
-					[DECLARE
-						TYPE Foursome IS TABLE OF VARCHAR2(15);
-						team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');
-					BEGIN
-						DBMS_OUTPUT.PUT_LINE('2001 Team:');
-						FOR i IN 1..4
-						LOOP
-							DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));
-						END LOOP;
-					END;]\
-					""";
+		String sql = "DECLARE\n" +
+			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
+			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +
+			"BEGIN\n" +
+			"	DBMS_OUTPUT.PUT_LINE('2001 Team:');\n" +
+			"	FOR i IN 1..4\n" +
+			"	LOOP\n" +
+			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
+			"	END LOOP;\n" +
+			"END;\n";
+
+		String expectedSql = "[DECLARE\n" +
+			"	TYPE Foursome IS TABLE OF VARCHAR2(15);\n" +
+			"	team Foursome := Foursome('John', 'Mary', 'Alberto', 'Juanita');\n" +
+			"BEGIN\n" +
+			"	DBMS_OUTPUT.PUT_LINE('2001 Team:');\n" +
+			"	FOR i IN 1..4\n" +
+			"	LOOP\n" +
+			"		DBMS_OUTPUT.PUT_LINE(i || '.' || team(i));\n" +
+			"	END LOOP;\n" +
+			"END;]";
 		List<SQLStatement> stat = SQLUtils.parseStatements(sql, DbType.oracle);
-		System.out.println(stat.toString());
+		System.out.println(stat);
 		Assert.assertEquals(expectedSql, stat.toString());
 		System.out.println("=============");
 	}

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParserUnpivotTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParserUnpivotTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.druid.sql.dialect.oracle.parser;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.AfterClass;

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParserUnpivotTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParserUnpivotTest.java
@@ -1,7 +1,6 @@
 package com.alibaba.druid.sql.dialect.oracle.parser;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.AfterClass;


### PR DESCRIPTION
```sql
DECLARE
	TYPE Foursome IS TABLE OF VARCHAR2(15);
BEGIN
       ...
END;
```

Is translated to

```sql
DECLARE
	VARCHAR2 VARCHAR2(15);
BEGIN
        ...
END;
```

The reason is part of because the `name` variable is reassigned