### PR TITLE
Fix Oracle SELECT FOR UPDATE of output and PG SET issue

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSetStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSetStatement.java
@@ -35,6 +35,8 @@ public class SQLSetStatement extends SQLStatementImpl {
 
     private List<SQLCommentHint> hints;
 
+    private boolean useSet;
+
     public SQLSetStatement() {
     }
 
@@ -80,6 +82,14 @@ public class SQLSetStatement extends SQLStatementImpl {
 
     public void setOption(Option option) {
         this.option = option;
+    }
+
+    public boolean isUseSet() {
+        return useSet;
+    }
+
+    public void setUseSet(boolean useSet) {
+        this.useSet = useSet;
     }
 
     public void set(SQLExpr target, SQLExpr value) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -350,6 +350,7 @@ public class OracleStatementParser extends SQLStatementParser {
                     if (binaryOpExpr.getOperator() == SQLBinaryOperator.Assignment) {
                         SQLSetStatement stmt = new SQLSetStatement();
                         stmt.setDbType(DbType.oracle);
+                        stmt.setUseSet(true); // now only effective for PG
                         stmt.setParent(parent);
 
                         SQLAssignItem assignItem = new SQLAssignItem(binaryOpExpr.getLeft(), binaryOpExpr.getRight());
@@ -1253,6 +1254,7 @@ public class OracleStatementParser extends SQLStatementParser {
         }
 
         SQLSetStatement stmt = new SQLSetStatement(dbType);
+        stmt.setUseSet(true);
         parseAssignItems(stmt.getItems(), stmt);
 
         stmt.putAttribute("parser.set", Boolean.TRUE);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -350,7 +350,6 @@ public class OracleStatementParser extends SQLStatementParser {
                     if (binaryOpExpr.getOperator() == SQLBinaryOperator.Assignment) {
                         SQLSetStatement stmt = new SQLSetStatement();
                         stmt.setDbType(DbType.oracle);
-                        stmt.setUseSet(true); // now only effective for PG
                         stmt.setParent(parent);
 
                         SQLAssignItem assignItem = new SQLAssignItem(binaryOpExpr.getLeft(), binaryOpExpr.getRight());

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -403,9 +403,8 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
             println();
             print0(ucase ? "FOR UPDATE" : "for update");
             if (x.getForUpdateOfSize() > 0) {
-                print('(');
+                print(" OF ");
                 printAndAccept(x.getForUpdateOf(), ", ");
-                print(')');
             }
 
             if (x.isNoWait()) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -702,6 +702,7 @@ public class PGSQLStatementParser extends SQLStatementParser {
             valueExpr = listExpr;
         }
         SQLSetStatement stmt = new SQLSetStatement(paramExpr, valueExpr, dbType);
+        stmt.setUseSet(true);
         stmt.setOption(option);
         return stmt;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -628,7 +628,9 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
     @Override
     public boolean visit(SQLSetStatement x) {
-        print0(ucase ? "SET " : "set ");
+        if (x.isUseSet()) {
+            print0(ucase ? "SET " : "set ");
+        }
 
         SQLSetStatement.Option option = x.getOption();
         if (option != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -645,13 +645,20 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
     @Override
     public boolean visit(SQLAssignItem x) {
+        if (!(x.getParent() instanceof SQLSetStatement)) {
+            return super.visit(x);
+        }
+
         x.getTarget().accept(this);
         SQLExpr value = x.getValue();
         if (x.getTarget() instanceof SQLIdentifierExpr
             && ((SQLIdentifierExpr) x.getTarget()).getName().equalsIgnoreCase("TIME ZONE")) {
             print(' ');
         } else {
-            if (x.getParent() instanceof SQLSetStatement && !((SQLSetStatement) x.getParent()).isUseSet()) {
+            if (!((SQLSetStatement) x.getParent()).isUseSet()) {
+                print0(" := ");
+            } else if (value instanceof SQLPropertyExpr
+                && ((SQLPropertyExpr) value).getOwner() instanceof SQLVariantRefExpr) {
                 print0(" := ");
             } else {
                 print0(" TO ");
@@ -664,6 +671,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
         } else {
             value.accept(this);
         }
+
         return false;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -636,38 +636,33 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             print(' ');
         }
 
-        List<SQLAssignItem> items = x.getItems();
-        for (int i = 0; i < items.size(); i++) {
-            if (i != 0) {
-                print0(", ");
-            }
+        printAndAccept(x.getItems(), ", ");
 
-            SQLAssignItem item = x.getItems().get(i);
-            SQLExpr target = item.getTarget();
-            target.accept(this);
+        return false;
+    }
 
-            SQLExpr value = item.getValue();
-
-            if (target instanceof SQLIdentifierExpr
-                    && ((SQLIdentifierExpr) target).getName().equalsIgnoreCase("TIME ZONE")) {
-                print(' ');
+    @Override
+    public boolean visit(SQLAssignItem x) {
+        x.getTarget().accept(this);
+        SQLExpr value = x.getValue();
+        if (x.getTarget() instanceof SQLIdentifierExpr
+            && ((SQLIdentifierExpr) x.getTarget()).getName().equalsIgnoreCase("TIME ZONE")) {
+            print(' ');
+        } else {
+            if (value instanceof SQLPropertyExpr
+                && ((SQLPropertyExpr) value).getOwner() instanceof SQLVariantRefExpr) {
+                print0(" := ");
             } else {
-                if (value instanceof SQLPropertyExpr
-                        && ((SQLPropertyExpr) value).getOwner() instanceof SQLVariantRefExpr) {
-                    print0(" := ");
-                } else {
-                    print0(" TO ");
-                }
-            }
-
-            if (value instanceof SQLListExpr) {
-                SQLListExpr listExpr = (SQLListExpr) value;
-                printAndAccept(listExpr.getItems(), ", ");
-            } else {
-                value.accept(this);
+                print0(" TO ");
             }
         }
 
+        if (value instanceof SQLListExpr) {
+            SQLListExpr listExpr = (SQLListExpr) value;
+            printAndAccept(listExpr.getItems(), ", ");
+        } else {
+            value.accept(this);
+        }
         return false;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -1342,9 +1342,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
         println();
         print0(ucase ? "FROM " : "from ");
-        if (x.getFrom() == null) {
-            print0(ucase ? "DUAL" : "dual");
-        } else {
+        if (x.getFrom() != null) {
             x.getFrom().accept(this);
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -651,8 +651,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             && ((SQLIdentifierExpr) x.getTarget()).getName().equalsIgnoreCase("TIME ZONE")) {
             print(' ');
         } else {
-            if (value instanceof SQLPropertyExpr
-                && ((SQLPropertyExpr) value).getOwner() instanceof SQLVariantRefExpr) {
+            if (x.getParent() instanceof SQLSetStatement && !((SQLSetStatement) x.getParent()).isUseSet()) {
                 print0(" := ");
             } else {
                 print0(" TO ");

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -1378,9 +1378,8 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             println();
             print0(ucase ? "FOR UPDATE" : "for update");
             if (x.getForUpdateOfSize() > 0) {
-                print('(');
+                print(" OF ");
                 printAndAccept(x.getForUpdateOf(), ", ");
-                print(')');
             }
 
             if (x.isNoWait()) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateTriggerTest6.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateTriggerTest6.java
@@ -120,8 +120,8 @@ public class OracleCreateTriggerTest6 extends OracleTest {
                         "\tvar_nRecordCount number;\n" +
                         "\tvar_sState varchar2(16);\n" +
                         "BEGIN\n" +
-                        "\tSET var_sState := :NEW.State;\n" +
-                        "\tSET var_dFirstCheckTime := :NEW.Commiteddate;\n" +
+                        "\tvar_sState := :NEW.State;\n" +
+                        "\tvar_dFirstCheckTime := :NEW.Commiteddate;\n" +
                         "\tIF var_sState = 'approved' THEN\n" +
                         "\t\t-- 鏌ヨ\uE1D7鍚堝悓 ID\n" +
                         "\t\tSELECT etfca_.contractid\n" +

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateViewTest13.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateViewTest13.java
@@ -36,7 +36,7 @@ public class OracleCreateViewTest13 extends OracleTest {
                         "WHERE rbi.rma_id > ?\n" +
                         "\tAND rsi.e_rprsendid = ?\n" +
                         "\tAND rsi.e_boardid IN (?)\n" +
-                        "FOR UPDATE(rbi.rma_id)\n";
+                        "FOR UPDATE OF rbi.rma_id\n";
 
         System.out.println(sql);
 
@@ -55,7 +55,7 @@ public class OracleCreateViewTest13 extends OracleTest {
                         "WHERE rbi.rma_id > ?\n" +
                         "\tAND rsi.e_rprsendid = ?\n" +
                         "\tAND rsi.e_boardid IN (?)\n" +
-                        "FOR UPDATE(rbi.rma_id)",//
+                        "FOR UPDATE OF rbi.rma_id",//
                 SQLUtils.toSQLString(stmt, JdbcConstants.ORACLE));
 
         OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectForUpdateTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectForUpdateTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2017 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.oracle.select;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.OracleTest;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleSysdateExpr;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleSchemaStatVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
+import com.alibaba.druid.stat.TableStat;
+import com.alibaba.druid.util.JdbcConstants;
+import org.junit.Assert;
+
+import java.util.List;
+
+public class OracleSelectForUpdateTest extends OracleTest {
+
+    public void test_0() throws Exception {
+        String sql = "SELECT salary\n" +
+                     "FROM employees\n" +
+                     "WHERE id = :employee_id\n" +
+                     "FOR UPDATE OF salary;";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statement = statementList.get(0);
+//        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+        assertEquals("SELECT salary\n" +
+                    "FROM employees\n" +
+                    "WHERE id = :employee_id\n" +
+                    "FOR UPDATE OF salary;", output(statementList));
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        statement.accept(visitor);
+
+//        System.out.println("Tables : " + visitor.getTables());
+//        System.out.println("fields : " + visitor.getColumns());
+//        System.out.println("conditions : " + visitor.getConditions());
+//        System.out.println("relationships : " + visitor.getRelationships());
+
+
+        Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("employees")));
+        Assert.assertEquals(2, visitor.getColumns().size());
+    }
+}


### PR DESCRIPTION
Changes:
- PG: If there is no "FROM" clause, avoid adding `DUAL` table as PG does not have it
- Fix Oracle, PG `SELECT FOR UPDATE OF` output:
  Should be `SELECT ... FOR UPDATE OF col1, col2;` instead of  `SELECT ... FOR UPDATE OF(col1, col2);`
  - Update some test cases using `FOR UPDATE OF(col...)`
- Restructure `visit(SQLSetStatement x)` for PG
- For `SQLSetStatement` output in PG, use `SET` only if the original query is using `SET`, related to issue #5663. It avoid s making P/SQL declaration to become SET. For example, `DECLARE a := 1 ...` to `DECLARE SET a := 1`.
  - Fix some test cases