### PR TITLE
Fix：DruidDataSource 中重复初始化lastActiveTimeMillis

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1697,7 +1697,6 @@ public class DruidDataSource extends DruidAbstractDataSource
                     if (creatingCountUpdater.compareAndSet(this, 0, 1)) {
                         PhysicalConnectionInfo pyConnInfo = DruidDataSource.this.createPhysicalConnection();
                         holder = new DruidConnectionHolder(this, pyConnInfo);
-                        holder.lastActiveTimeMillis = System.currentTimeMillis();
 
                         creatingCountUpdater.decrementAndGet(this);
                         directCreateCountUpdater.incrementAndGet(this);


### PR DESCRIPTION
DruidConnectionHolder 里面初始化过了