### PR TITLE
多层关联更新语句支持直接获取主表表名

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatement.java
@@ -118,6 +118,10 @@ public class SQLUpdateStatement extends SQLStatementImpl implements SQLReplaceab
     }
 
     public SQLName getTableName() {
+        return this.getTableName(false);
+    }
+
+    public SQLName getTableName(boolean lastFlag) {
         if (tableSource instanceof SQLExprTableSource) {
             return ((SQLExprTableSource) tableSource).getName();
         }
@@ -126,7 +130,19 @@ public class SQLUpdateStatement extends SQLStatementImpl implements SQLReplaceab
             SQLTableSource left = ((SQLJoinTableSource) tableSource).getLeft();
             if (left instanceof SQLExprTableSource) {
                 return ((SQLExprTableSource) left).getName();
+            } else if (lastFlag && left instanceof SQLJoinTableSource) {
+                return getLastTableName(left);
             }
+        }
+        return null;
+    }
+
+    private SQLName getLastTableName(SQLTableSource tableSource) {
+        SQLTableSource left = ((SQLJoinTableSource) tableSource).getLeft();
+        if (left instanceof SQLExprTableSource) {
+            return ((SQLExprTableSource) left).getName();
+        } else if (left instanceof SQLJoinTableSource) {
+            return getLastTableName(left);
         }
         return null;
     }

--- a/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatementTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatementTest.java
@@ -1,0 +1,23 @@
+package com.alibaba.druid.sql.ast.statement;
+
+import com.alibaba.druid.DbType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SQLUpdateStatementTest {
+    @Test
+    public void testGetTableName() {
+        SQLUpdateStatement sqlUpdateStatement = new SQLUpdateStatement();
+        SQLJoinTableSource tableSource1 = new SQLJoinTableSource();
+        SQLJoinTableSource tableSource2 = new SQLJoinTableSource();
+        SQLExprTableSource tableSource3 = new SQLExprTableSource();
+        tableSource3.setExpr("xxx");
+        tableSource2.setLeft(tableSource3);
+        tableSource1.setLeft(tableSource2);
+        sqlUpdateStatement.setDbType(DbType.mysql);
+        sqlUpdateStatement.setTableSource(tableSource1);
+
+        assertEquals(sqlUpdateStatement.getTableName(true), tableSource3.getName());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatementTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/ast/statement/SQLUpdateStatementTest.java
@@ -1,23 +1,28 @@
 package com.alibaba.druid.sql.ast.statement;
 
 import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.builder.SQLBuilderFactory;
+import com.alibaba.druid.sql.builder.SQLUpdateBuilder;
+import com.alibaba.druid.sql.builder.impl.SQLUpdateBuilderImpl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SQLUpdateStatementTest {
     @Test
     public void testGetTableName() {
-        SQLUpdateStatement sqlUpdateStatement = new SQLUpdateStatement();
-        SQLJoinTableSource tableSource1 = new SQLJoinTableSource();
-        SQLJoinTableSource tableSource2 = new SQLJoinTableSource();
-        SQLExprTableSource tableSource3 = new SQLExprTableSource();
-        tableSource3.setExpr("xxx");
-        tableSource2.setLeft(tableSource3);
-        tableSource1.setLeft(tableSource2);
-        sqlUpdateStatement.setDbType(DbType.mysql);
-        sqlUpdateStatement.setTableSource(tableSource1);
-
-        assertEquals(sqlUpdateStatement.getTableName(true), tableSource3.getName());
+        SQLUpdateBuilderImpl updateBuilder = (SQLUpdateBuilderImpl)SQLBuilderFactory.createUpdateBuilder("UPDATE a\n" +
+                "LEFT JOIN b ON b.id = a.id\n" +
+                "LEFT JOIN c ON c.id = a.id\n" +
+                "set a.id=11,b.id=11,c.id=11", DbType.mysql);
+        SQLUpdateStatement sqlUpdateStatement = updateBuilder.getSQLUpdateStatement();
+        SQLName tableName = sqlUpdateStatement.getTableName();
+        String simpleName = sqlUpdateStatement.getTableName(true).getSimpleName();
+        // 原有逻辑返回null
+        assertTrue(tableName == null);
+        // 新增逻辑 返回表名a
+        assertTrue(simpleName.equals("a"));
     }
 }


### PR DESCRIPTION
UPDATE a
LEFT JOIN b ON b.id = a.id
LEFT JOIN c ON c.id = a.id
set a.id=11,b.id=11,c.id=11

类似多层关联update语句 执行getTableName 返回是null 没有意义 直接返回主表a