### PR TITLE
Improve oracle schema statistics

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
@@ -52,11 +52,11 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
     private static final Set<Long> FUNCTIONS_IDENT;
     private static final Set<Long> IMPLICIT_CURSOR_ATTRIBUTES;
 
-	static {
-		PSEUDO_COLUMNS = new HashSet<>();
-		PSEUDO_COLUMNS.add(FnvHash.Constants.ROWID);
-		PSEUDO_COLUMNS.add(FnvHash.Constants.ROWNUM);
-		PSEUDO_COLUMNS.add(FnvHash.Constants.LEVEL);
+    static {
+        PSEUDO_COLUMNS = new HashSet<>();
+        PSEUDO_COLUMNS.add(FnvHash.Constants.ROWID);
+        PSEUDO_COLUMNS.add(FnvHash.Constants.ROWNUM);
+        PSEUDO_COLUMNS.add(FnvHash.Constants.LEVEL);
 
         FUNCTIONS_IDENT = new HashSet<>();
         FUNCTIONS_IDENT.add(FnvHash.Constants.SYSDATE);
@@ -72,9 +72,9 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
         IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.ROWCOUNT);
         IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.BULK_ROWCOUNT);
         IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.BULK_EXCEPTIONS);
-	}
+    }
 
-	public OracleSchemaStatVisitor() {
+    public OracleSchemaStatVisitor() {
         this(new ArrayList<Object>());
     }
 
@@ -580,21 +580,21 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
             SQLExpr valueExpr = null;
             if (x.getParent() instanceof SQLBlockStatement) {
                 List<SQLStatement> statementList = ((SQLBlockStatement) x.getParent()).getStatementList();
-				for (SQLStatement stmt : statementList) {
-					if (stmt == x) {
-						break;
-					}
+                for (SQLStatement stmt : statementList) {
+                    if (stmt == x) {
+                        break;
+                    }
 
-					if (stmt instanceof SQLSetStatement) {
-						List<SQLAssignItem> items = ((SQLSetStatement) stmt).getItems();
-						for (SQLAssignItem item : items) {
-							if (item.getTarget().equals(dynamicSql)) {
-								valueExpr = item.getValue();
-								break;
-							}
-						}
-					}
-				}
+                    if (stmt instanceof SQLSetStatement) {
+                        List<SQLAssignItem> items = ((SQLSetStatement) stmt).getItems();
+                        for (SQLAssignItem item : items) {
+                            if (item.getTarget().equals(dynamicSql)) {
+                                valueExpr = item.getValue();
+                                break;
+                            }
+                        }
+                    }
+                }
             }
 
             if (valueExpr != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
@@ -360,12 +360,7 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
     public boolean visit(OracleExceptionStatement.Item x) {
         SQLExpr when = x.getWhen();
         if (when instanceof SQLIdentifierExpr) {
-            SQLIdentifierExpr ident = (SQLIdentifierExpr) when;
-            if (ident.getName().equalsIgnoreCase("OTHERS")) {
-                // skip
-            } else {
-                this.visit(ident);
-            }
+            return false;
         } else if (when != null) {
             when.accept(this);
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleSchemaStatVisitor.java
@@ -43,10 +43,38 @@ import com.alibaba.druid.stat.TableStat.Mode;
 import com.alibaba.druid.util.FnvHash;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class OracleSchemaStatVisitor extends SchemaStatVisitor implements OracleASTVisitor {
-    public OracleSchemaStatVisitor() {
+    private static final Set<Long> PSEUDO_COLUMNS;
+    private static final Set<Long> FUNCTIONS_IDENT;
+    private static final Set<Long> IMPLICIT_CURSOR_ATTRIBUTES;
+
+	static {
+		PSEUDO_COLUMNS = new HashSet<>();
+		PSEUDO_COLUMNS.add(FnvHash.Constants.ROWID);
+		PSEUDO_COLUMNS.add(FnvHash.Constants.ROWNUM);
+		PSEUDO_COLUMNS.add(FnvHash.Constants.LEVEL);
+
+        FUNCTIONS_IDENT = new HashSet<>();
+        FUNCTIONS_IDENT.add(FnvHash.Constants.SYSDATE);
+        FUNCTIONS_IDENT.add(FnvHash.Constants.CURRENT_DATE);
+        FUNCTIONS_IDENT.add(FnvHash.Constants.CURRENT_TIMESTAMP);
+        FUNCTIONS_IDENT.add(FnvHash.Constants.SYSTIMESTAMP);
+        FUNCTIONS_IDENT.add(FnvHash.Constants.SQLCODE);
+        FUNCTIONS_IDENT.add(FnvHash.Constants.SQLERRM);
+
+        IMPLICIT_CURSOR_ATTRIBUTES = new HashSet<>();
+        IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.FOUND);
+        IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.NOTFOUND);
+        IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.ROWCOUNT);
+        IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.BULK_ROWCOUNT);
+        IMPLICIT_CURSOR_ATTRIBUTES.add(FnvHash.Constants.BULK_EXCEPTIONS);
+	}
+
+	public OracleSchemaStatVisitor() {
         this(new ArrayList<Object>());
     }
 
@@ -176,21 +204,50 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
         }
 
         long hashCode64 = x.hashCode64();
-
-        if (hashCode64 == FnvHash.Constants.ROWNUM
-                || hashCode64 == FnvHash.Constants.SYSDATE
-                || hashCode64 == FnvHash.Constants.LEVEL
-                || hashCode64 == FnvHash.Constants.SQLCODE) {
-            return false;
-        }
-
-        if (hashCode64 == FnvHash.Constants.ISOPEN
-                && x.getParent() instanceof SQLBinaryOpExpr
-                && ((SQLBinaryOpExpr) x.getParent()).getOperator() == SQLBinaryOperator.Modulus) {
+        if (isPseudoColumn(hashCode64) || isFunctionIdentifier(hashCode64) ||
+                isImplicitCursorBinaryExpr(x.getParent())) {
             return false;
         }
 
         return super.visit(x);
+    }
+
+    // This is to override the default behavior of the {@link SchemaStatVisitor} to ignore pseudo columns.
+    @Override
+    protected boolean isPseudoColumn(long hash) {
+        // Pseudo columns which are not covered by {@link SchemaStatVisitor} to ignore. Not all pseudo
+        // columns are ignored, for example, wildcard * is not ignored.
+        return PSEUDO_COLUMNS.contains(hash);
+    }
+
+    protected boolean isFunctionIdentifier(long hash) {
+        return FUNCTIONS_IDENT.contains(hash);
+    }
+
+    private static boolean isImplicitCursorBinaryExpr(SQLObject sqlObject) {
+        if (!(sqlObject instanceof SQLBinaryOpExpr)) {
+            return false;
+        }
+
+        SQLBinaryOpExpr sqlBinaryOpExpr = (SQLBinaryOpExpr) sqlObject;
+        if (sqlBinaryOpExpr.getOperator() == SQLBinaryOperator.Modulus) {
+            SQLExpr left = sqlBinaryOpExpr.getLeft();
+            SQLExpr right = sqlBinaryOpExpr.getRight();
+            return isImplicitCursorBinaryExpr(left, right);
+        }
+
+        return false;
+    }
+
+    private static boolean isImplicitCursorBinaryExpr(SQLExpr left, SQLExpr right) {
+        // Change: if it is an implicit cursor, skip it
+        if (left instanceof SQLIdentifierExpr && right instanceof SQLIdentifierExpr) {
+            long leftHashCode64 = ((SQLIdentifierExpr) left).hashCode64();
+            long rightHashCode64 = ((SQLIdentifierExpr) right).hashCode64();
+            return leftHashCode64 == FnvHash.Constants.SQL && IMPLICIT_CURSOR_ATTRIBUTES.contains(rightHashCode64);
+        }
+
+        return false;
     }
 
     @Override
@@ -528,22 +585,21 @@ public class OracleSchemaStatVisitor extends SchemaStatVisitor implements Oracle
             SQLExpr valueExpr = null;
             if (x.getParent() instanceof SQLBlockStatement) {
                 List<SQLStatement> statementList = ((SQLBlockStatement) x.getParent()).getStatementList();
-                for (int i = 0, size = statementList.size(); i < size; ++i) {
-                    SQLStatement stmt = statementList.get(i);
-                    if (stmt == x) {
-                        break;
-                    }
+				for (SQLStatement stmt : statementList) {
+					if (stmt == x) {
+						break;
+					}
 
-                    if (stmt instanceof SQLSetStatement) {
-                        List<SQLAssignItem> items = ((SQLSetStatement) stmt).getItems();
-                        for (SQLAssignItem item : items) {
-                            if (item.getTarget().equals(dynamicSql)) {
-                                valueExpr = item.getValue();
-                                break;
-                            }
-                        }
-                    }
-                }
+					if (stmt instanceof SQLSetStatement) {
+						List<SQLAssignItem> items = ((SQLSetStatement) stmt).getItems();
+						for (SQLAssignItem item : items) {
+							if (item.getTarget().equals(dynamicSql)) {
+								valueExpr = item.getValue();
+								break;
+							}
+						}
+					}
+				}
             }
 
             if (valueExpr != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
@@ -861,8 +861,6 @@ public class SchemaStatVisitor extends SQLASTVisitorAdapter {
     }
 
     protected Column getColumn(SQLExpr expr) {
-        final SQLExpr original = expr;
-
         // unwrap
         expr = unwrapExpr(expr);
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
@@ -876,7 +876,8 @@ public class SchemaStatVisitor extends SQLASTVisitorAdapter {
                 SQLObject resolvedOwnerObject = propertyExpr.getResolvedOwnerObject();
                 if (resolvedOwnerObject instanceof SQLSubqueryTableSource
                         || resolvedOwnerObject instanceof SQLCreateProcedureStatement
-                        || resolvedOwnerObject instanceof SQLCreateFunctionStatement) {
+                        || resolvedOwnerObject instanceof SQLCreateFunctionStatement
+                        || resolvedOwnerObject instanceof SQLParameter) {
                     table = null;
                 }
 

--- a/core/src/main/java/com/alibaba/druid/util/FnvHash.java
+++ b/core/src/main/java/com/alibaba/druid/util/FnvHash.java
@@ -357,7 +357,7 @@ public final class FnvHash {
         return hashCode;
     }
 
-    public static interface Constants {
+    public interface Constants {
         long HIGH_PRIORITY = fnv1a_64_lower("HIGH_PRIORITY");
         long DISTINCTROW = fnv1a_64_lower("DISTINCTROW");
         long STRAIGHT = fnv1a_64_lower("STRAIGHT");
@@ -528,6 +528,7 @@ public final class FnvHash {
         long SUBTIME = fnv1a_64_lower("SUBTIME");
         long TIMEDIFF = fnv1a_64_lower("TIMEDIFF");
         long SQLCODE = fnv1a_64_lower("SQLCODE");
+        long SQLERRM = fnv1a_64_lower("SQLERRM");
         long PRECISION = fnv1a_64_lower("PRECISION");
         long DOUBLE = fnv1a_64_lower("DOUBLE");
         long DOUBLE_PRECISION = fnv1a_64_lower("DOUBLE PRECISION");
@@ -736,6 +737,11 @@ public final class FnvHash {
         long ENDS = fnv1a_64_lower("ENDS");
         long BINARY = fnv1a_64_lower("BINARY");
         long GEOMETRY = fnv1a_64_lower("GEOMETRY");
+        long FOUND = fnv1a_64_lower("FOUND");
+        long NOTFOUND = fnv1a_64_lower("NOTFOUND");
+        long ROWCOUNT = fnv1a_64_lower("ROWCOUNT");
+        long BULK_ROWCOUNT = fnv1a_64_lower("BULK_ROWCOUNT");
+        long BULK_EXCEPTIONS = fnv1a_64_lower("BULK_EXCEPTIONS");
         long ISOPEN = fnv1a_64_lower("ISOPEN");
         long CONFLICT = fnv1a_64_lower("CONFLICT");
         long NOTHING = fnv1a_64_lower("NOTHING");

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest12.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest12.java
@@ -76,7 +76,7 @@ public class OracleBlockTest12 extends OracleTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("emp_sal")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("emp_job")));
 
-        Assert.assertEquals(11, visitor.getColumns().size());
+        Assert.assertEquals(10, visitor.getColumns().size());
         Assert.assertEquals(1, visitor.getConditions().size());
 
 //        Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("employees", "salary")));

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest13.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest13.java
@@ -78,7 +78,7 @@ public class OracleBlockTest13 extends OracleTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("employees")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("emp_name")));
 
-        Assert.assertEquals(7, visitor.getColumns().size());
+        Assert.assertEquals(6, visitor.getColumns().size());
         Assert.assertEquals(2, visitor.getConditions().size());
         Assert.assertEquals(0, visitor.getRelationships().size());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest14.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/block/OracleBlockTest14.java
@@ -79,7 +79,7 @@ public class OracleBlockTest14 extends OracleTest {
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("employees")));
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("emp_name")));
 
-        Assert.assertEquals(7, visitor.getColumns().size());
+        Assert.assertEquals(6, visitor.getColumns().size());
         Assert.assertEquals(2, visitor.getConditions().size());
         Assert.assertEquals(0, visitor.getRelationships().size());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateFunctionTest_3.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateFunctionTest_3.java
@@ -132,8 +132,7 @@ public class OracleCreateFunctionTest_3 extends OracleTest {
         System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         assertEquals(1, visitor.getTables().size());
-
-        assertEquals(1, visitor.getColumns().size());
+        assertEquals(0, visitor.getColumns().size());
 
 //        assertTrue(visitor.getColumns().contains(new TableStat.Column("orders", "order_total")));
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateMaterializedViewTest0.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateMaterializedViewTest0.java
@@ -69,7 +69,7 @@ public class OracleCreateMaterializedViewTest0 extends OracleTest {
 
         assertEquals(1, visitor.getTables().size());
 
-        assertEquals(4, visitor.getColumns().size());
+        assertEquals(3, visitor.getColumns().size());
 
         assertTrue(visitor.getColumns().contains(new TableStat.Column("invoice", "seller_no")));
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest1.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest1.java
@@ -35,10 +35,9 @@ public class OracleCreateProcedureTest1 extends OracleTest {
                 " " +
                 "  IF SQL%FOUND THEN" +
                 "    DBMS_OUTPUT.PUT_LINE (" +
-                "      'Delete succeeded for department number ' || dept_no" +
-                "    );" +
+                "      'Delete succeeded for department number');" +
                 "  ELSE" +
-                "    DBMS_OUTPUT.PUT_LINE ('No department number ' || dept_no);" +
+                "    DBMS_OUTPUT.PUT_LINE ('No department number');" +
                 "  END IF;" +
                 "END;" +
                 "/" +
@@ -68,7 +67,8 @@ public class OracleCreateProcedureTest1 extends OracleTest {
 
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("dept_temp")));
 
-//        Assert.assertEquals(7, visitor.getColumns().size());
+        Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertEquals(1, visitor.getColumns().size());
         Assert.assertEquals(1, visitor.getConditions().size());
         Assert.assertEquals(0, visitor.getRelationships().size());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest1.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest1.java
@@ -64,14 +64,60 @@ public class OracleCreateProcedureTest1 extends OracleTest {
         System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertEquals(1, visitor.getColumns().size());
+        Assert.assertEquals(1, visitor.getConditions().size());
+        Assert.assertEquals(0, visitor.getRelationships().size());
 
+        Assert.assertEquals(1, visitor.getTables().size());
         Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("dept_temp")));
+        Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("dept_temp", "department_id")));
+    }
+
+    public void test_1() throws Exception {
+        String sql = "CREATE OR REPLACE PROCEDURE p (" +
+                "  dept_no NUMBER" +
+                ") AS " +
+                "BEGIN" +
+                "  DELETE FROM dept_temp" +
+                "  WHERE department_id = dept_no;" +
+                " " +
+                "  IF SQL%NOTFOUND THEN" +
+                "    DBMS_OUTPUT.PUT_LINE (" +
+                "      'No department number');" +
+                "  ELSE" +
+                "    DBMS_OUTPUT.PUT_LINE ('Delete succeeded for department number');" +
+                "  END IF;" +
+                "END;" +
+                "/" +
+                "BEGIN" +
+                "  p(270);" +
+                "  p(400);" +
+                "END;"; //
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        print(statementList);
+
+        Assert.assertEquals(3, statementList.size());
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        for (SQLStatement statement : statementList) {
+            statement.accept(visitor);
+        }
+
+        System.out.println("Tables : " + visitor.getTables());
+        System.out.println("fields : " + visitor.getColumns());
+        System.out.println("coditions : " + visitor.getConditions());
+        System.out.println("relationships : " + visitor.getRelationships());
+        System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         Assert.assertEquals(1, visitor.getTables().size());
         Assert.assertEquals(1, visitor.getColumns().size());
         Assert.assertEquals(1, visitor.getConditions().size());
         Assert.assertEquals(0, visitor.getRelationships().size());
 
-        // Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("employees", "salary")));
+        Assert.assertEquals(1, visitor.getTables().size());
+        Assert.assertTrue(visitor.getTables().containsKey(new TableStat.Name("dept_temp")));
+        Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("dept_temp", "department_id")));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest4.java
@@ -187,9 +187,9 @@ public class OracleCreateProcedureTest4 extends OracleTest {
 
         assertTrue(visitor.getTables().containsKey(new TableStat.Name("fact_brand_provider")));
 
-        assertEquals(23, visitor.getColumns().size());
-        assertEquals(6, visitor.getConditions().size());
-        assertEquals(4, visitor.getRelationships().size());
+        assertEquals(22, visitor.getColumns().size());
+        assertEquals(5, visitor.getConditions().size());
+        assertEquals(1, visitor.getRelationships().size());
 
         assertTrue(visitor.containsColumn("fact_brand_provider", "gyscode"));
         assertTrue(visitor.containsColumn("fact_brand_provider", "gysname"));

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/create/OracleCreateProcedureTest4.java
@@ -187,7 +187,7 @@ public class OracleCreateProcedureTest4 extends OracleTest {
 
         assertTrue(visitor.getTables().containsKey(new TableStat.Name("fact_brand_provider")));
 
-        assertEquals(24, visitor.getColumns().size());
+        assertEquals(23, visitor.getColumns().size());
         assertEquals(6, visitor.getConditions().size());
         assertEquals(4, visitor.getRelationships().size());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/insert/OracleInsertTest2.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/insert/OracleInsertTest2.java
@@ -61,5 +61,4 @@ public class OracleInsertTest2 extends OracleTest {
         Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("employees", "job_id")));
         Assert.assertTrue(visitor.getColumns().contains(new TableStat.Column("employees", "salary")));
     }
-
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest110.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest110.java
@@ -177,7 +177,7 @@ public class OracleSelectTest110 extends OracleTest {
         System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         assertEquals(1, visitor.getTables().size());
-        assertEquals(30, visitor.getColumns().size());
+        assertEquals(29, visitor.getColumns().size());
         assertEquals(1, visitor.getConditions().size());
         assertEquals(0, visitor.getRelationships().size());
         assertEquals(0, visitor.getOrderByColumns().size());


### PR DESCRIPTION
Changes:
- Avoid the following cases where invalid columns are added in schema statistics
  - Oracle PL/SQL implicit cursors
    - `IF SQL%FOUND`, `IF SQL%NOTFOUND` etc...
  - Oracle exception in `when` clause:
    - `WHEN NO_DATA_FOUND`, `WHEN TOO_MANY_ROWS` etc
    - Custom exceptions
  - Oracle PL/SQL declared variables