### PR TITLE
去除timeout默认值为10秒的逻辑 #5729

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -825,14 +825,6 @@ public class DruidDataSource extends DruidAbstractDataSource
                 this.transactionIdSeedUpdater.addAndGet(this, delta);
             }
 
-            if (connectTimeout == 0) {
-                connectTimeout = DEFAULT_TIME_CONNECT_TIMEOUT_MILLIS;
-            }
-
-            if (socketTimeout == 0) {
-                socketTimeout = DEFAULT_TIME_SOCKET_TIMEOUT_MILLIS;
-            }
-
             if (this.jdbcUrl != null) {
                 this.jdbcUrl = this.jdbcUrl.trim();
                 initFromWrapDriverUrl();

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest10.java
@@ -49,6 +49,14 @@ public class DruidDataSourceTest10 {
         assertEquals(0, ds.getConnectTimeout());
         assertEquals(0, ds.getSocketTimeout());
     }
+
+    @Test
+    public void test_timeout_is_zero_default() throws Exception {
+        ds.setUrl("jdbc:mysql://127.0.0.1:3306/xxx");
+        ds.init();
+        assertEquals(0, ds.getConnectTimeout());
+        assertEquals(0, ds.getSocketTimeout());
+    }
     @Test
     public void test_timeout_is_zero2() throws Exception {
         ds.setUrl("jdbc:mysql://127.0.0.1:3306/xxx");
@@ -61,17 +69,24 @@ public class DruidDataSourceTest10 {
 
     /**
      * @throws Exception
-     * @see https://github.com/alibaba/druid/issues/5396
+     * @see <a href="https://github.com/alibaba/druid/issues/5396">...</a>
      */
     @Test
     public void test_timeout_in_loadbalance() throws Exception {
+        ds.setUrl(
+            "jdbc:mysql:loadbalance://localhost:3306,localhost:3310/test?connectTimeout=98&socketTimeout=99&loadBalanceConnectionGroup=first&ha.enableJMX=true");
+        ds.init();
+        assertEquals(98, ds.getConnectTimeout());
+        assertEquals(99, ds.getSocketTimeout());
+    }
+    @Test
+    public void test_timeout_is_zero_in_loadbalance() throws Exception {
         ds.setUrl(
             "jdbc:mysql:loadbalance://localhost:3306,localhost:3310/test?connectTimeout=0&socketTimeout=0&loadBalanceConnectionGroup=first&ha.enableJMX=true");
         ds.init();
         assertEquals(0, ds.getConnectTimeout());
         assertEquals(0, ds.getSocketTimeout());
     }
-
     @Test
     public void test_timeout_in_replication() throws Exception {
         ds.setUrl(


### PR DESCRIPTION
之前版本只能通过给datasoure配置属性来自定义超时实际，否则会走到默认值10秒逻辑，最新代码虽然也不区分jdbc类型，统一解析url和properties的设置了，但是为了存量项目无需修改任何配置就能平滑升级组件，因此还是去掉这个默认10秒的逻辑