### PR TITLE
适配南大通用GBase 8s数据库

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1306,6 +1306,7 @@ public class DruidDataSource extends DruidAbstractDataSource
                 || JdbcUtils.MYSQL_DRIVER_6.equals(this.driverClass)
                 || JdbcUtils.MYSQL_DRIVER_603.equals(this.driverClass)
                 || JdbcUtils.GOLDENDB_DRIVER.equals(this.driverClass)
+                || JdbcUtils.GBASE8S_DRIVER.equals(this.driverClass)
         ) {
             isMySql = true;
         }

--- a/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -160,4 +160,6 @@ public interface JdbcConstants {
     String TAOS_DATA_RS = "com.taosdata.jdbc.rs.RestfulDriver";
 
     String GOLDENDB_DRIVER = "com.goldendb.jdbc.Driver";
+
+    String GBASE8S_DRIVER = "com.gbasedbt.jdbc.Driver";
 }

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -539,6 +539,8 @@ public final class JdbcUtils implements JdbcConstants {
             return JdbcConstants.TAOS_DATA;
         } else if (rawUrl.startsWith("jdbc:TAOS-RS:")) {
             return JdbcConstants.TAOS_DATA_RS;
+        } else if (rawUrl.startsWith("jdbc:gbasedbt-sqli:")) {
+            return JdbcConstants.GBASE8S_DRIVER;
         } else {
             throw new SQLException("unknown jdbc driver : " + rawUrl);
         }


### PR DESCRIPTION
GBase 8s是天津南大通用数据技术股份有限公司自主研发的、成熟稳定的基于共享存储的数据库集群，拥有自主知识产权。产品达到安全数据库四级标准（国际B2），支持国密算法，支持SQL92/99、ODBC、JDBC、ADO.NET、GCI(OCI/OCCI)、Python接口等国际数据库规范和开发接口。支持集中式部署、共享存储高可用部署、两地三中心高可用部署，具备高容量、高并发、高性能等特性。

druid中的gbase分支是公司GBase 8a数据库，本次提交的是适配公司GBase 8s数据库.