### PR TITLE
Configuring `DefaultAdvisorAutoProxyCreator` when proxying via cglib

### DIFF
--- a/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/stat/DruidSpringAopConfiguration.java
+++ b/druid-spring-boot-3-starter/src/main/java/com/alibaba/druid/spring/boot3/autoconfigure/stat/DruidSpringAopConfiguration.java
@@ -21,6 +21,7 @@ import org.aopalliance.aop.Advice;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.aop.support.RegexpMethodPointcutAdvisor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
@@ -40,6 +41,7 @@ public class DruidSpringAopConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingClass("org.aspectj.weaver.Advice")
     @ConditionalOnProperty(name = "spring.aop.auto", havingValue = "false")
     public DefaultAdvisorAutoProxyCreator advisorAutoProxyCreator() {
         DefaultAdvisorAutoProxyCreator advisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();

--- a/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidSpringAopConfiguration.java
+++ b/druid-spring-boot-starter/src/main/java/com/alibaba/druid/spring/boot/autoconfigure/stat/DruidSpringAopConfiguration.java
@@ -21,6 +21,7 @@ import org.aopalliance.aop.Advice;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.aop.support.RegexpMethodPointcutAdvisor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
@@ -40,6 +41,7 @@ public class DruidSpringAopConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingClass("org.aspectj.weaver.Advice")
     @ConditionalOnProperty(name = "spring.aop.auto", havingValue = "false")
     public DefaultAdvisorAutoProxyCreator advisorAutoProxyCreator() {
         DefaultAdvisorAutoProxyCreator advisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();


### PR DESCRIPTION
- Configuring `DefaultAdvisorAutoProxyCreator` when proxying via cglib.
- Fixes #2770. Fixes #3096 .
- This is an extension of further investigation into https://github.com/apache/shardingsphere/issues/32765 .
- According to https://docs.spring.io/spring-boot/reference/features/aop.html and https://github.com/spring-projects/spring-boot/blob/v3.3.3/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/aop/AopAutoConfiguration.java , auto-configuration for `org.aopalliance.aop.Advice` about `spring.aop` is injected if and only if `aspectjweaver.jar` is on the classpath. Otherwise the cglib proxy is used.
- By default, `com.alibaba:druid:1.2.23` does not depend on `org.aspectj:aspectjweaver:1.9.22.1`. It is necessary to additionally detect whether `org.aspectj.weaver.Advice` exists.