### PR TITLE
fix: lateral view alias解析错误

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -27,7 +27,6 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 import com.alibaba.druid.util.FnvHash;
 import com.alibaba.druid.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class SQLSelectParser extends SQLParser {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -27,6 +27,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 import com.alibaba.druid.util.FnvHash;
 import com.alibaba.druid.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SQLSelectParser extends SQLParser {
@@ -2017,16 +2018,9 @@ public class SQLSelectParser extends SQLParser {
         SQLMethodInvokeExpr udtf = (SQLMethodInvokeExpr) this.exprParser.primary();
         lateralViewTabSrc.setMethod(udtf);
 
-        String alias;
-        if (lexer.token == Token.AS) {
-            lexer.nextToken();
-            if (lexer.token == Token.AS) {
-                lexer.nextToken();
-            }
-
+        String alias = null;
+        if (lexer.token != Token.AS) {
             alias = alias();
-        } else {
-            alias = as();
         }
         if (alias != null) {
             lateralViewTabSrc.setAlias(alias);

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -9124,8 +9124,10 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         }
 
         x.getMethod().accept(this);
-        print(' ');
-        print0(x.getAlias());
+        if (x.getAlias() != null) {
+            print(' ');
+            print0(x.getAlias());
+        }
 
         if (x.getColumns() != null && x.getColumns().size() > 0) {
             print0(ucase ? " AS " : " as ");

--- a/core/src/test/java/com/alibaba/druid/sql/parser/LateralViewTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/LateralViewTest.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.sql.parser;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class LateralViewTest extends TestCase {
+
+    private final static SQLParserFeature[] FORMAT_DEFAULT_FEATURES = {
+            SQLParserFeature.KeepComments,
+            SQLParserFeature.EnableSQLBinaryOpExprGroup
+    };
+
+    public String format(String sql) {
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, "hive", FORMAT_DEFAULT_FEATURES);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        return statementList.get(0).toString();
+    }
+
+    public void test1() {
+        String sql = "SELECT DISTINCT t3 FROM d1.t1 t2 LATERAL VIEW explode( split(c1,',')) l1 AS t3";
+        String formatted = "SELECT DISTINCT t3\n" +
+                "FROM d1.t1 t2\n" +
+                "\tLATERAL VIEW explode(split(c1, ',')) l1 AS t3";
+        assertEquals(format(sql), formatted);
+    }
+
+    public void test2() {
+        String sql = "SELECT DISTINCT t3 FROM d1.t1 t2 LATERAL VIEW explode( split(c1,',')) AS t3";
+        String formatted = "SELECT DISTINCT t3\n" +
+                "FROM d1.t1 t2\n" +
+                "\tLATERAL VIEW explode(split(c1, ',')) AS t3";
+        assertEquals(format(sql), formatted);
+    }
+}


### PR DESCRIPTION

`LATERAL VIEW ... AS a`parse成SQLStatement，再toString后变成`LATERAL VIEW ... a`， 丢失了`AS`。

Spark中，`LATERAL VIEW`的语法如下：
```
LATERAL VIEW [ OUTER ] generator_function ( expression [ , ... ] ) [ table_alias ] AS column_alias [ , ... ]
```

Druid大概是把`column_alias`解析成了`table_alias`。