### PR TITLE
DruidAdmin完善

### DIFF
--- a/druid-admin/pom.xml
+++ b/druid-admin/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
-            <version>2.0.29</version>
+            <version>2.0.52</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/druid-admin/src/main/java/com/alibaba/druid/admin/model/dto/BasicResult.java
+++ b/druid-admin/src/main/java/com/alibaba/druid/admin/model/dto/BasicResult.java
@@ -1,0 +1,42 @@
+package com.alibaba.druid.admin.model.dto;
+
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Data
+public class BasicResult {
+
+    @JSONField(name = "ResultCode")
+    private int ResultCode;
+    @JSONField(name = "Content")
+    private List<ContentBean> Content;
+
+    @NoArgsConstructor
+    @Data
+    public static class ContentBean {
+        private String serviceId;
+        private String name;
+
+        @JSONField(name = "Version")
+        private String Version;
+        @JSONField(name = "Drivers")
+        private List<String> Drivers;
+        @JSONField(name = "ResetEnable")
+        private boolean ResetEnable;
+        @JSONField(name = "ResetCount")
+        private int ResetCount;
+        @JSONField(name = "JavaVMName")
+        private String JavaVMName;
+        @JSONField(name = "JavaVersion")
+        private String JavaVersion;
+        @JSONField(name = "JavaClassPath")
+        private String JavaClassPath;
+        @JSONField(name = "StartTime")
+        private String StartTime;
+    }
+
+}

--- a/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
+++ b/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
@@ -396,7 +396,7 @@ public class MonitorStatService implements DruidStatServiceMBean {
                 List<DataSourceResult.ContentBean> nodeContent = dataSourceResult.getContent();
                 if (nodeContent != null) {
                     for (DataSourceResult.ContentBean contentBean : nodeContent) {
-                        contentBean.setName(serviceName);
+                        contentBean.setName(serviceName + " ( " + contentBean.getName() + " ) ");
                         contentBean.setServiceId(serviceNode.getId());
                     }
                     contentBeans.addAll(nodeContent);

--- a/druid-admin/src/main/resources/support/http/resources/index.html
+++ b/druid-admin/src/main/resources/support/http/resources/index.html
@@ -5,86 +5,105 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf8" />
 		<link href='css/bootstrap.min.css' rel="stylesheet" />
 		<link href="css/style.css" type="text/css" rel="stylesheet"/>
+		<script src="js/doT.js" type="text/javascript" charset="utf8"></script>
     	<script type="text/javascript" src="js/jquery.min.js"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js"></script>
     	<script src="js/lang.js" type="text/javascript" charset="utf8"></script>
 		<script src="js/common.js" type="text/javascript" charset="utf8"></script>
 	</head>
 	<body>
-		
-    	<div class="container">
-          				<h3>
-          					Stat Index
-          					<a href="basic.json" target="_blank" class="lang" langKey="ViewJSONAPI">View JSON API</a>
-          				</h3>
+
+	<div class="container">
+		<div class="row-fluid">
+			<div class="span12">
+				<h3>
+					Stat Index
+					<a href="basic.json" target="_blank" class="lang" langKey="ViewJSONAPI">View JSON API</a>
+				</h3>
+			</div>
+		</div>
+
+		<script id="basic-tmpl" type="text/template">
+			<ul class="nav nav-tabs" id="basicTab">
+				{{~ it.Content :basicNow:i  }}
+				<li class="{{=i==0?'active':''}}" id="basicTab-li-{{=i}}">
+					<a href="index.html#dstab{{=i}}">{{=basicNow.name}}</a>
+				</li>
+				{{~ }}
+			</ul>
+			<div class="tab-content">
+				{{~ it.Content :basicNow:i  }}
+				<div class="tab-pane {{=i==0?'active':''}}" id="dstab{{=i}}">
 						<table id="dataTable" style="background-color: #fff" class="table table-bordered responsive-utilities">
 							<tr>
 								<td valign="top" class="td_lable lang" langKey="StartTime" style="min-width:80px"> StartTime</td>
-								<td id="StartTime"></td>
+								<td class="StartTime">{{=basicNow.StartTime}}</td>
 							</tr>
 							<tr >
 								<td valign="top" width="100" class="td_lable lang"  langKey="Version">
 									Version
 								</td>
-								<td id="DruidVersion" width="90%"></td>
+								<td class="DruidVersion" width="90%">{{=basicNow.Version}}</td>
 							</tr>
 							<tr >
 								<td valign="top" class="td_lable lang" langKey="Drivers"> Drivers </td>
-								<td id="DruidDrivers"> </td>
+								<td class="DruidDrivers">
+									{{~ basicNow.Drivers :value:index  }}
+									{{=value}}<br>
+									{{~ }}
+								</td>
 							</tr>
 							<tr >
 								<td valign="top" class="td_lable lang" langKey="ResetEnable"> ResetEnable </td>
-								<td id="ResetEnable"></td>
+								<td class="ResetEnable">{{=basicNow.ResetEnable}}</td>
 							</tr>
 							<tr >
 								<td valign="top" class="td_lable lang" langKey="ResetCount"> ResetCount </td>
-								<td id="ResetCount"></td>
+								<td class="ResetCount">{{=basicNow.ResetCount}}</td>
 							</tr>
 							<tr >
 								<td valign="top" class="td_lable lang" langKey="JavaVersion"> JavaVersion </td>
-								<td id="JavaVersion"></td>
+								<td class="JavaVersion">{{=basicNow.JavaVersion}}</td>
 							</tr>
 							<tr >
 								<td valign="top" class="td_lable lang" langKey="JavaVMName"> JavaVMName </td>
-								<td id="JavaVMName"></td>
+								<td class="JavaVMName">{{=basicNow.JavaVMName}}</td>
 							</tr>
 							<tr>
 								<td valign="top" class="td_lable lang" langKey="JavaClassPath"> JavaClassPath </td>
-								<td id="JavaClassPath"></td>
+								<td class="JavaClassPath">{{=basicNow.JavaClassPath}}</td>
 							</tr>
 						</table>
-          			</div>
+				</div>
+				{{~ }}
+			</div>
+		</script>
+	</div>
 		<script type="text/javascript">
 			$.namespace("druid.index");
-			druid.index = function () {  
+			druid.index = function () {
 				return  {
 					init : function() {
 						druid.common.buildHead(0);
 						this.ajaxRequestForBasicInfo();
 					},
-					
+
 					ajaxRequestForBasicInfo : function() {
 						$.ajax({
 							type: 'POST',
 							url: "basic.json",
 							success: function(data) {
-								$("#DruidVersion").text(data.Content.Version)
-								var driversList = data.Content.Drivers;
-								if (driversList) {
-									var driverHtml = '';
-									for ( var i = 0; i < driversList.length; i++) {
-										var driver = driversList[i];
-										driverHtml += driver + '<br/>';
-									}
-									$("#DruidDrivers").html(driverHtml);
-								}
-								$("#ResetEnable").text(data.Content.ResetEnable)
-								$("#ResetCount").text(data.Content.ResetCount)
-								$("#JavaVersion").text(data.Content.JavaVersion)
-								$("#JavaVMName").text(data.Content.JavaVMName)
-								var splittor = /^[a-zA-Z]:\\/g.test(data.Content.JavaClassPath) ? ";" : ":";
-								$("#JavaClassPath").html(data.Content.JavaClassPath.split(splittor).join("<br/>"))
-								$("#StartTime").text(data.Content.StartTime)
-								
+								var tmpl = $('#basic-tmpl').html();
+								var doTtmpl = doT.template(tmpl);
+								var contentHtml = doTtmpl(data);
+								console.log('contentHtml' + contentHtml)
+								$(".span12 h3").after(contentHtml);
+
+								$('#basicTab a').click(function (e) {
+									e.preventDefault();
+									$(this).tab('show');
+								});
+
 								druid.lang.trigger();
 							},
 							dataType: "json"
@@ -92,7 +111,7 @@
 					}
 				}
 			}();
-			
+
 			$(document).ready(function() {
 				druid.index.init();
 			});


### PR DESCRIPTION
1. 新增主页统计信息接口 `/basic.json`，支持获取多服务的聚合统计信息。该功能通过HTTP请求获取每个服务的基本信息，包括版本、驱动程序、重置状态等，并将其聚合在一个统一的响应中。此更改还包括相关的UI更新，以支持显示这些聚合数据。
2. 将fastjson2库从版本2.0.29升级到2.0.52。解决”SQL详情接口“序列化异常的问题。
3. 修改了监控统计服务中数据源名称的显示方式，现在会在原有的数据源名称前后添加服务名称，以“(服务名 数据源名)”的格式显示，增加了数据源识别的清晰度。