### PR TITLE
添加神通数据库根据jdbcUrl获取DbType的支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
@@ -70,6 +70,7 @@ import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
 import com.alibaba.druid.sql.dialect.oscar.ast.stmt.OscarSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.oscar.parser.OscarExprParser;
 import com.alibaba.druid.sql.dialect.oscar.parser.OscarLexer;
+import com.alibaba.druid.sql.dialect.oscar.visitor.OscarStatementParser;
 import com.alibaba.druid.sql.dialect.phoenix.parser.PhoenixExprParser;
 import com.alibaba.druid.sql.dialect.phoenix.parser.PhoenixLexer;
 import com.alibaba.druid.sql.dialect.phoenix.parser.PhoenixStatementParser;
@@ -196,6 +197,8 @@ public class SQLParserUtils {
                 return new ImpalaStatementParser(sql, features);
             case doris:
                 return new DorisStatementParser(sql, features);
+            case oscar:
+                return new OscarStatementParser(sql, features);
             default:
                 return new SQLStatementParser(sql, dbType, features);
         }

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -664,7 +664,9 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.gaussdb;
         } else if (rawUrl.startsWith("jdbc:TAOS:") || rawUrl.startsWith("jdbc:TAOS-RS:")) {
             return DbType.taosdata;
-        } else {
+        } else if(rawUrl.startsWith("jdbc:oscar:")){
+            return DbType.oscar;
+        }else {
             return null;
         }
     }

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -664,9 +664,9 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.gaussdb;
         } else if (rawUrl.startsWith("jdbc:TAOS:") || rawUrl.startsWith("jdbc:TAOS-RS:")) {
             return DbType.taosdata;
-        } else if(rawUrl.startsWith("jdbc:oscar:")){
+        } else if (rawUrl.startsWith("jdbc:oscar:")) {
             return DbType.oscar;
-        }else {
+        } else {
             return null;
         }
     }


### PR DESCRIPTION
seata使用druid作为DbTypeParser，无法解析神通的jdbcUrl,添加神通数据库根据url判断类型枚举的逻辑