### PR TITLE
Add module-info.java with valid module name

### DIFF
--- a/druid-spring-boot-3-starter/src/main/java/module-info.java
+++ b/druid-spring-boot-3-starter/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module druid.spring.boot3.starter {
+    requires spring.boot;
+    requires spring.boot.autoconfigure;
+    requires spring.context;
+    requires druid;
+}


### PR DESCRIPTION
Adds a `module-info.java` file to the `druid-spring-boot-3-starter` component to declare a valid module name and specify module dependencies.
- **File Addition**: Introduces `module-info.java` in the `druid-spring-boot-3-starter/src/main/java` directory.
- **Module Declaration**: Declares the module name as `druid.spring.boot3.starter`, aligning with Java module naming conventions.
- **Dependencies**: Specifies module dependencies including `spring.boot`, `spring.boot.autoconfigure`, `spring.context`, and `druid`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alibaba/druid?shareId=e21dddb8-ad7c-45f4-ac1d-dd6336557093).