### PR TITLE
1. 支持 pg create/alter/drop schema 语句中同时指定库。

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGAlterSchemaStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGAlterSchemaStatement.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
 
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStatementImpl;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.SQLAlterStatement;
@@ -22,15 +23,15 @@ import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class PGAlterSchemaStatement extends SQLStatementImpl implements PGSQLStatement, SQLAlterStatement {
-    private SQLIdentifierExpr schemaName;
+    private SQLName schemaName;
     private SQLIdentifierExpr newName;
     private SQLIdentifierExpr newOwner;
 
-    public SQLIdentifierExpr getSchemaName() {
+    public SQLName getSchemaName() {
         return schemaName;
     }
 
-    public void setSchemaName(SQLIdentifierExpr schemaName) {
+    public void setSchemaName(SQLName schemaName) {
         this.schemaName = schemaName;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGCreateSchemaStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGCreateSchemaStatement.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
 
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStatementImpl;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.SQLCreateStatement;
@@ -25,17 +26,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PGCreateSchemaStatement extends SQLStatementImpl implements PGSQLStatement, SQLCreateStatement {
-    private SQLIdentifierExpr schemaName;
+    private SQLName schemaName;
     private SQLIdentifierExpr userName;
     private boolean ifNotExists;
     private boolean authorization;
     private List<SQLCreateStatement> createStatements = new ArrayList<>();
 
-    public SQLIdentifierExpr getSchemaName() {
+    public SQLName getSchemaName() {
         return schemaName;
     }
 
-    public void setSchemaName(SQLIdentifierExpr schemaName) {
+    public void setSchemaName(SQLName schemaName) {
         this.schemaName = schemaName;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGDropSchemaStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGDropSchemaStatement.java
@@ -15,8 +15,8 @@
  */
 package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
 
+import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStatementImpl;
-import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.SQLDropStatement;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
@@ -25,25 +25,25 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PGDropSchemaStatement extends SQLStatementImpl implements PGSQLStatement, SQLDropStatement {
-    private SQLIdentifierExpr schemaName;
-    private List<SQLIdentifierExpr> multipleNames = new ArrayList<>();
+    private SQLName schemaName;
+    private List<SQLName> multipleNames = new ArrayList<>();
     private boolean ifExists;
     private boolean cascade;
     private boolean restrict;
 
-    public SQLIdentifierExpr getSchemaName() {
+    public SQLName getSchemaName() {
         return this.schemaName;
     }
 
-    public void setSchemaName(SQLIdentifierExpr schemaName) {
+    public void setSchemaName(SQLName schemaName) {
         this.schemaName = schemaName;
     }
 
-    public List<SQLIdentifierExpr> getMultipleNames() {
+    public List<SQLName> getMultipleNames() {
         return this.multipleNames;
     }
 
-    public void setMultipleNames(List<SQLIdentifierExpr> multipleNames) {
+    public void setMultipleNames(List<SQLName> multipleNames) {
         this.multipleNames = multipleNames;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -299,8 +299,7 @@ public class PGSQLStatementParser extends SQLStatementParser {
                 SQLIdentifierExpr userName = (SQLIdentifierExpr) this.exprParser.expr();
                 stmt.setUserName(userName);
             } else {
-                SQLIdentifierExpr schemaName = (SQLIdentifierExpr) this.exprParser.expr();
-                stmt.setSchemaName(schemaName);
+                stmt.setSchemaName(this.exprParser.name());
 
                 if (lexer.identifierEquals("AUTHORIZATION")) {
                     lexer.nextToken();
@@ -350,7 +349,7 @@ public class PGSQLStatementParser extends SQLStatementParser {
         accept(Token.SCHEMA);
 
         PGAlterSchemaStatement stmt = new PGAlterSchemaStatement();
-        stmt.setSchemaName(this.exprParser.identifier());
+        stmt.setSchemaName(this.exprParser.name());
 
         if (lexer.identifierEquals(FnvHash.Constants.RENAME)) {
             lexer.nextToken();
@@ -416,13 +415,13 @@ public class PGSQLStatementParser extends SQLStatementParser {
             stmt.setIfExists(true);
         }
 
-        SQLIdentifierExpr name = this.exprParser.identifier();
+        SQLName name = this.exprParser.name();
         stmt.setSchemaName(name);
         stmt.getMultipleNames().add(name);
 
         while (lexer.token() == COMMA) {
             lexer.nextToken();
-            stmt.getMultipleNames().add(this.exprParser.identifier());
+            stmt.getMultipleNames().add(this.exprParser.name());
         }
 
         if (lexer.token() == Token.CASCADE) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -729,7 +729,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             printUcase("IF EXISTS ");
         }
 
-        List<SQLIdentifierExpr> multipleName = x.getMultipleNames();
+        List<SQLName> multipleName = x.getMultipleNames();
         for (int i = 0; i < multipleName.size(); i++) {
             if (i > 0) {
                 printUcase(", ");

--- a/core/src/test/resources/bvt/parser/postgresql/20.txt
+++ b/core/src/test/resources/bvt/parser/postgresql/20.txt
@@ -1,3 +1,11 @@
+create schema abc
+--------------------
+CREATE SCHEMA abc
+------------------------------------------------------------------------------------------------------------------------
+create schema abc.abc
+--------------------
+CREATE SCHEMA abc.abc
+------------------------------------------------------------------------------------------------------------------------
 create schema abc create table test_user (id int primary key,name varchar(50));
 --------------------
 CREATE SCHEMA abc CREATE TABLE test_user (
@@ -28,3 +36,19 @@ DROP SCHEMA IF EXISTS abc CASCADE
 drop schema abc, ccc ,aac
 --------------------
 DROP SCHEMA abc, ccc, aac
+------------------------------------------------------------------------------------------------------------------------
+create schema abc
+--------------------
+CREATE SCHEMA abc
+------------------------------------------------------------------------------------------------------------------------
+alter schema test.ABC_TEST rename to abc_test
+--------------------
+ALTER SCHEMA test.ABC_TEST RENAME TO abc_test
+------------------------------------------------------------------------------------------------------------------------
+drop schema abc.test
+--------------------
+DROP SCHEMA abc.test
+------------------------------------------------------------------------------------------------------------------------
+drop schema test.abc, test2.ccc ,test3.aac
+--------------------
+DROP SCHEMA test.abc, test2.ccc, test3.aac


### PR DESCRIPTION
支持 PG create/alter/drop schema 语句中同时指定库。

create schema abc.abc
alter schema abc.test rename to abc_test
drop schema abc.test
drop schema test.abc, test2.ccc ,test3.aac