### PR TITLE
Set the default value of `testWhileIdle` to `false` to prevent Error Log

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -73,7 +73,7 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
     public static final String DEFAULT_VALIDATION_QUERY = null;                                                //
     public static final boolean DEFAULT_TEST_ON_BORROW = false;
     public static final boolean DEFAULT_TEST_ON_RETURN = false;
-    public static final boolean DEFAULT_WHILE_IDLE = true;
+    public static final boolean DEFAULT_WHILE_IDLE = false;
     public static final long DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS = 60 * 1000L;
     public static final long DEFAULT_TIME_BETWEEN_CONNECT_ERROR_MILLIS = 500;
     public static final int DEFAULT_NUM_TESTS_PER_EVICTION_RUN = 3;


### PR DESCRIPTION
- Set the default value of `testWhileIdle` to `false` to prevent Error Log.
- Fixes #6076.
- Also fixes #1497.
- This is an extension of the investigation of https://github.com/apache/shardingsphere/issues/32765 . When `testWhileIdle` is `true`, `validationQuery` is always required. The `validationQuery` of each database is different, which results in the default value of `validationQuery` can only be empty.
- This will resolve the following Error Log.
```bash
2024-09-11T18:01:52.245+08:00 ERROR 15152 --- [           main] com.alibaba.druid.pool.DruidDataSource   : testWhileIdle is true, validationQuery not set
```