### PR TITLE
Fix typo and @Deprecated in WallConfig

### DIFF
--- a/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
@@ -757,6 +757,7 @@ public class WallConfig implements WallConfigMBean {
         this.deleteWhereAlwayTrueCheck = deleteWhereAlwayTrueCheck;
     }
 
+    @Deprecated
     public boolean isUpdateWhereAlayTrueCheck() {
         return updateWhereAlwayTrueCheck;
     }
@@ -773,7 +774,6 @@ public class WallConfig implements WallConfigMBean {
         this.updateWhereAlwayTrueCheck = updateWhereAlwayTrueCheck;
     }
 
-    @Deprecated
     public boolean isConditionOpBitwseAllow() {
         return conditionOpBitwseAllow;
     }

--- a/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
@@ -29,7 +29,7 @@ public class WallConfig implements WallConfigMBean {
     private boolean noneBaseStatementAllow;
 
     private boolean callAllow = true;
-    private boolean selelctAllow = true;
+    private boolean selectAllow = true;
     private boolean selectIntoAllow = true;
     private boolean selectIntoOutfileAllow;
     private boolean selectWhereAlwayTrueCheck = true;
@@ -119,7 +119,7 @@ public class WallConfig implements WallConfigMBean {
     private boolean metadataAllow = true;
 
     private boolean conditionOpXorAllow;
-    private boolean conditionOpBitwseAllow = true;
+    private boolean conditionOpBitwiseAllow = true;
 
     private boolean caseConditionConstAllow;
 
@@ -696,11 +696,11 @@ public class WallConfig implements WallConfigMBean {
     }
 
     public boolean isSelectAllow() {
-        return selelctAllow;
+        return selectAllow;
     }
 
-    public void setSelectAllow(boolean selelctAllow) {
-        this.selelctAllow = selelctAllow;
+    public void setSelectAllow(boolean selectAllow) {
+        this.selectAllow = selectAllow;
     }
 
     /**
@@ -782,12 +782,35 @@ public class WallConfig implements WallConfigMBean {
         this.updateWhereAlwayTrueCheck = updateWhereAlwayTrueCheck;
     }
 
+    /**
+     * @deprecated Sine 1.2.24, use {@link WallConfig#isConditionOpBitwiseAllow()} instead.
+     */
+    @Deprecated
     public boolean isConditionOpBitwseAllow() {
-        return conditionOpBitwseAllow;
+        return isConditionOpBitwiseAllow();
     }
 
+    /**
+     *
+     * @deprecated Sine 1.2.24, use {@link WallConfig#setConditionOpBitwiseAllow(boolean)} instead.
+     */
+    @Deprecated
     public void setConditionOpBitwseAllow(boolean conditionOpBitwseAllow) {
-        this.conditionOpBitwseAllow = conditionOpBitwseAllow;
+        setConditionOpBitwiseAllow(conditionOpBitwseAllow);
+    }
+
+    /**
+     * @since 1.2.24
+     */
+    public boolean isConditionOpBitwiseAllow() {
+        return conditionOpBitwiseAllow;
+    }
+
+    /**
+     * @since 1.2.24
+     */
+    public void setConditionOpBitwiseAllow(boolean conditionOpBitwiseAllow) {
+        this.conditionOpBitwiseAllow = conditionOpBitwiseAllow;
     }
 
     public void setInited(boolean inited) {
@@ -850,7 +873,11 @@ public class WallConfig implements WallConfigMBean {
             }
         }
         {
-            Boolean propertyValue = getBoolean(properties, "druid.wall.selelctAllow");
+            Boolean propertyValue = getBoolean(properties, "druid.wall.selectAllow");
+            //Compatible with previous property
+            if (propertyValue == null) {
+                propertyValue = getBoolean(properties, "druid.wall.selelctAllow");
+            }
             if (propertyValue != null) {
                 this.setSelectAllow(propertyValue);
             }
@@ -890,7 +917,7 @@ public class WallConfig implements WallConfigMBean {
             if (propertyValue != null) {
                 String[] items = propertyValue.split(",");
                 for (String item : items) {
-                    addUpdateCheckCoumns(item);
+                    addUpdateCheckColumns(item);
                 }
             }
         }
@@ -908,7 +935,19 @@ public class WallConfig implements WallConfigMBean {
         }
     }
 
+    /**
+     *
+     * @deprecated Since 1.2.24, use {@link WallConfig#addUpdateCheckColumns(String)} instead.
+     */
+    @Deprecated
     public void addUpdateCheckCoumns(String columnInfo) {
+        addUpdateCheckColumns(columnInfo);
+    }
+
+    /**
+     * @since 1.2.24
+     */
+    public void addUpdateCheckColumns(String columnInfo) {
         String[] items = columnInfo.split("\\.");
         if (items.length != 2) {
             return;

--- a/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallConfig.java
@@ -704,15 +704,17 @@ public class WallConfig implements WallConfigMBean {
     }
 
     /**
-     * @deprecated use isSelectAllow
+     * @deprecated use {@link WallConfig#isSelectAllow()}
      */
+    @Deprecated
     public boolean isSelelctAllow() {
         return isSelectAllow();
     }
 
     /**
-     * @deprecated use setSelelctAllow
+     * @deprecated use {@link WallConfig#setSelectAllow(boolean)}
      */
+    @Deprecated
     public void setSelelctAllow(boolean selelctAllow) {
         this.setSelectAllow(selelctAllow);
     }
@@ -757,11 +759,17 @@ public class WallConfig implements WallConfigMBean {
         this.deleteWhereAlwayTrueCheck = deleteWhereAlwayTrueCheck;
     }
 
+    /**
+     * @deprecated use {@link WallConfig#isUpdateWhereAlwayTrueCheck()}
+     */
     @Deprecated
     public boolean isUpdateWhereAlayTrueCheck() {
         return updateWhereAlwayTrueCheck;
     }
 
+    /**
+     * @deprecated use {@link WallConfig#setUpdateWhereAlwayTrueCheck(boolean)}
+     */
     @Deprecated
     public void setUpdateWhereAlayTrueCheck(boolean updateWhereAlwayTrueCheck) {
         this.updateWhereAlwayTrueCheck = updateWhereAlwayTrueCheck;

--- a/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/wall/spi/WallVisitorUtils.java
@@ -1000,7 +1000,7 @@ public class WallVisitorUtils {
 
         boolean checkCondition = visitor != null
                 && (!visitor.getConfig().isConstArithmeticAllow()
-                || !visitor.getConfig().isConditionOpBitwseAllow() || !visitor.getConfig().isConditionOpXorAllow());
+                || !visitor.getConfig().isConditionOpBitwiseAllow() || !visitor.getConfig().isConditionOpXorAllow());
 
         if (x.getLeft() instanceof SQLName) {
             if (x.getRight() instanceof SQLName) {
@@ -1454,7 +1454,7 @@ public class WallVisitorUtils {
                 addViolation(visitor, ErrorCode.XOR, " allow", x);
             }
 
-            if (current.hasBitwise() && !visitor.getConfig().isConditionOpBitwseAllow()) {
+            if (current.hasBitwise() && !visitor.getConfig().isConditionOpBitwiseAllow()) {
                 addViolation(visitor, ErrorCode.BITWISE, "bitwise operator not allow", x);
             }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/bug/Issue_728.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/bug/Issue_728.java
@@ -45,7 +45,7 @@ public class Issue_728 extends TestCase {
         String sql = "SELECT * from city_list where city_id = 1 & 2";
 
         WallConfig config = new WallConfig();
-        config.setConditionOpBitwseAllow(false);
+        config.setConditionOpBitwiseAllow(false);
 
         Assert.assertFalse(WallUtils.isValidateMySql(sql, config));
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseAndTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseAndTest.java
@@ -15,7 +15,7 @@ public class BitwiseAndTest extends TestCase {
 
     public void test_false() throws Exception {
         WallConfig config = new WallConfig();
-        config.setConditionOpBitwseAllow(false);
+        config.setConditionOpBitwiseAllow(false);
         Assert.assertFalse(WallUtils.isValidateMySql(//
                 "SELECT * from t where (id = 1) & 2", config)); //
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseInvertTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseInvertTest.java
@@ -15,7 +15,7 @@ public class BitwiseInvertTest extends TestCase {
 
     public void test_false() throws Exception {
         WallConfig config = new WallConfig();
-        config.setConditionOpBitwseAllow(false);
+        config.setConditionOpBitwiseAllow(false);
         Assert.assertFalse(WallUtils.isValidateMySql(//
                 "SELECT * from t where ~2", config)); //
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseOrTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseOrTest.java
@@ -15,7 +15,7 @@ public class BitwiseOrTest extends TestCase {
 
     public void test_false() throws Exception {
         WallConfig config = new WallConfig();
-        config.setConditionOpBitwseAllow(false);
+        config.setConditionOpBitwiseAllow(false);
         Assert.assertFalse(WallUtils.isValidateMySql(//
                 "SELECT * from t where (id = 1) | 2", config)); //
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseXorTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/wall/BitwiseXorTest.java
@@ -15,7 +15,7 @@ public class BitwiseXorTest extends TestCase {
 
     public void test_false() throws Exception {
         WallConfig config = new WallConfig();
-        config.setConditionOpBitwseAllow(false);
+        config.setConditionOpBitwiseAllow(false);
         Assert.assertFalse(WallUtils.isValidateMySql(//
                 "SELECT * from t where (id = 1) ^ (1=1)", config)); //
     }


### PR DESCRIPTION
1. `isConditionOpBitwseAllow` 被错误标记为 `@Deprecated` ，应该是 `isUpdateWhereAlayTrueCheck`
2. `isSelelctAllow `和 `setSelelctAllow `注释上写了废弃，此次添加 `@Deprecated `注解
3. 拼写修复