### PR TITLE
fix: 修复 PGSql 和 OscarSql Parser 解析 offset x limit y 会丢失 offset 的问题

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oscar/parser/OscarSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oscar/parser/OscarSelectParser.java
@@ -46,7 +46,6 @@ public class OscarSelectParser extends SQLSelectParser {
         return new OscarExprParser(lexer);
     }
 
-
     @Override
     public SQLSelectQuery query(SQLObject parent, boolean acceptUnion) {
         if (lexer.token() == Token.VALUES) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oscar/parser/OscarSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oscar/parser/OscarSelectParser.java
@@ -46,6 +46,7 @@ public class OscarSelectParser extends SQLSelectParser {
         return new OscarExprParser(lexer);
     }
 
+
     @Override
     public SQLSelectQuery query(SQLObject parent, boolean acceptUnion) {
         if (lexer.token() == Token.VALUES) {
@@ -151,7 +152,7 @@ public class OscarSelectParser extends SQLSelectParser {
 
         for (;;) {
             if (lexer.token() == Token.LIMIT) {
-                SQLLimit limit = new SQLLimit();
+                SQLLimit limit = getOrInitLimit(queryBlock);
 
                 lexer.nextToken();
                 if (lexer.token() == Token.ALL) {
@@ -163,11 +164,7 @@ public class OscarSelectParser extends SQLSelectParser {
 
                 queryBlock.setLimit(limit);
             } else if (lexer.token() == Token.OFFSET) {
-                SQLLimit limit = queryBlock.getLimit();
-                if (limit == null) {
-                    limit = new SQLLimit();
-                    queryBlock.setLimit(limit);
-                }
+                SQLLimit limit = getOrInitLimit(queryBlock);
                 lexer.nextToken();
                 SQLExpr offset = expr();
                 limit.setOffset(offset);
@@ -251,6 +248,15 @@ public class OscarSelectParser extends SQLSelectParser {
         }
 
         return queryRest(queryBlock, acceptUnion);
+    }
+
+    private SQLLimit getOrInitLimit(SQLSelectQueryBlock queryBlock) {
+        SQLLimit limit = queryBlock.getLimit();
+        if (limit == null) {
+            limit = new SQLLimit();
+            queryBlock.setLimit(limit);
+        }
+        return limit;
     }
 
     public SQLTableSource parseTableSourceRest(SQLTableSource tableSource) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -18,11 +18,7 @@ package com.alibaba.druid.sql.dialect.postgresql.parser;
 import com.alibaba.druid.sql.ast.*;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.expr.SQLSizeExpr;
-import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
-import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
-import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
-import com.alibaba.druid.sql.ast.statement.SQLTableSampling;
-import com.alibaba.druid.sql.ast.statement.SQLTableSource;
+import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGFunctionTableSource;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectQueryBlock.IntoOption;
@@ -142,7 +138,7 @@ public class PGSelectParser extends SQLSelectParser {
 
         for (; ; ) {
             if (lexer.token() == Token.LIMIT) {
-                SQLLimit limit = new SQLLimit();
+                SQLLimit limit = getOrInitLimit(queryBlock);
 
                 lexer.nextToken();
                 if (lexer.token() == Token.ALL) {
@@ -152,13 +148,9 @@ public class PGSelectParser extends SQLSelectParser {
                     limit.setRowCount(expr());
                 }
 
-                queryBlock.setLimit(limit);
             } else if (lexer.token() == Token.OFFSET) {
-                SQLLimit limit = queryBlock.getLimit();
-                if (limit == null) {
-                    limit = new SQLLimit();
-                    queryBlock.setLimit(limit);
-                }
+                SQLLimit limit = getOrInitLimit(queryBlock);
+
                 lexer.nextToken();
                 SQLExpr offset = expr();
                 limit.setOffset(offset);
@@ -242,6 +234,15 @@ public class PGSelectParser extends SQLSelectParser {
         }
 
         return queryRest(queryBlock, acceptUnion);
+    }
+
+    private SQLLimit getOrInitLimit(SQLSelectQueryBlock queryBlock) {
+        SQLLimit limit = queryBlock.getLimit();
+        if (limit == null) {
+            limit = new SQLLimit();
+            queryBlock.setLimit(limit);
+        }
+        return limit;
     }
 
     public SQLTableSource parseTableSourceRest(SQLTableSource tableSource) {

--- a/core/src/test/java/com/alibaba/druid/sql/parser/LimitOffsetSQLTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/LimitOffsetSQLTest.java
@@ -1,0 +1,49 @@
+package com.alibaba.druid.sql.parser;
+
+import com.alibaba.druid.sql.dialect.oscar.visitor.OscarStatementParser;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+import junit.framework.TestCase;
+
+/**
+ * Created by tianzhen.wtz on 2014/12/26 0026 20:44.
+ * 类说明：
+ */
+public class LimitOffsetSQLTest extends TestCase {
+
+
+    public void testPGLimitOffsetSQL() {
+        String sql1 = "SELECT * FROM table1 LIMIT 10 OFFSET 20";
+        String sql1Result = new PGSQLStatementParser(sql1).parseSelect().toString()
+                .replace("\n", " ");
+        ;
+
+        assertEquals(sql1, sql1Result);
+
+        String sql2 = "SELECT * FROM table1 OFFSET 20 LIMIT 10 ";
+        String sql2Result = new PGSQLStatementParser(sql2).parseSelect().toString()
+                .replace("\n", " ");
+
+        // OFFSET 20 LIMIT 20 会被解析成 OFFSET 20 LIMIT 10
+        assertEquals(sql1, sql2Result);
+
+    }
+
+    public void testOscarLimitOffsetSQL() {
+        String sql1 = "SELECT * FROM table1 LIMIT 10 OFFSET 20";
+        String sql1Result = new OscarStatementParser(sql1).parseSelect().toString()
+                .replace("\n", " ");
+        ;
+
+        assertEquals(sql1, sql1Result);
+
+        String sql2 = "SELECT * FROM table1 OFFSET 20 LIMIT 10 ";
+        String sql2Result = new OscarStatementParser(sql2).parseSelect().toString()
+                .replace("\n", " ");
+
+        // OFFSET 20 LIMIT 20 会被解析成 OFFSET 20 LIMIT 10
+        assertEquals(sql1, sql2Result);
+
+    }
+
+
+}


### PR DESCRIPTION
解析 SELECT * FROM table1 LIMIT 10 OFFSET 20 没问题, 但如果 LIMIT 和 OFFSET 顺序变了会有问题, 会变成 SELECT * FROM table1 LIMIT 10 , 丢失了 OFFSET, 原因是处理 LIMIT 的时候创建了一个新的 SQLLimit 对象, 把 处理 OFFSET 时候的 SQLLimit 对象给覆盖了