### PR TITLE
fix: Parse Oracle open cursor statement SQL error when parameters con…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLOpenStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLOpenStatement.java
@@ -31,7 +31,7 @@ public class SQLOpenStatement extends SQLStatementImpl {
     //cursor name
     private SQLName cursorName;
 
-    private final List<SQLName> columns = new ArrayList<SQLName>();
+    private final List<SQLExpr> columns = new ArrayList<SQLExpr>();
 
     private SQLExpr forExpr;
 
@@ -76,7 +76,7 @@ public class SQLOpenStatement extends SQLStatementImpl {
         this.forExpr = forExpr;
     }
 
-    public List<SQLName> getColumns() {
+    public List<SQLExpr> getColumns() {
         return columns;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -5326,7 +5326,7 @@ public class SQLStatementParser extends SQLParser {
 
         if (lexer.token == Token.LPAREN) {
             lexer.nextToken();
-            this.exprParser.names(stmt.getColumns(), stmt);
+            this.exprParser.exprList(stmt.getColumns(), stmt);
             accept(Token.RPAREN);
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -7376,7 +7376,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         print0(ucase ? "OPEN " : "open ");
         printExpr(x.getCursorName(), parameterized);
 
-        List<SQLName> columns = x.getColumns();
+        List<SQLExpr> columns = x.getColumns();
         if (columns.size() > 0) {
             print('(');
             printAndAccept(columns, ", ");

--- a/core/src/test/java/com/alibaba/druid/sql/parser/OracleCursorOpenTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/parser/OracleCursorOpenTest.java
@@ -1,0 +1,30 @@
+package com.alibaba.druid.sql.parser;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.List;
+
+public class OracleCursorOpenTest extends TestCase {
+    public void test_open_cursor_with_method() {
+        String sql = "create or replace procedure proc_test1 (myArray in self_define_array) is \n" +
+                "\n" +
+                "CURSOR c_test (p1 varchar2) is\n" +
+                "select\n" +
+                "     *\n" +
+                "from\n" +
+                "     test1\n" +
+                "where\n" +
+                "     id = p1;\n" +
+                "\n" +
+                "BEGIN OPEN c_test (myArray (1));\n" +
+                "\n" +
+                "END proc_test1;";
+        List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DbType.oracle);
+        System.out.println(sqlStatements);
+        Assert.assertFalse(sqlStatements.isEmpty());
+    }
+}


### PR DESCRIPTION
The parameters of oracle open cursor statement should be SQLExpr.

#6183 