### PR TITLE
fix insert parse \' in varchar value.

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -514,7 +514,11 @@ public class Lexer {
         this.startPos = pos;
         if (ch == '\'') {
             bufPos = 0;
-            scanString();
+            if (dbType == DbType.mysql) {
+                scanString2();
+            } else {
+                scanString();
+            }
             return;
         }
 
@@ -1409,7 +1413,11 @@ public class Lexer {
                     }
                     return;
                 case '\'':
-                    scanString();
+                    if (dbType == DbType.mysql) {
+                        scanString2();
+                    } else {
+                        scanString();
+                    }
                     return;
                 case '\"':
                     scanAlias();

--- a/core/src/test/java/com/alibaba/druid/sql/dialect/mysql/testparser/MySqlStatementParserCommonTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/dialect/mysql/testparser/MySqlStatementParserCommonTest.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.sql.dialect.mysql.testparser;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+/**
+ * @author 枭博
+ * @date 2025/01/21
+ */
+public class MySqlStatementParserCommonTest {
+    @Test
+    public void testInsertWithEscape() {
+        SQLStatementParser sqlStatementParser
+            = new SQLStatementParser("INSERT INTO tb (id, c0) VALUES(1, 'CREATE TABLE tb (\n"
+            + "id bigint(20) NOT NULL AUTO_INCREMENT,\n"
+            + " c0 varchar(40) NOT NULL COMMENT \\'c0\\',\n"
+            + " PRIMARY KEY (id)\n"
+            + " )');",
+            DbType.mysql);
+        SQLStatement sqlStatement = sqlStatementParser.parseInsert();
+        // make sure \' in varchar value can parse
+        assert sqlStatement instanceof SQLInsertStatement;
+    }
+}


### PR DESCRIPTION
fix bad case:

```sql
INSERT INTO tb (id, c0) VALUES(1, 'CREATE TABLE tb (
           id bigint(20) NOT NULL AUTO_INCREMENT,
            c0 varchar(40) NOT NULL COMMENT \'c0\',
            PRIMARY KEY (id)
            )');
```