### PR TITLE
Fix typo in WallVisitorUtils

### DIFF
--- a/core/src/main/java/com/alibaba/druid/wall/WallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallVisitor.java
@@ -77,7 +77,7 @@ public interface WallVisitor extends SQLASTVisitor {
     }
 
     default boolean visit(SQLSelectQueryBlock x) {
-        WallVisitorUtils.checkSelelct(this, x);
+        WallVisitorUtils.checkSelect(this, x);
 
         return true;
     }

--- a/core/src/main/java/com/alibaba/druid/wall/spi/MySqlWallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/MySqlWallVisitor.java
@@ -42,7 +42,7 @@ public class MySqlWallVisitor extends WallVisitorBase implements WallVisitor, My
 
     @Override
     public boolean visit(MySqlSelectQueryBlock x) {
-        WallVisitorUtils.checkSelelct(this, x);
+        WallVisitorUtils.checkSelect(this, x);
         return true;
     }
 

--- a/core/src/main/java/com/alibaba/druid/wall/spi/PGWallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/PGWallVisitor.java
@@ -52,7 +52,7 @@ public class PGWallVisitor extends WallVisitorBase implements WallVisitor, PGAST
 
     @Override
     public boolean visit(PGSelectQueryBlock x) {
-        WallVisitorUtils.checkSelelct(this, x);
+        WallVisitorUtils.checkSelect(this, x);
         return true;
     }
 

--- a/core/src/main/java/com/alibaba/druid/wall/spi/SQLServerWallVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/SQLServerWallVisitor.java
@@ -118,7 +118,7 @@ public class SQLServerWallVisitor extends WallVisitorBase implements WallVisitor
     }
 
     public boolean visit(SQLServerSelectQueryBlock x) {
-        WallVisitorUtils.checkSelelct(this, x);
+        WallVisitorUtils.checkSelect(this, x);
         return true;
     }
     @Override

--- a/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
@@ -187,7 +187,15 @@ public class WallVisitorUtils {
         checkInsertForMultiTenant(visitor, x);
     }
 
+    /**
+     *
+     * @deprecated use {@link WallVisitorUtils#checkSelect(WallVisitor, SQLSelectQueryBlock)}
+     */
+    @Deprecated
     public static void checkSelelct(WallVisitor visitor, SQLSelectQueryBlock x) {
+        checkSelect(visitor, x);
+    }
+    public static void checkSelect(WallVisitor visitor, SQLSelectQueryBlock x) {
         if (x.getInto() != null) {
             checkReadOnly(visitor, x.getInto());
         }


### PR DESCRIPTION
 WallVisitorUtils#checkSelelct 修正为  WallVisitorUtils#checkSelect，同时标记 WallVisitorUtils#checkSelelct 为 deprecated 