### PR TITLE
Fix the property name of connectionInitSqls in DruidDataSourceFactory

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSourceFactory.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSourceFactory.java
@@ -57,7 +57,7 @@ public class DruidDataSourceFactory implements ObjectFactory {
     public static final String PROP_USERNAME = "username";
     public static final String PROP_VALIDATIONQUERY = "validationQuery";
     public static final String PROP_VALIDATIONQUERY_TIMEOUT = "validationQueryTimeout";
-    public static final String PROP_INITCONNECTIONSQLS = "initConnectionSqls";
+    public static final String PROP_CONNECTIONINITSQLS = "connectionInitSqls";
     public static final String PROP_ACCESSTOUNDERLYINGCONNECTIONALLOWED = "accessToUnderlyingConnectionAllowed";
     public static final String PROP_REMOVEABANDONED = "removeAbandoned";
     public static final String PROP_REMOVEABANDONEDTIMEOUT = "removeAbandonedTimeout";
@@ -97,7 +97,7 @@ public class DruidDataSourceFactory implements ObjectFactory {
             PROP_USERNAME,
             PROP_VALIDATIONQUERY,
             PROP_VALIDATIONQUERY_TIMEOUT,
-            PROP_INITCONNECTIONSQLS,
+            PROP_CONNECTIONINITSQLS,
             PROP_ACCESSTOUNDERLYINGCONNECTIONALLOWED,
             PROP_REMOVEABANDONED,
             PROP_REMOVEABANDONEDTIMEOUT,
@@ -368,7 +368,7 @@ public class DruidDataSourceFactory implements ObjectFactory {
             dataSource.setExceptionSorter(value);
         }
 
-        value = (String) properties.get(PROP_INITCONNECTIONSQLS);
+        value = (String) properties.get(PROP_CONNECTIONINITSQLS);
         if (value != null) {
             StringTokenizer tokenizer = new StringTokenizer(value, ";");
             dataSource.setConnectionInitSqls(Collections.list(tokenizer));

--- a/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest_initSql_factory.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/pool/DruidDataSourceTest_initSql_factory.java
@@ -17,7 +17,7 @@ public class DruidDataSourceTest_initSql_factory extends TestCase {
     protected void setUp() throws Exception {
         Properties properties = new Properties();
         properties.put(DruidDataSourceFactory.PROP_URL, "jdbc:mock:xxx");
-        properties.put(DruidDataSourceFactory.PROP_INITCONNECTIONSQLS, ";;select 123");
+        properties.put(DruidDataSourceFactory.PROP_CONNECTIONINITSQLS, ";;select 123");
         dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(properties);
     }
 


### PR DESCRIPTION
The property values in DruidDataSourceFactory are inconsistent with the external documentation, so the external documentation should take precedence.  https://github.com/alibaba/druid/wiki/DruidDataSource%E9%85%8D%E7%BD%AE