### PR TITLE
fix: 修复通过maxwell进行数据同步时， RowMap中对象为BigInteger时提示UnsupportedOperationE…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4551,7 +4551,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 print(((Double) value).doubleValue());
             } else if (value instanceof Date) {
                 print((Date) value);
-            } else if (value instanceof BigDecimal || value instanceof BigInteger) {
+            } else if (value instanceof BigDecimal) {
+                print(((BigDecimal)value).toPlainString());
+            } else if (value instanceof BigInteger) {
                 print(value.toString());
             } else if (value == null) {
                 print0(ucase ? "NULL" : "null");

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4551,7 +4551,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 print(((Double) value).doubleValue());
             } else if (value instanceof Date) {
                 print((Date) value);
-            } else if (value instanceof BigDecimal) {
+            } else if (value instanceof BigDecimal || value instanceof BigInteger) {
                 print(value.toString());
             } else if (value == null) {
                 print0(ucase ? "NULL" : "null");

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4552,7 +4552,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             } else if (value instanceof Date) {
                 print((Date) value);
             } else if (value instanceof BigDecimal) {
-                print(((BigDecimal)value).toPlainString());
+                print(((BigDecimal) value).toPlainString());
             } else if (value instanceof BigInteger) {
                 print(value.toString());
             } else if (value == null) {


### PR DESCRIPTION
修复通过maxwell进行数据同步时， RowMap中对象为BigInteger时提示UnsupportedOperationException问题

`
        MySqlInsertStatement stmt = new MySqlInsertStatement();
        stmt.setTableName(new SQLIdentifierExpr(r.getTable()));
        SQLInsertStatement.ValuesClause valuesClause = new SQLInsertStatement.ValuesClause();
        stmt.addValueCause(valuesClause);
        LinkedHashMap<String, Object> data = r.getData();
        for (String k : data.keySet()) {
            // v可能是BigInteger
            Object v = data.get(k);
            stmt.addColumn(new SQLIdentifierExpr(k));
            valuesClause.addValue(v);
        }
`