### PR TITLE
fix: data source definition overriding

### DIFF
--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidFilterConfiguratio
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidSpringAopConfiguration;
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidStatViewServletConfiguration;
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidWebStatFilterConfiguration;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -59,7 +60,7 @@ public class DruidDataSourceAutoConfigure {
      * @return druid data source wrapper
      */
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean({DruidDataSourceWrapper.class, DruidDataSource.class, DataSource.class})
     public DruidDataSourceWrapper dataSource() {
         LOGGER.info("Init DruidDataSource");
         return new DruidDataSourceWrapper();

--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -21,7 +21,6 @@ import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidFilterConfiguratio
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidSpringAopConfiguration;
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidStatViewServletConfiguration;
 import com.alibaba.druid.spring.boot3.autoconfigure.stat.DruidWebStatFilterConfiguration;
-import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -34,6 +33,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
 
 /**
  * @author lihengming [89921218@qq.com]
@@ -60,7 +61,9 @@ public class DruidDataSourceAutoConfigure {
      * @return druid data source wrapper
      */
     @Bean
-    @ConditionalOnMissingBean({DruidDataSourceWrapper.class, DruidDataSource.class, DataSource.class})
+    @ConditionalOnMissingBean({DruidDataSourceWrapper.class,
+        DruidDataSource.class,
+        DataSource.class})
     public DruidDataSourceWrapper dataSource() {
         LOGGER.info("Init DruidDataSource");
         return new DruidDataSourceWrapper();

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -21,7 +21,6 @@ import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidFilterConfiguration
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidSpringAopConfiguration;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidStatViewServletConfiguration;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidWebStatFilterConfiguration;
-import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -34,6 +33,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
 
 /**
  * @author lihengming [89921218@qq.com]

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidFilterConfiguration
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidSpringAopConfiguration;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidStatViewServletConfiguration;
 import com.alibaba.druid.spring.boot.autoconfigure.stat.DruidWebStatFilterConfiguration;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -59,7 +60,7 @@ public class DruidDataSourceAutoConfigure {
      * @return druid data source wrapper
      */
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean({DruidDataSourceWrapper.class, DruidDataSource.class, DataSource.class})
     public DruidDataSourceWrapper dataSource() {
         LOGGER.info("Init DruidDataSource");
         return new DruidDataSourceWrapper();

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/DruidDataSourceAutoConfigure.java
@@ -60,7 +60,9 @@ public class DruidDataSourceAutoConfigure {
      * @return druid data source wrapper
      */
     @Bean
-    @ConditionalOnMissingBean({DruidDataSourceWrapper.class, DruidDataSource.class, DataSource.class})
+    @ConditionalOnMissingBean({DruidDataSourceWrapper.class,
+        DruidDataSource.class,
+        DataSource.class})
     public DruidDataSourceWrapper dataSource() {
         LOGGER.info("Init DruidDataSource");
         return new DruidDataSourceWrapper();


### PR DESCRIPTION
修复由 #5671 导致无法设置其他默认数据源：
1. 在多数据源或动态数据源下，无法设置其他数据源为默认dataSource

如下：
```
The bean 'dataSource', defined in class path resource [com/alibaba/druid/spring/boot3/autoconfigure/DruidDataSourceAutoConfigure.class], could not be registered. A bean with that name has already been defined in class path resource [....class] and overriding is disabled.
Action:

Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true

```
如果开启spring.main.allow-bean-definition-overriding=true，会导致dataSource被DruidDataSourceAutoConfigure覆盖出现问题。