### PR TITLE
Support to parse nested data type.

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKExprParser.java
@@ -30,8 +30,10 @@ import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.SQLParserFeature;
 import com.alibaba.druid.sql.parser.Token;
 import com.alibaba.druid.util.FnvHash;
+import com.google.common.collect.Lists;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static com.alibaba.druid.sql.parser.Token.LPAREN;
 import static com.alibaba.druid.sql.parser.Token.RPAREN;
@@ -39,6 +41,7 @@ import static com.alibaba.druid.sql.parser.Token.RPAREN;
 public class CKExprParser extends SQLExprParser {
     private static final String[] AGGREGATE_FUNCTIONS;
     private static final long[] AGGREGATE_FUNCTIONS_CODES;
+    private static final List<String> NESTED_DATA_TYPE;
 
     static {
         String[] strings = {"AVG", "COUNT", "MAX", "MIN", "STDDEV", "SUM", "ROW_NUMBER",
@@ -50,6 +53,7 @@ public class CKExprParser extends SQLExprParser {
             int index = Arrays.binarySearch(AGGREGATE_FUNCTIONS_CODES, hash);
             AGGREGATE_FUNCTIONS[index] = str;
         }
+        NESTED_DATA_TYPE = Lists.newArrayList("array", "tuple", "nullable", "lowcardinality", "variant");
     }
 
     public CKExprParser(String sql) {
@@ -66,6 +70,7 @@ public class CKExprParser extends SQLExprParser {
         super(lexer);
         this.aggregateFunctions = AGGREGATE_FUNCTIONS;
         this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
+        this.nestedDataType = NESTED_DATA_TYPE;
     }
 
     protected SQLExpr parseAliasExpr(String alias) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/CKOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/visitor/CKOutputVisitor.java
@@ -311,4 +311,19 @@ public class CKOutputVisitor extends SQLASTOutputVisitor implements CKASTVisitor
             }
         }
     }
+
+    @Override
+    public boolean visit(SQLMapDataType x) {
+        print0(ucase ? "MAP(" : "map(");
+
+        SQLDataType keyType = x.getKeyType();
+        SQLDataType valueType = x.getValueType();
+
+        keyType.accept(this);
+        print0(", ");
+
+        valueType.accept(this);
+        print(')');
+        return false;
+    }
 }

--- a/core/src/test/resources/bvt/parser/clickhouse/4.txt
+++ b/core/src/test/resources/bvt/parser/clickhouse/4.txt
@@ -10,7 +10,12 @@ CREATE TABLE replicated_orders (
                     order_date Date,
                     product_id LowCardinality(UInt32),
                     quantity Int32,
-                    price Decimal(10, 2)
+                    price Decimal(10, 2),
+                    array1 Array(UInt8),
+                    tuple1 Tuple(UInt8, String),
+                    map1 Map(String, UInt64),
+                    variant1 Variant(String, Array(UInt8)),
+                    null1 Nullable(String)
                 )
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/replicated_orders', '{replica}')
                 PARTITION BY order_date
@@ -22,7 +27,12 @@ CREATE TABLE replicated_orders (
 	order_date Date,
 	product_id LowCardinality(UInt32),
 	quantity Int32,
-	price Decimal(10, 2)
+	price Decimal(10, 2),
+	array1 Array(UInt8),
+	tuple1 Tuple(UInt8, String),
+	map1 MAP(String, UInt64),
+	variant1 Variant(String, Array(UInt8)),
+	null1 Nullable(String)
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/replicated_orders', '{replica}')
 PARTITION BY order_date
 ORDER BY (order_date, customer_id, order_id)


### PR DESCRIPTION
Currently,  datatype LowCardinality(String) will be parsed as SQLDataTypleImpl 'LowCardinanlity' with one param SQLIdentifier 'String'.  In this PR, we parse 'String' as SQLDataTypeRef instead of Identifier. It only works for pre-defined nestDataType, such us LowCardinality, Nullable, Tuple and etc in clickhouse.