### PR TITLE
bug fix: url encode & decode

### DIFF
--- a/core/src/main/java/com/alibaba/druid/stat/DruidStatService.java
+++ b/core/src/main/java/com/alibaba/druid/stat/DruidStatService.java
@@ -31,7 +31,10 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -375,6 +378,12 @@ public final class DruidStatService implements DruidStatServiceMBean {
     public static Map<String, String> getParameters(String url) {
         if (url == null || (url = url.trim()).length() == 0) {
             return Collections.<String, String>emptyMap();
+        }
+
+        try {
+            url = URLDecoder.decode(url, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            LOG.error("url decode error", e);
         }
 
         String parametersStr = StringUtils.subString(url, "?", null);

--- a/core/src/main/resources/support/http/resources/js/common.js
+++ b/core/src/main/resources/support/http/resources/js/common.js
@@ -154,7 +154,7 @@ druid.common = function () {
         ajaxRequestForBasicInfo: function () {
             $.ajax({
                 type: 'POST',
-                url: druid.common.getAjaxUrl(druid.common.ajaxuri),
+                url: encodeURIComponent(druid.common.getAjaxUrl(druid.common.ajaxuri)),
                 success: function (data) {
                     druid.common.handleAjaxResult(data);
                 },

--- a/core/src/test/java/com/alibaba/druid/bvt/stat/DruidStatServiceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/stat/DruidStatServiceTest.java
@@ -520,5 +520,9 @@ public class DruidStatServiceTest extends TestCase {
         url = "/%E4%B8%AD%E6%96%87";
         parameters = DruidStatService.getParameters(url);
         assertThat(parameters.isEmpty(), is(true));
+        url = "/sql.json%3ForderBy%3DHistogram%5B3%5D%26orderType%3Ddesc";
+        parameters = DruidStatService.getParameters(url);
+        assertThat(parameters.get("orderBy"), equalTo("Histogram[3]"));
+        assertThat(parameters.get("orderType"), equalTo("desc"));
     }
 }

--- a/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
+++ b/druid-admin/src/main/java/com/alibaba/druid/admin/service/MonitorStatService.java
@@ -25,6 +25,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -443,6 +446,11 @@ public class MonitorStatService implements DruidStatServiceMBean {
     public static Map<String, String> getParameters(String url) {
         if (url == null || (url = url.trim()).length() == 0) {
             return Collections.<String, String>emptyMap();
+        }
+        try {
+            url = URLDecoder.decode(url, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            log.error("url decode error", e);
         }
 
         String parametersStr = StringUtils.subString(url, "?", null);

--- a/druid-admin/src/main/resources/support/http/resources/js/common.js
+++ b/druid-admin/src/main/resources/support/http/resources/js/common.js
@@ -161,7 +161,7 @@ druid.common = function () {
         ajaxRequestForBasicInfo: function () {
             $.ajax({
                 type: 'POST',
-                url: druid.common.getAjaxUrl(druid.common.ajaxuri),
+                url: encodeURIComponent(druid.common.getAjaxUrl(druid.common.ajaxuri)),
                 success: function (data) {
                     druid.common.handleAjaxResult(data);
                 },


### PR DESCRIPTION
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/37c006e5-4220-4115-82fa-13d27da96118" />

区间排序因为中括号问题，导致请求失败，uri参数需要做编码，java代码接收时进行uri解码