### PR TITLE
fixed #5866 DDL SQL syntax error.

### DIFF
--- a/core/src/main/java/com/alibaba/druid/util/OracleUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/OracleUtils.java
@@ -261,7 +261,7 @@ public class OracleUtils {
             sql.append("select DBMS_METADATA.GET_DDL('TABLE', TABLE_NAME) FROM user_tables");
 
             if (tables.size() > 0) {
-                sql.append("IN (");
+                sql.append(" WHERE TABLE_NAME IN (");
                 for (int i = 0; i < tables.size(); ++i) {
                     if (i != 0) {
                         sql.append(", ?");


### PR DESCRIPTION
修复了OracleUtils按表名获取DDL时的SQL拼接错误
![image](https://github.com/alibaba/druid/assets/39900932/115ca489-e863-470b-98fe-1da11e88a3f4)
修复前为：`sql.append("IN (");`
修复后为：`sql.append(" WHERE TABLE_NAME IN (");`