### PR TITLE
Update Oracle and PostgreSQL output visitors for SQLIfStatement.ElseIf

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1487,7 +1487,7 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
 
     @Override
     public boolean visit(SQLIfStatement.ElseIf x) {
-        print0(ucase ? "ELSE IF " : "else if ");
+        print0(ucase ? "ELSIF " : "elsif ");
         x.getCondition().accept(this);
         print0(ucase ? " THEN" : " then");
         this.indentCount++;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -2349,7 +2349,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
     @Override
     public boolean visit(SQLIfStatement.ElseIf x) {
-        print0(ucase ? "ELSE IF " : "else if ");
+        print0(ucase ? "ELSIF " : "elsif ");
         x.getCondition().accept(this);
         print0(ucase ? " THEN" : " then");
         this.indentCount++;

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateFunctionTest_4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateFunctionTest_4.java
@@ -82,7 +82,7 @@ public class OracleCreateFunctionTest_4 extends OracleTest {
                         "BEGIN\n" +
                         "\tIF I = 0 THEN\n" +
                         "\t\tT_STR := STR;\n" +
-                        "\tELSE IF INSTR(STR, SEP) = 0 THEN\n" +
+                        "\tELSIF INSTR(STR, SEP) = 0 THEN\n" +
                         "\t\tT_STR := SEP;\n" +
                         "\tELSE\n" +
                         "\t\tSELECT COUNT(*)\n" +

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateTypeTest10.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateTypeTest10.java
@@ -98,7 +98,7 @@ public class OracleCreateTypeTest10 extends OracleTest {
                         "\tBEGIN\n" +
                         "\t\tIF ctx2.currentstr IS NULL THEN\n" +
                         "\t\t\tself.currentstr := self.currentstr;\n" +
-                        "\t\tELSE IF self.currentstr IS NULL THEN\n" +
+                        "\t\tELSIF self.currentstr IS NULL THEN\n" +
                         "\t\t\tself.currentstr := ctx2.currentstr;\n" +
                         "\t\tELSE\n" +
                         "\t\t\tself.currentstr := self.currentstr || currentseprator || ctx2.currentstr;\n" +

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/pl/Oracle_pl_if_3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/pl/Oracle_pl_if_3.java
@@ -66,7 +66,7 @@ public class Oracle_pl_if_3 extends OracleTest {
             String output = SQLUtils.toOracleString(stmt);
             assertEquals("IF l_salary BETWEEN 10000 AND 20000 THEN\n" +
                             "\tgive_bonus(l_employee_id, 1000);\n" +
-                            "ELSE IF l_salary > 20000 THEN\n" +
+                            "ELSIF l_salary > 20000 THEN\n" +
                             "\tgive_bonus(l_employee_id, 500);\n" +
                             "ELSE\n" +
                             "\tgive_bonus(l_employee_id, 0);\n" +
@@ -77,7 +77,7 @@ public class Oracle_pl_if_3 extends OracleTest {
             String output = SQLUtils.toOracleString(stmt, SQLUtils.DEFAULT_LCASE_FORMAT_OPTION);
             assertEquals("if l_salary between 10000 and 20000 then\n" +
                             "\tgive_bonus(l_employee_id, 1000);\n" +
-                            "else if l_salary > 20000 then\n" +
+                            "elsif l_salary > 20000 then\n" +
                             "\tgive_bonus(l_employee_id, 500);\n" +
                             "else\n" +
                             "\tgive_bonus(l_employee_id, 0);\n" +


### PR DESCRIPTION
The "ELSE IF" output for Oracle and PG should be `ELSIF` instead of `ELSE IF`. 

Changes:
- Updated the Oracle and PG visitor for `SQLIfStatement.ElseIf`
- Fix Oracle test(did not add PG test as PL/SQL parsing is not available yet...)

Reference:
- Oracle: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnpls/IF-statement.html#GUID-B7D65A8E-B0C3-448F-B79C-6C330190A266
- PG: https://www.postgresql.org/docs/7.2/plpgsql-control-structures.html