### PR TITLE
Update PostgreSQL cursor output in PL declaration

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -2009,9 +2009,9 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
     public boolean visit(SQLParameter x) {
         SQLName name = x.getName();
         if (x.getDataType().getName().equalsIgnoreCase("CURSOR")) {
-            print0(ucase ? "CURSOR " : "cursor ");
             x.getName().accept(this);
-            print0(ucase ? " IS" : " is");
+            print0(ucase ? "CURSOR " : "cursor ");
+            print0(ucase ? " FOR" : " for");
             this.indentCount++;
             println();
             SQLSelect select = ((SQLQueryExpr) x.getDefaultValue()).getSubQuery();


### PR DESCRIPTION
Changes:
- PG puts `CURSOR` keyword after cursor name which is the opposite in Oracle
- PG use `FOR query` instead of `IS query` as In Oracle

No tests added as Druid cannot parse PG plpglsql yet