### PR TITLE
feat: extend a syntax support for mysql create table with option 'distributed by hash xxx'

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlCreateTableStatement.java
@@ -57,6 +57,7 @@ public class MySqlCreateTableStatement extends SQLCreateTableStatement implement
     // for ads
     protected SQLName distributeByType;
     protected List<SQLName> distributeBy = new ArrayList<SQLName>();
+    protected List<SQLName> distributeByHashGroup = new ArrayList<SQLName>();
     protected boolean isBroadCast;
     // for ads
     protected Map<String, SQLName> with = new HashMap<String, SQLName>(3);
@@ -565,6 +566,10 @@ public class MySqlCreateTableStatement extends SQLCreateTableStatement implement
 
     public List<SQLName> getDistributeBy() {
         return distributeBy;
+    }
+
+    public List<SQLName> getDistributeByHashGroup() {
+        return distributeByHashGroup;
     }
 
     public SQLExpr getTbpartitions() {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -864,6 +864,21 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                     }
                     accept(Token.RPAREN);
                     stmt.setDistributeByType(new SQLIdentifierExpr("HASH"));
+                    // syntax: hash(col1,col2)(g1,g2,g3)
+                    if (lexer.token() == Token.LPAREN) {
+                        accept(Token.LPAREN);
+                        for (; ; ) {
+                            SQLName name = this.exprParser.name();
+                            stmt.getDistributeByHashGroup().add(name);
+                            if (lexer.token() == Token.COMMA) {
+                                lexer.nextToken();
+                                continue;
+                            }
+                            break;
+                        }
+                        accept(Token.RPAREN);
+                    }
+
                 } else if (lexer.identifierEquals(FnvHash.Constants.DUPLICATE)) {
                     lexer.nextToken();
                     accept(Token.LPAREN);

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -10505,6 +10505,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 print0(ucase ? "HASH(" : "hash(");
                 printAndAccept(x.getDistributeBy(), ",");
                 print0(")");
+                if (!x.getDistributeByHashGroup().isEmpty()) {
+                    print0("(");
+                    printAndAccept(x.getDistributeByHashGroup(), ",");
+                    print0(")");
+                }
 
             } else if ("DUPLICATE".equalsIgnoreCase(distributeByType.getSimpleName())) {
                 print0(ucase ? "DUPLICATE(" : "duplicate(");

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest163_distributed_by_hash_group.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/createTable/MySqlCreateTableTest163_distributed_by_hash_group.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.mysql.createTable;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.MysqlTest;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
+
+
+public class MySqlCreateTableTest163_distributed_by_hash_group extends MysqlTest {
+    public void test_0() throws Exception {
+        String sql = "CREATE TABLE `test_user` ( `id` int(11) NOT NULL AUTO_INCREMENT ) DISTRIBUTE BY HASH(id,name);";
+
+        MySqlCreateTableStatement stmt = (MySqlCreateTableStatement) SQLUtils.parseSingleMysqlStatement(sql);
+
+        assertEquals(sql, SQLUtils.toSQLString(stmt, DbType.mysql, new SQLUtils.FormatOption(VisitorFeature.OutputUCase)));
+    }
+
+    public void test_1() throws Exception {
+        String sql = "CREATE TABLE `test_user` ( `id` int(11) NOT NULL AUTO_INCREMENT ) DISTRIBUTED BY HASH(col1,col2)(g1,g2,g3);";
+
+        MySqlCreateTableStatement stmt = (MySqlCreateTableStatement) SQLUtils.parseSingleMysqlStatement(sql);
+
+        assertEquals(sql, SQLUtils.toSQLString(stmt, DbType.mysql, new SQLUtils.FormatOption(
+                VisitorFeature.OutputDistributedLiteralInCreateTableStmt, VisitorFeature.OutputUCase)));
+    }
+
+}


### PR DESCRIPTION
feat: add syntax support for MySQL create table with option 'distributed by hash(col1,col2)(g1,g2,g3)' .
g1/g2/g3  is the database instance node number.
col1/col2 is the table column name.