### PR TITLE
Respect MERGE statement update/insert clause visit order

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLMergeStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLMergeStatement.java
@@ -38,8 +38,13 @@ public class SQLMergeStatement extends SQLStatementImpl {
             acceptChild(visitor, into);
             acceptChild(visitor, using);
             acceptChild(visitor, on);
-            acceptChild(visitor, updateClause);
-            acceptChild(visitor, insertClause);
+            if (insertClauseFirst) {
+                acceptChild(visitor, insertClause);
+                acceptChild(visitor, updateClause);
+            } else {
+                acceptChild(visitor, updateClause);
+                acceptChild(visitor, insertClause);
+            }
             acceptChild(visitor, errorLoggingClause);
         }
         visitor.endVisit(this);


### PR DESCRIPTION
使MERGE statement traverse的顺序跟本来的SQL也保持一致