### PR TITLE
Improve INDEX BY table parsing capability

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -2044,13 +2044,16 @@ public class OracleStatementParser extends SQLStatementParser {
                         int len = lenExpr.getNumber().intValue();
                         dataType = new SQLDataTypeImpl(typeName, len);
                         accept(Token.RPAREN);
+                    } else {
+                        String typeName = "TABLE OF " + sqlName.toString();
+                        dataType = new SQLDataTypeImpl(typeName);
+                    }
 
-                        if (lexer.token() == Token.INDEX) {
-                            lexer.nextToken();
-                            accept(Token.BY);
-                            SQLExpr indexBy = this.exprParser.primary();
-                            ((SQLDataTypeImpl) dataType).setIndexBy(indexBy);
-                        }
+                    if (lexer.token() == Token.INDEX) {
+                        lexer.nextToken();
+                        accept(Token.BY);
+                        SQLExpr indexBy = this.exprParser.primary();
+                        ((SQLDataTypeImpl) dataType).setIndexBy(indexBy);
                     }
                     dataType.setDbType(dbType);
                 } else if (lexer.identifierEquals("VARRAY")) {

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleParameterParserTest.java
@@ -24,4 +24,25 @@ public class OracleParameterParserTest {
 		Assert.assertEquals(sql, stat.toString());
 		System.out.println("=============");
 	}
+
+	@Test
+	public void testNestedParameter_NumberIndexBy() {
+		String sql = "DECLARE\n" +
+					 "\tTYPE NUMBER_ARRAY_TYPE IS TABLE OF NUMBER INDEX BY BINARY_INTEGER;\n" +
+					 "\tmyArray NUMBER_ARRAY_TYPE;\n" +
+					 "BEGIN\n" +
+					 "\tFOR i IN 1..10\n" +
+					 "\tLOOP\n" +
+					 "\t\tmyArray(i) := i * 10;\n" +
+					 "\tEND LOOP;\n" +
+					 "\tFOR i IN 1..10\n" +
+					 "\tLOOP\n" +
+					 "\t\tDBMS_OUTPUT.PUT_LINE('Index: ' || i || ', Value: ' || myArray(i));\n" +
+					 "\tEND LOOP;\n" +
+					 "END;";
+		SQLStatement stat = SQLUtils.parseSingleStatement(sql, DbType.oracle, false);
+		System.out.println(stat);
+		Assert.assertEquals(sql, stat.toString());
+		System.out.println("=============");
+	}
 }


### PR DESCRIPTION
We only parse the case where the syntax is `TABLE OF dataType() INDEX BY`. However, we do not parse the case where the syntax is `TABLE OF dataType INDEX BY`, which lacks parenthese. For instance: 
```sql
DECLARE
  TYPE NUMBER_ARRAY_TYPE IS TABLE OF NUMBER INDEX BY BINARY_INTEGER;
  ...
```

只考虑到了数据类型有括号的情况 没有考虑无括号的情况