### PR TITLE
在ConfigTools中添加1.2.22版本之前存在的main方法，用于做数据库密码加密。

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -36,6 +36,14 @@ public class ConfigTools {
     private static final String DEFAULT_PRIVATE_KEY_STRING = "MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAocbCrurZGbC5GArEHKlAfDSZi7gFBnd4yxOt0rwTqKBFzGyhtQLu5PRKjEiOXVa95aeIIBJ6OhC2f8FjqFUpawIDAQABAkAPejKaBYHrwUqUEEOe8lpnB6lBAsQIUFnQI/vXU4MV+MhIzW0BLVZCiarIQqUXeOhThVWXKFt8GxCykrrUsQ6BAiEA4vMVxEHBovz1di3aozzFvSMdsjTcYRRo82hS5Ru2/OECIQC2fAPoXixVTVY7bNMeuxCP4954ZkXp7fEPDINCjcQDywIgcc8XLkkPcs3Jxk7uYofaXaPbg39wuJpEmzPIxi3k0OECIGubmdpOnin3HuCP/bbjbJLNNoUdGiEmFL5hDI4UdwAdAiEAtcAwbm08bKN7pwwvyqaCBC//VnEWaq39DCzxr+Z2EIk=";
     public static final String DEFAULT_PUBLIC_KEY_STRING = "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKHGwq7q2RmwuRgKxBypQHw0mYu4BQZ3eMsTrdK8E6igRcxsobUC7uT0SoxIjl1WveWniCASejoQtn/BY6hVKWsCAwEAAQ==";
 
+    public static void main(String[] args) throws Exception {
+        String password = args[0];
+        String[] arr = genKeyPair(512);
+        System.out.println("privateKey:" + arr[0]);
+        System.out.println("publicKey:" + arr[1]);
+        System.out.println("password:" + encrypt(arr[0], password));
+    }
+
     public static String decrypt(String cipherText) throws Exception {
         return decrypt((String) null, cipherText);
     }


### PR DESCRIPTION
在ConfigTools中添加1.2.22版本之前存在的main方法，用于做数据库密码加密。1.2.22版本不存在该方法，导致无法快捷方便的做数据库密码加密。