### PR TITLE
Support sql has comma before grouping sets

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectGroupByClause.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLSelectGroupByClause.java
@@ -34,6 +34,7 @@ public class SQLSelectGroupByClause extends SQLObjectImpl implements SQLReplacea
 
     private boolean distinct;
     private boolean paren;
+    private boolean groupingSetsHaveComma;
 
     public SQLSelectGroupByClause() {
     }
@@ -78,6 +79,14 @@ public class SQLSelectGroupByClause extends SQLObjectImpl implements SQLReplacea
 
     public void setWithCube(boolean withCube) {
         this.withCube = withCube;
+    }
+
+    public boolean isGroupingSetsHaveComma() {
+        return groupingSetsHaveComma;
+    }
+
+    public void setGroupingSetsHaveComma(boolean groupingSetsHaveComma) {
+        this.groupingSetsHaveComma = groupingSetsHaveComma;
     }
 
     public SQLExpr getHaving() {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -922,6 +922,7 @@ public class SQLSelectParser extends SQLParser {
                 groupBy.setWithCube(true);
             }
 
+            boolean hasComma = false;
             for (; ; ) {
                 List<String> comments = null;
                 if (lexer.hasComment()) {
@@ -930,6 +931,9 @@ public class SQLSelectParser extends SQLParser {
                 SQLExpr item = parseGroupByItem();
                 if (comments != null) {
                     item.addBeforeComment(comments);
+                }
+                if (item instanceof SQLGroupingSetExpr && hasComma) {
+                    groupBy.setGroupingSetsHaveComma(true);
                 }
 
                 item.setParent(groupBy);
@@ -946,8 +950,10 @@ public class SQLSelectParser extends SQLParser {
                             && lexer.line == line + 1) {
                         item.addAfterComment(lexer.readAndResetComments());
                     }
+                    hasComma = true;
                     continue;
                 } else if (lexer.identifierEquals(FnvHash.Constants.GROUPING)) {
+                    hasComma = false;
                     continue;
                 } else {
                     break;

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -51,13 +51,7 @@ import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.NClob;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAmount;
 import java.util.*;
@@ -2575,7 +2569,9 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 if (i != 0) {
                     if (groupItemSingleLine) {
                         if (item instanceof SQLGroupingSetExpr) {
-                            if (!item.hasBeforeComment()) {
+                            if (x.isGroupingSetsHaveComma()) {
+                                println(',');
+                            } else if (!item.hasBeforeComment()) {
                                 println();
                             }
                         } else {
@@ -2583,7 +2579,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                         }
                     } else {
                         if (item instanceof SQLGroupingSetExpr) {
-                            println();
+                            if (x.isGroupingSetsHaveComma()) {
+                                println(',');
+                            } else {
+                                println();
+                            }
                         } else {
                             print(", ");
                         }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/GroupingSetsTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/GroupingSetsTest.java
@@ -17,4 +17,26 @@ public class GroupingSetsTest extends TestCase {
                 + "\nFROM items_sold"
                 + "\nGROUP BY GROUPING SETS ((brand), (size), ());", result);
     }
+
+    public void test_groupingSetsHasComma() throws Exception {
+        String sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY brand, size, GROUPING SETS ((brand), (size), ());";
+
+        String result = SQLUtils.format(sql, (DbType) null);
+
+        Assert.assertEquals("SELECT brand, size, sum(sales)\n" +
+                "FROM items_sold\n" +
+                "GROUP BY brand, size,\n" +
+                "\tGROUPING SETS ((brand), (size), ());", result);
+    }
+
+    public void test_groupingSetsNoComma() throws Exception {
+        String sql = "SELECT brand, size, sum(sales) FROM items_sold GROUP BY brand, size GROUPING SETS ((brand), (size), ());";
+
+        String result = SQLUtils.format(sql, (DbType) null);
+
+        Assert.assertEquals("SELECT brand, size, sum(sales)\n" +
+                "FROM items_sold\n" +
+                "GROUP BY brand, size\n" +
+                "\tGROUPING SETS ((brand), (size), ());", result);
+    }
 }


### PR DESCRIPTION
Both sql 
`SELECT brand, size, sum(sales) FROM items_sold GROUP BY brand, size, GROUPING SETS ((brand), (size), ());`
and 
`SELECT brand, size, sum(sales) FROM items_sold GROUP BY brand, size GROUPING SETS ((brand), (size), ());` 
is allowed in many dbms like hive,spark,odps. we need to support them.