### PR TITLE
验证时，只要不报错就认为连接有效

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/ValidConnectionCheckerAdapter.java
+++ b/core/src/main/java/com/alibaba/druid/pool/ValidConnectionCheckerAdapter.java
@@ -66,7 +66,7 @@ public class ValidConnectionCheckerAdapter implements ValidConnectionChecker {
                 stmt.setQueryTimeout(validationQueryTimeout);
             }
             rs = stmt.executeQuery(query);
-            return rs.next();
+            return true;
         } finally {
             JdbcUtils.close(rs);
             if (!isDruidStatementConnection) {


### PR DESCRIPTION
Oracle JDBC连接初始化时无法指定Schema（与登录用户不同），通过验证连接进行状态验证的同时切换Schema（alter session set current_schema = xxxx），该语句没有返回值，rs.next()是false，导致使用异常