### PR TITLE
修复SQLExprTableSource未clone hints的bug #5763

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExprTableSource.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExprTableSource.java
@@ -294,6 +294,12 @@ public class SQLExprTableSource extends SQLTableSourceImpl implements SQLReplace
             x.setExpr(expr.clone());
         }
 
+        if (hints != null) {
+            for (SQLHint p : hints) {
+                SQLHint p1 = p.clone();
+                x.getHints().add(p1);
+            }
+        }
         if (partitions != null) {
             for (SQLName p : partitions) {
                 SQLName p1 = p.clone();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/MySqlIndexHintImpl.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/MySqlIndexHintImpl.java
@@ -20,6 +20,7 @@ import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class MySqlIndexHintImpl extends MySqlObjectImpl implements MySqlIndexHint {
     private Option option;
@@ -54,5 +55,22 @@ public abstract class MySqlIndexHintImpl extends MySqlObjectImpl implements MySq
             name2.setParent(x);
             x.indexList.add(name2);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MySqlIndexHintImpl)) {
+            return false;
+        }
+        MySqlIndexHintImpl that = (MySqlIndexHintImpl) o;
+        return getOption() == that.getOption() && Objects.equals(getIndexList(), that.getIndexList());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getOption(), getIndexList());
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/bug/Issue5763.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/bug/Issue5763.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.bug;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.util.JdbcConstants;
+
+import junit.framework.TestCase;
+
+/**
+ * @Author lizongbo
+ * @see <a href="https://github.com/alibaba/druid/issues/5763">...</a>
+ */
+public class Issue5763 extends TestCase {
+
+    public void test_for_clone() throws Exception {
+        String sql = "select user.col from user use index(a)";
+        SQLStatement origin = SQLUtils.parseSingleMysqlStatement(sql);
+        System.out.println("origin = " + origin);
+
+        SQLStatement clone = origin.clone();
+        System.out.println("clone = " + clone);
+        assertEquals(origin.toString(), clone.toString());
+        assertEquals(origin, clone);
+    }
+}


### PR DESCRIPTION
修复SQLExprTableSource未clone hints的bug，顺便修复equals相关实现的问题