### PR TITLE
Add property `closeConnOnFatalError` to match HikariCP's behavior

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -147,6 +147,7 @@ public class DruidDataSource extends DruidAbstractDataSource
     private boolean asyncInit;
     protected boolean killWhenSocketReadTimeout;
     protected boolean checkExecuteTime;
+    protected boolean closeConnOnFatalError = true;
 
     private static List<Filter> autoFilters;
     private boolean loadSpifilterSkip;
@@ -183,6 +184,14 @@ public class DruidDataSource extends DruidAbstractDataSource
 
     public void setAsyncInit(boolean asyncInit) {
         this.asyncInit = asyncInit;
+    }
+
+    public boolean isCloseConnOnFatalError() {
+        return closeConnOnFatalError;
+    }
+
+    public void setCloseConnOnFatalError(boolean closeConnOnFatalError) {
+        this.closeConnOnFatalError = closeConnOnFatalError;
     }
 
     @Deprecated
@@ -1640,7 +1649,7 @@ public class DruidDataSource extends DruidAbstractDataSource
         ReentrantLock fatalErrorCountLock = hasHolderDataSource ? holder.getDataSource().lock : conn.lock;
         fatalErrorCountLock.lock();
         try {
-            if ((!conn.closed) && !conn.disable) {
+            if ((!conn.closed) && !conn.disable && isCloseConnOnFatalError()) {
                 conn.disable(error);
                 requireDiscard = true;
             }

--- a/core/src/main/java/com/alibaba/druid/util/DruidDataSourceUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/DruidDataSourceUtils.java
@@ -326,5 +326,6 @@ public class DruidDataSourceUtils {
         trySetIntProperty(properties, "druid.socketTimeout", druidDataSource::setSocketTimeout);
         trySetIntProperty(properties, "druid.transactionQueryTimeout", druidDataSource::setTransactionQueryTimeout);
         trySetIntProperty(properties, "druid.loginTimeout", druidDataSource::setLoginTimeout);
+        trySetBooleanProperty(properties, "druid.closeConnOnFatalError", druidDataSource::setCloseConnOnFatalError);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/util/DruidDataSourceUtilsTest.java
+++ b/core/src/test/java/com/alibaba/druid/util/DruidDataSourceUtilsTest.java
@@ -396,6 +396,8 @@ public class DruidDataSourceUtilsTest extends TestCase {
         properties.put("druid.disableException", druidDisableException);
         String druidInstanceKey = "@lizongbo";
         properties.put("druid.instanceKey", druidInstanceKey);
+        String druidCloseConnOnFatalError = "false";
+        properties.put("druid.closeConnOnFatalError", druidCloseConnOnFatalError);
 
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.configFromPropeties(properties);
@@ -455,6 +457,7 @@ public class DruidDataSourceUtilsTest extends TestCase {
         assertEquals(druidKillWhenSocketReadTimeout, String.valueOf(dataSource.isKillWhenSocketReadTimeout()));
         //assertEquals(druidCheckExecuteTime, String.valueOf(dataSource.isCheckExecuteTime()));
         //assertEquals(druidLoadSpifilterSkip, String.valueOf(dataSource.isLoadSpifilterSkip()));
+        assertEquals(druidCloseConnOnFatalError, String.valueOf(dataSource.isCloseConnOnFatalError()));
     }
 
     public void testGenTestCode() {


### PR DESCRIPTION
- Add property `closeConnOnFatalError` to match HikariCP's behavior.
- Fixes https://github.com/apache/shardingsphere/issues/32765 .
- Also fixes #6050 . Also fixes #5963 . Also fixes #4188 . Also fixes #4013 . Also fixes #3626 . Also fixes #2404 .
- By setting `closeConnOnFatalError` to `false`, Druid's behavior will align with HikariCP, that is, the connection will no longer be closed when a fatal error defined by Druid occurs. This solves a series of controversies surrounding Spring Boot, Hibernate, Flyway, and ShardingSphere. This is a huge regret introduced from https://github.com/alibaba/druid/commit/882470b1ce7a51a94f3525beceec91384ccd425f 7 years ago.
```yaml
dataSources:
  db:
    dataSourceClassName: com.alibaba.druid.pool.DruidDataSource
    driverClassName: com.mysql.cj.jdbc.Driver
    url: jdbc:mysql://127.0.0.1:3306/demo_ds?serverTimezone=UTC
    username: root
    password: 
    closeConnOnFatalError: false
```
- Also see https://github.com/flyway/flyway/issues/2240#issuecomment-494743566 .
> The connection pool shouldn't close a connection after an exception. Please file an issue with them.