### PR TITLE
Update OracleIntervalExpr handling in PGOutputVisitor

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -171,7 +171,6 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
     }
 
     public boolean visit(OracleIntervalExpr x) {
-        SQLExpr value = x.getValue();
         if (x.getValue() instanceof SQLLiteralExpr || x.getValue() instanceof SQLVariantRefExpr) {
             print0(ucase ? "INTERVAL " : "interval ");
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -962,13 +962,9 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
     public boolean visit(OracleIntervalExpr x) {
         if (x.getValue() instanceof SQLLiteralExpr || x.getValue() instanceof SQLVariantRefExpr) {
             print0(ucase ? "INTERVAL " : "interval ");
-            x.getValue().accept(this);
-            print(' ');
-        } else {
-            print('(');
-            x.getValue().accept(this);
-            print0(") ");
         }
+        x.getValue().accept(this);
+        print(' ');
 
         print0(x.getType().name());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleXmlelementTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleXmlelementTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class OracleXmlelementTest extends OracleTest {
     public void testOracleXmlelement() {
-        String sql = "SELECT /* NUSQL.TEST */ XMLELEMENT(NAME foo).getstringval() from dual";
+        String sql = "SELECT XMLELEMENT(NAME foo).getstringval() from dual";
 
         OracleStatementParser parser = new OracleStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();
@@ -27,7 +27,7 @@ public class OracleXmlelementTest extends OracleTest {
     }
 
     public void testOracleXmlelement_WithoutNameKeyword() {
-        String sql = "SELECT /* NUSQL.TEST */ XMLELEMENT(foo).getstringval() from dual";
+        String sql = "SELECT XMLELEMENT(foo).getstringval() from dual";
 
         OracleStatementParser parser = new OracleStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
@@ -96,7 +96,7 @@ public class OracleSelectTest71 extends OracleTest {
     }
 
     public void testSelectWithJoin_UnderParen() {
-        String sql = "SELECT /* NUSQL.TEST */\n" +
+        String sql = "SELECT\n" +
                      "    A.ID,\n" +
                      "    B.NAME,\n" +
                      "    C.TYPE\n" +

--- a/core/src/test/java/com/alibaba/druid/sql/parser/PGIntervalSQLTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/PGIntervalSQLTest.java
@@ -1,9 +1,13 @@
 package com.alibaba.druid.sql.parser;
 
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import com.alibaba.druid.sql.test.TestUtils;
 import junit.framework.TestCase;
-import org.junit.Assert;
+
+import java.util.List;
 
 /**
  * Created by tianzhen.wtz on 2014/12/26 0026 20:44.
@@ -29,8 +33,17 @@ public class PGIntervalSQLTest extends TestCase {
     private void equal(String targetSql, String resultSql) {
         PGSQLStatementParser parser = new PGSQLStatementParser(targetSql);
         PGSelectStatement statement = parser.parseSelect();
-        Assert.assertTrue(statement.toString().equals(resultSql));
+        assertEquals(statement.toString(), resultSql);
 
     }
 
+    public void testIntervalSQL_OracleToPg() {
+        String sql = "SELECT (SYSTIMESTAMP - order_date) DAY(9) TO SECOND from orders WHERE order_id = 2458";
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        assertEquals(1, statementList.size());
+
+        String output = TestUtils.outputPg(statementList);
+        assertEquals("SELECT (SYSTIMESTAMP - order_date) DAY(9) TO SECOND\nFROM orders\nWHERE order_id = 2458", output);
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/sql/test/TestUtils.java
+++ b/core/src/test/java/com/alibaba/druid/sql/test/TestUtils.java
@@ -24,6 +24,7 @@ import javax.management.ObjectName;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.oracle.visitor.OracleOutputVisitor;
+import com.alibaba.druid.sql.dialect.postgresql.visitor.PGOutputVisitor;
 import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTOutputVisitor;
 
@@ -31,6 +32,17 @@ public class TestUtils {
     public static String outputOracle(List<SQLStatement> stmtList) {
         StringBuilder out = new StringBuilder();
         OracleOutputVisitor visitor = new OracleOutputVisitor(out);
+
+        for (SQLStatement stmt : stmtList) {
+            stmt.accept(visitor);
+        }
+
+        return out.toString();
+    }
+    
+    public static String outputPg(List<SQLStatement> stmtList) {
+        StringBuilder out = new StringBuilder();
+        PGOutputVisitor visitor = new PGOutputVisitor(out);
 
         for (SQLStatement stmt : stmtList) {
             stmt.accept(visitor);


### PR DESCRIPTION
解决PGOutputVisitor输出OracleIntervalExpr出现多余的括号的问题，比如：
`SELECT (SYSTIMESTAMP - order_date) DAY(9) TO SECOND from orders WHERE order_id = 2458;`
会变成
`SELECT ((SYSTIMESTAMP - order_date)) DAY(9) TO SECOND from orders WHERE order_id = 2458;`

代码变得跟OracleOutputVisitor的相同方法的code完全相同

没有添加测试用例因为这个设计的是Oracle Interval到PG输出的问题，好像一般测试用例不涉及到跨两个数据库