### PR TITLE
fix mysql alter table option: algorithm

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableAlgorithm.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterTableAlgorithm.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.sql.dialect.mysql.ast.statement;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableItem;
+import com.alibaba.druid.sql.dialect.mysql.ast.MySqlObjectImpl;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
+
+public class MySqlAlterTableAlgorithm extends MySqlObjectImpl implements SQLAlterTableItem {
+    private SQLExpr algorithmType;
+
+    @Override
+    public void accept0(MySqlASTVisitor visitor) {
+        if (visitor.visit(this)) {
+            acceptChild(visitor, algorithmType);
+        }
+        visitor.endVisit(this);
+    }
+
+    public SQLExpr getAlgorithmType() {
+        return algorithmType;
+    }
+
+    public void setAlgorithmType(SQLExpr algorithmType) {
+        this.algorithmType = algorithmType;
+    }
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -5864,12 +5864,14 @@ public class MySqlStatementParser extends SQLStatementParser {
                     alterTableAdd(stmt);
                     return true;
                 } else if (lexer.identifierEquals(FnvHash.Constants.ALGORITHM)) {
-                    // ALGORITHM [=] {DEFAULT|INPLACE|COPY}
+                    // ALGORITHM [=] {DEFAULT | INSTANT | INPLACE | COPY}
                     lexer.nextToken();
                     if (lexer.token() == Token.EQ) {
                         lexer.nextToken();
                     }
-                    stmt.addItem(new MySqlAlterTableOption("ALGORITHM", lexer.stringVal()));
+                    MySqlAlterTableAlgorithm item = new MySqlAlterTableAlgorithm();
+                    item.setAlgorithmType(new SQLIdentifierExpr(lexer.stringVal()));
+                    stmt.addItem(item);
                     lexer.nextToken();
                     return true;
                 } else if (lexer.identifierEquals(FnvHash.Constants.CHANGE)) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlASTVisitor.java
@@ -918,6 +918,13 @@ public interface MySqlASTVisitor extends SQLASTVisitor {
     default void endVisit(MySqlAlterTableLock x) {
     }
 
+    default boolean visit(MySqlAlterTableAlgorithm x) {
+        return true;
+    }
+
+    default void endVisit(MySqlAlterTableAlgorithm x) {
+    }
+
     default boolean visit(MySqlAlterTableOrderBy x) {
         return true;
     }

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlCreateTableStatementTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlCreateTableStatementTest.java
@@ -1,0 +1,58 @@
+package com.alibaba.druid.sql.dialect.mysql.ast.statement;
+
+import com.alibaba.druid.sql.ast.SQLName;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
+import com.alibaba.druid.sql.repository.SchemaObject;
+import com.alibaba.druid.sql.repository.SchemaRepository;
+import com.alibaba.druid.util.JdbcConstants;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class MySqlCreateTableStatementTest {
+    @Test
+    public void testAlterTable() {
+        SchemaRepository repository = new SchemaRepository(JdbcConstants.MYSQL);
+        repository.setDefaultSchema("`db`");
+
+        // init table struct
+        repository.console("CREATE TABLE tb (\n"
+            + "\tid bigint(20) NOT NULL AUTO_INCREMENT,\n"
+            + "\tc0 varchar(40) NOT NULL COMMENT 'c0',\n"
+            + "\tPRIMARY KEY (id)\n"
+            + ")");
+        // expect 2 column
+        assertArrayEquals(new String[] {"id", "c0"}, findColumnNames(repository.findSchema("db").findTable("tb")));
+
+        // add column with alter option
+        repository.console("ALTER TABLE `db`.`tb` ADD COLUMN `c1` int COMMENT 'c1' , algorithm=inplace ,lock=none");
+        SchemaObject schemaObject = repository.findSchema("db").findTable("tb");
+        // expect 3 column after add column
+        assertArrayEquals(new String[] {"id", "c0", "c1"}, findColumnNames(schemaObject));
+
+        // generate create table sql
+        String createTableSql = schemaObject.getStatement().toString();
+
+        // restore from full create table sql
+        repository = new SchemaRepository(JdbcConstants.MYSQL);
+        repository.setDefaultSchema("`db`");
+        repository.console(createTableSql);
+
+        // expect 3 column after restore
+        assertArrayEquals(new String[] {"id", "c0", "c1"},
+            findColumnNames(repository.findSchema("db").findTable("tb")));
+    }
+
+    private Object[] findColumnNames(SchemaObject schemaObject) {
+        SQLStatement statement = schemaObject.getStatement();
+        assert statement instanceof MySqlCreateTableStatement;
+        return ((MySqlCreateTableStatement)statement).getTableElementList()
+            .stream()
+            .filter(element -> element instanceof SQLColumnDefinition)
+            .map(element -> ((SQLColumnDefinition)element).getName())
+            .map(SQLName::getSimpleName)
+            .toArray();
+    }
+}


### PR DESCRIPTION
alter_option should not apply to table_option. sample: 
```
ALTER TABLE `db`.`tb` ADD COLUMN `c1` int COMMENT 'c1' , algorithm=inplace ,lock=none
```

https://dev.mysql.com/doc/refman/8.4/en/alter-table.html
      