### PR TITLE
Fix unary operator for identifier

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -422,9 +422,12 @@ public class OracleExprParser extends SQLExprParser {
                         sqlExpr = new OracleBinaryDoubleExpr(Double.parseDouble(lexer.numberString()) * -1);
                         lexer.nextToken();
                         break;
+                    case IDENTIFIER:
+                        sqlExpr = new SQLUnaryExpr(SQLUnaryOperator.Negative, new SQLIdentifierExpr(lexer.stringVal()));
+                        lexer.nextToken();
+                        break;
                     case VARIANT:
                     case QUES:
-                    case IDENTIFIER:
                     case LITERAL_ALIAS:
                         sqlExpr = expr();
                         sqlExpr = new SQLUnaryExpr(SQLUnaryOperator.Negative, sqlExpr);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -423,8 +423,8 @@ public class OracleExprParser extends SQLExprParser {
                         lexer.nextToken();
                         break;
                     case IDENTIFIER:
-                        sqlExpr = new SQLUnaryExpr(SQLUnaryOperator.Negative, new SQLIdentifierExpr(lexer.stringVal()));
-                        lexer.nextToken();
+                        sqlExpr = primary();
+                        sqlExpr = new SQLUnaryExpr(SQLUnaryOperator.Negative, sqlExpr);
                         break;
                     case VARIANT:
                     case QUES:

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest83_number_negative.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest83_number_negative.java
@@ -69,4 +69,21 @@ public class OracleSelectTest83_number_negative extends OracleTest {
 //         Assert.assertTrue(visitor.containsColumn("sup_task", "orgid"));
 //
     }
+
+    public void test_1() throws Exception {
+        String sql = "SELECT * FROM employees WHERE -salary < 0 ORDER BY employee_id";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statement = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        statement.accept(visitor);
+
+        Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertEquals(3, visitor.getColumns().size());
+    }
 }


### PR DESCRIPTION
`SELECT * FROM employees WHERE -salary < 0 ORDER BY employee_id` is  wrongly converted to: `SELECT * FROM employees WHERE -(salary < 0) ORDER BY employee_id`， causing error in Oracle:
```
ORA-00907: missing right parenthesis
```