### PR TITLE
Improve PGTypeCastExpr

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLParameter.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLParameter.java
@@ -34,6 +34,20 @@ public final class SQLParameter extends SQLObjectImpl implements SQLObjectWithDa
     private boolean map;
     private boolean member;
 
+    public SQLParameter() {
+    }
+
+    public SQLParameter(SQLName name, SQLDataType dataType) {
+        this.setName(name);
+        this.setDataType(dataType);
+    }
+
+    public SQLParameter(SQLName name, SQLDataType dataType, SQLExpr defaultValue) {
+        this.setName(name);
+        this.setDataType(dataType);
+        this.setDefaultValue(defaultValue);
+    }
+
     public SQLExpr getDefaultValue() {
         return defaultValue;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExprStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExprStatement.java
@@ -27,7 +27,7 @@ public class SQLExprStatement extends SQLStatementImpl implements SQLReplaceable
     }
 
     public SQLExprStatement(SQLExpr expr) {
-        this.expr = expr;
+        this.setExpr(expr);
     }
 
     @Override
@@ -36,7 +36,6 @@ public class SQLExprStatement extends SQLStatementImpl implements SQLReplaceable
             acceptChild(visitor, expr);
         }
         visitor.endVisit(this);
-
     }
 
     public SQLExpr getExpr() {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -121,8 +121,7 @@ public class OracleExprParser extends SQLExprParser {
                 || hash == FnvHash.Constants.VARCHAR
                 || hash == FnvHash.Constants.VARCHAR2
                 || hash == FnvHash.Constants.NVARCHAR
-                || hash == FnvHash.Constants.NVARCHAR2
-                || hash == FnvHash.Constants.CHARACTER;
+                || hash == FnvHash.Constants.NVARCHAR2;
     }
 
     public SQLDataType parseDataType(boolean restrict) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
@@ -49,10 +49,6 @@ public class PGTypeCastExpr extends SQLCastExpr implements PGExpr {
         super.accept0(visitor);
     }
 
-    public String toString() {
-        return SQLUtils.toPGString(this);
-    }
-
     @Override
     public PGTypeCastExpr clone() {
         PGTypeCastExpr x = new PGTypeCastExpr();
@@ -64,5 +60,9 @@ public class PGTypeCastExpr extends SQLCastExpr implements PGExpr {
             x.setDataType(dataType.clone());
         }
         return x;
+    }
+
+    public String toString() {
+        return SQLUtils.toPGString(this);
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
@@ -43,4 +43,17 @@ public class PGTypeCastExpr extends SQLCastExpr implements PGExpr {
     public String toString() {
         return SQLUtils.toPGString(this);
     }
+
+    @Override
+    public PGTypeCastExpr clone() {
+        PGTypeCastExpr x = new PGTypeCastExpr();
+        x.isTry = isTry;
+        if (expr != null) {
+            x.setExpr(expr.clone());
+        }
+        if (dataType != null) {
+            x.setDataType(dataType.clone());
+        }
+        return x;
+    }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
@@ -16,11 +16,20 @@
 package com.alibaba.druid.sql.dialect.postgresql.ast.expr;
 
 import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLDataType;
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class PGTypeCastExpr extends SQLCastExpr implements PGExpr {
+    public PGTypeCastExpr() {
+    }
+    
+    public PGTypeCastExpr(SQLExpr expr, SQLDataType dataType) {
+        super(expr, dataType);
+    }
+    
     @Override
     public void accept0(PGASTVisitor visitor) {
         if (visitor.visit(this)) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExpr.java
@@ -25,11 +25,11 @@ import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 public class PGTypeCastExpr extends SQLCastExpr implements PGExpr {
     public PGTypeCastExpr() {
     }
-    
+
     public PGTypeCastExpr(SQLExpr expr, SQLDataType dataType) {
         super(expr, dataType);
     }
-    
+
     @Override
     public void accept0(PGASTVisitor visitor) {
         if (visitor.visit(this)) {

--- a/core/src/test/java/com/alibaba/druid/sql/ast/SQLParameterTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/ast/SQLParameterTest.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.sql.ast;
+
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SQLParameterTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        SQLParameter parameter = new SQLParameter();
+
+        assertNull(parameter.getName());
+        assertNull(parameter.getDataType());
+        assertNull(parameter.getDefaultValue());
+    }
+
+    @Test
+    public void testConstructorWithNameAndDataType() {
+        // DECLARE testName testType;
+        SQLName name = new SQLIdentifierExpr("testName");
+        SQLDataType dataType = new SQLDataTypeImpl("testType");
+        SQLParameter sqlParameter = new SQLParameter(name, dataType);
+
+        assertEquals(name, sqlParameter.getName());
+        assertEquals(dataType, sqlParameter.getDataType());
+        assertNull(sqlParameter.getDefaultValue());
+        
+        // Test parent relationship
+        assertEquals(sqlParameter, name.getParent());
+        assertEquals(sqlParameter, dataType.getParent());
+    }
+
+    @Test
+    public void testConstructorWithNameDataTypeAndDefaultValue() {
+        // DECLARE testName testType;
+        SQLName name = new SQLIdentifierExpr("testName");
+        SQLDataType dataType = new SQLDataTypeImpl("testType");
+        SQLExpr defaultValue = new SQLIdentifierExpr("testDefault");
+        SQLParameter sqlParameter = new SQLParameter(name, dataType, defaultValue);
+
+        assertEquals(name, sqlParameter.getName());
+        assertEquals(dataType, sqlParameter.getDataType());
+        assertEquals(defaultValue, sqlParameter.getDefaultValue());
+
+        // Test parent relationship
+        assertEquals(sqlParameter, name.getParent());
+        assertEquals(sqlParameter, dataType.getParent());
+        assertEquals(sqlParameter, defaultValue.getParent());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLExprStatementTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLExprStatementTest.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.sql.ast.statement;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SQLExprStatementTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        SQLExpr sqlExpr = new SQLBinaryOpExpr();
+        SQLExprStatement stmt = new SQLExprStatement();
+        stmt.setExpr(sqlExpr);
+
+        assertEquals(sqlExpr, stmt.getExpr());
+        
+        // Test parent relationship
+        assertEquals(stmt, sqlExpr.getParent());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        SQLExpr sqlExpr = new SQLBinaryOpExpr();
+        SQLExprStatement stmt = new SQLExprStatement(sqlExpr);
+        stmt.setExpr(sqlExpr);
+
+        assertEquals(sqlExpr, stmt.getExpr());
+        
+        // Test parent relationship
+        assertEquals(stmt, sqlExpr.getParent());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExprTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/postgresql/ast/expr/PGTypeCastExprTest.java
@@ -1,0 +1,52 @@
+package com.alibaba.druid.sql.dialect.postgresql.ast.expr;
+
+import com.alibaba.druid.sql.ast.SQLDataType;
+import com.alibaba.druid.sql.ast.SQLDataTypeImpl;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class PGTypeCastExprTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        PGTypeCastExpr pgTypeCastExpr = new PGTypeCastExpr();
+        assertNotNull(pgTypeCastExpr);
+        assertNull(pgTypeCastExpr.getExpr());
+        assertNull(pgTypeCastExpr.getDataType());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        // '100'::INT
+        SQLExpr sqlCharExpr = new SQLCharExpr("100");
+        SQLDataType sqlDataType = new SQLDataTypeImpl(SQLDataType.Constants.INT);
+
+        PGTypeCastExpr pgTypeCastExpr = new PGTypeCastExpr(sqlCharExpr, sqlDataType);
+        assertNotNull(pgTypeCastExpr);
+        assertEquals(sqlCharExpr, pgTypeCastExpr.getExpr());
+        assertEquals(sqlDataType, pgTypeCastExpr.getDataType());
+        
+        // Test parent relationship
+        assertEquals(pgTypeCastExpr, sqlCharExpr.getParent());
+        assertEquals(pgTypeCastExpr, sqlDataType.getParent());
+    }
+    
+    @Test
+    public void testClone() {
+        // '100'::INT
+        SQLExpr sqlCharExpr = new SQLCharExpr("100");
+        SQLDataType sqlDataType = new SQLDataTypeImpl(SQLDataType.Constants.INT);
+
+        PGTypeCastExpr pgTypeCastExpr = new PGTypeCastExpr(sqlCharExpr, sqlDataType);
+        PGTypeCastExpr pgTypeCastExprClone = pgTypeCastExpr.clone();
+        assertNotNull(pgTypeCastExprClone);
+        assertEquals(pgTypeCastExpr, pgTypeCastExprClone);
+        assertEquals(pgTypeCastExpr.getExpr(), pgTypeCastExprClone.getExpr());
+        assertEquals(pgTypeCastExpr.getDataType(), pgTypeCastExprClone.getDataType());
+    }
+}


### PR DESCRIPTION
Changes:
- Adding constructors, and implement `clone()` method fo `PGTypeCastExpr` class
- Add constructors for `SQLParameter`
- Use `setExpr` method in `SQLExprStatement` constructor to ensure the parent-child relationship is built