### PR TITLE
添加对科蓝sundb数据库的支持

### DIFF
--- a/core/src/main/java/com/alibaba/druid/DbType.java
+++ b/core/src/main/java/com/alibaba/druid/DbType.java
@@ -102,7 +102,8 @@ public enum DbType {
     pointbase(0),
     edbc(0),
     mimer(0),
-    taosdata(0);
+    taosdata(0),
+    sundb(0);
 
     public final long mask;
     public final long hashCode64;

--- a/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -167,4 +167,6 @@ public interface JdbcConstants {
     String GBASE8S_DRIVER = "com.gbasedbt.jdbc.Driver";
 
     String OPENGAUSS_DRIVER = "org.opengauss.Driver";
+    String SUNDB = "sundb"; //科蓝数s据
+    String SUNDB_DRIVER = "csii.sundb.jdbc.SundbDriver";
 }

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -543,6 +543,8 @@ public final class JdbcUtils implements JdbcConstants {
             return JdbcConstants.TAOS_DATA_RS;
         } else if (rawUrl.startsWith("jdbc:gbasedbt-sqli:")) {
             return JdbcConstants.GBASE8S_DRIVER;
+        } else if (rawUrl.startsWith("jdbc:sundb:")) {
+            return JdbcConstants.SUNDB_DRIVER;
         } else {
             throw new SQLException("unknown jdbc driver : " + rawUrl);
         }
@@ -666,6 +668,8 @@ public final class JdbcUtils implements JdbcConstants {
             return DbType.taosdata;
         } else if (rawUrl.startsWith("jdbc:oscar:")) {
             return DbType.oscar;
+        } else if (rawUrl.startsWith("jdbc:sundb:")) {
+            return DbType.sundb;
         } else {
             return null;
         }


### PR DESCRIPTION
seata使用druid作为DbTypeParser，无法解析SunDb的jdbcUrl,添加科蓝SunDB数据库根据url判断类型枚举的逻辑