### PR TITLE
Fix solve the issue in SQL where the < operator is mistakenly recogni…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -1677,10 +1677,6 @@ public class Lexer {
                             scanChar();
                             scanChar();
                             token = Token.LTLT;
-                        } else if (c1 == '@') {
-                            scanChar();
-                            scanChar();
-                            token = Token.LT_MONKEYS_AT;
                         } else if (c1 == '-' && charAt(pos + 2) == '>') {
                             scanChar();
                             scanChar();

--- a/core/src/test/java/com/alibaba/druid/mysql/MysqlVarantRefTest.java
+++ b/core/src/test/java/com/alibaba/druid/mysql/MysqlVarantRefTest.java
@@ -3,16 +3,23 @@ package com.alibaba.druid.mysql;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
 import com.alibaba.druid.sql.ast.statement.SQLSetStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSetTransactionStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitor;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.alibaba.druid.util.JdbcConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BinaryOperator;
 
 /**
  * Created by szf on 2017/11/16.
@@ -150,4 +157,54 @@ public class MysqlVarantRefTest {
         Assert.assertTrue(resultExpr5.isSession());
     }
 
+    @Test
+    public void test7() {
+        // in this case, < @sid is recognized as < operator and user-defined variables@sid
+        String sql = "set @sid=1;select * from aaa where id < @sid; ";
+        SQLStatementParser parser = new MySqlStatementParser(sql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+
+        SQLSetStatement result0 = (SQLSetStatement) stmtList.get(0);
+        SQLVariantRefExpr resultExpr0 = (SQLVariantRefExpr) result0.getItems().get(0).getTarget();
+        Assert.assertEquals("@sid", resultExpr0.getName());
+
+        AtomicReference<SQLVariantRefExpr> resultExpr1Ref = new AtomicReference<>();
+        AtomicInteger variableCnt = new AtomicInteger(0);
+        AtomicInteger arrayContainerByOperatorCnt = new AtomicInteger(0);
+        MySqlASTVisitor visitor = new MySqlASTVisitorAdapter() {
+            @Override
+            public boolean visit(SQLVariantRefExpr x) {
+                resultExpr1Ref.set(x);
+                variableCnt.addAndGet(1);
+                return super.visit(x);
+            }
+
+            @Override
+            public boolean visit(SQLBinaryOpExpr x) {
+                if(SQLBinaryOperator.Array_ContainedBy.equals(x.getOperator())) {
+                    arrayContainerByOperatorCnt.addAndGet(1);
+                }
+                return super.visit(x);
+            }
+        };
+        stmtList.get(1).accept(visitor);
+
+
+        Assert.assertEquals(1, variableCnt.get());
+        Assert.assertEquals(0, arrayContainerByOperatorCnt.get());
+        Assert.assertEquals("@sid", resultExpr1Ref.get().getName());
+
+        // in this case, <@ is recognized as <@, instead of < user-defined variables@sid
+        String sql2 = "select * from aaa where id <@ sid; ";
+        SQLStatementParser parser2 = new MySqlStatementParser(sql2);
+
+        List<SQLStatement> stmtList2 = parser2.parseStatementList();
+        variableCnt.set(0);
+        arrayContainerByOperatorCnt.set(0);
+        resultExpr1Ref.set(null);
+        stmtList2.get(0).accept(visitor);
+        Assert.assertEquals(0, variableCnt.get());
+        Assert.assertEquals(1, arrayContainerByOperatorCnt.get());
+        Assert.assertNull(resultExpr1Ref.get());
+    }
 }


### PR DESCRIPTION
…zed as <@ when used jointly with user-defined variables.
In SQL, <@ is a special binary operator. However, in MySQL parsing, if a space is added between < and @, MySQL will report a parsing error when executing. This means that '<@' does not need to be identified separately in MySQL as LT_MONKEYS_AT type.
In addition, when the < operator is mixed with user-defined variables, the token type identified by the current lexical parsing is incorrect.
For example:
select * from aaa where id > @sid
The correct identification method is that @sid is a user-defined variable, and the id field is compared with the variable using the binary operator >.
Current identification method:
>@ is identified as the binary operator Array_ContainedBy, which is incorrect.