### PR TITLE
add oracle json_table grammar support

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/expr/OracleJSONTableExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/expr/OracleJSONTableExpr.java
@@ -1,0 +1,237 @@
+package com.alibaba.druid.sql.dialect.oracle.ast.expr;
+
+import com.alibaba.druid.sql.ast.*;
+import com.alibaba.druid.sql.dialect.oracle.ast.OracleSQLObjectImpl;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
+import com.alibaba.druid.sql.visitor.SQLASTVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class OracleJSONTableExpr extends SQLExprImpl implements OracleExpr {
+    private final List<Column> columns = new ArrayList<Column>();
+    private SQLExpr expr;
+    private SQLExpr path;
+
+    @Override
+    public void accept0(OracleASTVisitor v) {
+        if (v.visit(this)) {
+            acceptChild(v, expr);
+            acceptChild(v, path);
+            acceptChild(v, columns);
+        }
+        v.endVisit(this);
+    }
+
+    @Override
+    public List<SQLObject> getChildren() {
+        return null;
+    }
+
+    public SQLExpr getExpr() {
+        return expr;
+    }
+
+    public void setExpr(SQLExpr x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+
+        this.expr = x;
+    }
+
+    public SQLExpr getPath() {
+        return path;
+    }
+
+    public void setPath(SQLExpr x) {
+        if (x != null) {
+            x.setParent(this);
+        }
+        this.path = x;
+    }
+
+    public List<Column> getColumns() {
+        return columns;
+    }
+
+    public void addColumn(Column column) {
+        column.setParent(this);
+        this.columns.add(column);
+    }
+
+    public static class Column extends OracleSQLObjectImpl {
+        private final List<Column> nestedColumns = new ArrayList<Column>();
+        private SQLName name;
+        private SQLDataType dataType;
+        private SQLExpr path;
+        private boolean ordinality;
+        private boolean exists;
+        private SQLExpr onError;
+        private SQLExpr onEmpty;
+
+        @Override
+        public void accept0(OracleASTVisitor v) {
+            if (v.visit(this)) {
+                acceptChild(v, name);
+                acceptChild(v, dataType);
+                acceptChild(v, path);
+                acceptChild(v, onEmpty);
+                acceptChild(v, onError);
+            }
+            v.endVisit(this);
+        }
+
+        public SQLName getName() {
+            return name;
+        }
+
+        public void setName(SQLName x) {
+            if (x != null) {
+                x.setParent(this);
+            }
+            this.name = x;
+        }
+
+        public SQLDataType getDataType() {
+            return dataType;
+        }
+
+        public void setDataType(SQLDataType x) {
+            if (x != null) {
+                x.setParent(this);
+            }
+            this.dataType = x;
+        }
+
+        public SQLExpr getPath() {
+            return path;
+        }
+
+        public void setPath(SQLExpr x) {
+            if (x != null) {
+                x.setParent(this);
+            }
+            this.path = x;
+        }
+
+        public boolean isOrdinality() {
+            return ordinality;
+        }
+
+        public void setOrdinality(boolean ordinality) {
+            this.ordinality = ordinality;
+        }
+
+        public boolean isExists() {
+            return exists;
+        }
+
+        public void setExists(boolean exists) {
+            this.exists = exists;
+        }
+
+        public SQLExpr getOnError() {
+            return onError;
+        }
+
+        public void setOnError(SQLExpr x) {
+            if (x != null) {
+                x.setParent(this);
+            }
+            this.onError = x;
+        }
+
+        public SQLExpr getOnEmpty() {
+            return onEmpty;
+        }
+
+        public void setOnEmpty(SQLExpr x) {
+            if (x != null) {
+                x.setParent(this);
+            }
+            this.onEmpty = x;
+        }
+
+        public List<Column> getNestedColumns() {
+            return nestedColumns;
+        }
+
+        public void addNestedColumn(Column column) {
+            column.setParent(this);
+            this.nestedColumns.add(column);
+        }
+
+        @Override
+        public Column clone() {
+            Column result = new Column();
+            for(Column nestedColumn : nestedColumns) {
+                result.addNestedColumn(nestedColumn.clone());
+            }
+            if(name != null) {
+                result.setName(name.clone());
+            }
+            if(dataType != null) {
+                result.setDataType(dataType.clone());
+            }
+            if(path != null) {
+                result.setPath(path.clone());
+            }
+            result.setOrdinality(ordinality);
+            result.setExists(exists);
+            if(onError != null) {
+                result.setOnEmpty(onError.clone());
+            }
+            if(onEmpty != null) {
+                result.setOnEmpty(onEmpty.clone());
+            }
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Column)) return false;
+            Column column = (Column) o;
+            return ordinality == column.ordinality && exists == column.exists && Objects.equals(nestedColumns, column.nestedColumns) && Objects.equals(name, column.name) && Objects.equals(dataType, column.dataType) && Objects.equals(path, column.path) && Objects.equals(onError, column.onError) && Objects.equals(onEmpty, column.onEmpty);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nestedColumns, name, dataType, path, ordinality, exists, onError, onEmpty);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OracleJSONTableExpr)) return false;
+        OracleJSONTableExpr that = (OracleJSONTableExpr) o;
+        return Objects.equals(columns, that.columns) && Objects.equals(expr, that.expr) && Objects.equals(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columns, expr, path);
+    }
+
+    @Override
+    public SQLExpr clone() {
+        OracleJSONTableExpr result = new OracleJSONTableExpr();
+        for(Column column : columns) {
+            result.addColumn(column.clone());
+        }
+        if(expr != null) {
+            result.setExpr(expr.clone());
+        }
+        if(path != null) {
+            result.setPath(path.clone());
+        }
+        return result;
+    }
+
+    @Override
+    protected void accept0(SQLASTVisitor v) {
+        this.accept0((OracleASTVisitor) v);
+    }
+
+}

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleASTVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleASTVisitor.java
@@ -45,6 +45,22 @@ public interface OracleASTVisitor extends SQLASTVisitor {
     default void endVisit(OracleOuterExpr x) {
     }
 
+
+    default boolean visit(OracleJSONTableExpr x) {
+        return true;
+    }
+
+    default void endVisit(OracleJSONTableExpr x) {
+
+    }
+
+    default boolean visit(OracleJSONTableExpr.Column x) {
+        return true;
+    }
+
+    default void endVisit(OracleJSONTableExpr.Column x) {
+    }
+
     default void endVisit(OracleSelectJoin x) {
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -2995,4 +2995,77 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         }
         return false;
     }
+
+    public boolean visit(OracleJSONTableExpr x) {
+        print0(ucase ? "JSON_TABLE(" : "json_table(");
+        x.getExpr().accept(this);
+        print(',');
+        x.getPath().accept(this);
+        incrementIndent();
+        println();
+        print0(ucase ? "COLUMNS (" : "columns (");
+        incrementIndent();
+        println();
+        printlnAndAccept(x.getColumns(), ",");
+        decrementIndent();
+        println();
+        print(')');
+        decrementIndent();
+        println();
+        print(')');
+
+        return false;
+    }
+
+    public boolean visit(OracleJSONTableExpr.Column x) {
+        x.getName().accept(this);
+
+        if (x.isOrdinality()) {
+            print0(ucase ? " FOR ORDINALITY" : " for ordinality");
+        }
+
+        SQLDataType dataType = x.getDataType();
+        if (dataType != null) {
+            print(' ');
+            dataType.accept(this);
+        }
+
+        if (x.isExists()) {
+            print0(ucase ? " EXISTS" : " exists");
+        }
+
+        SQLExpr path = x.getPath();
+        if (path != null) {
+            print0(ucase ? " PATH " : " path ");
+            path.accept(this);
+        }
+
+        List<OracleJSONTableExpr.Column> nestedColumns = x.getNestedColumns();
+        if (nestedColumns.size() > 0) {
+            print0(ucase ? " COLUMNS (" : " columns (");
+            printAndAccept(nestedColumns, ", ");
+            print(')');
+        }
+
+        SQLExpr onEmpty = x.getOnEmpty();
+        if (onEmpty != null) {
+            print(' ');
+            if (!(onEmpty instanceof SQLNullExpr || onEmpty instanceof SQLIdentifierExpr)) {
+                print0(ucase ? "DEFAULT " : "default ");
+            }
+            onEmpty.accept(this);
+            print0(ucase ? " ON EMPTY" : " on empty");
+        }
+
+        SQLExpr onError = x.getOnError();
+        if (onError != null) {
+            print(' ');
+            if (!(onEmpty instanceof SQLNullExpr || onEmpty instanceof SQLIdentifierExpr)) {
+                print0(ucase ? "DEFAULT " : "default ");
+            }
+            onError.accept(this);
+            print0(ucase ? " ON ERROR" : " on error");
+        }
+        return false;
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/oracle/OracleJsonTableTest.java
+++ b/core/src/test/java/com/alibaba/druid/oracle/OracleJsonTableTest.java
@@ -1,0 +1,45 @@
+package com.alibaba.druid.oracle;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleJSONTableExpr;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitor;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleASTVisitorAdapter;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.List;
+
+/**
+ * Created by pku_liuqiang on 2025/5/7.
+ * 类说明：
+ */
+public class OracleJsonTableTest extends TestCase {
+
+    public void testLimit() {
+        String sql = "select a1.* " +
+                "from aaa a1 left join " +
+                "JSON_TABLE(a1.jsondata, '$[*]' COLUMNS ( id NUMBER PATH '$.id', code VARCHAR2(100) path '$.code')) b1 on a1.id=b1.id";
+        SQLStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        OracleASTVisitor visitor = new OracleASTVisitorAdapter() {
+            @Override
+            public boolean visit(OracleJSONTableExpr x) {
+                Assert.assertNotNull(x.getExpr());
+                Assert.assertNotNull(x.getPath());
+                Assert.assertEquals(2, x.getColumns().size());
+                return super.visit(x);
+            }
+
+            @Override
+            public boolean visit(OracleJSONTableExpr.Column x) {
+                Assert.assertNotNull(x.getName());
+                Assert.assertNotNull(x.getDataType());
+                Assert.assertNotNull(x.getPath());
+                return super.visit(x);
+            }
+        };
+        stmtList.get(0).accept(visitor);
+    }
+}


### PR DESCRIPTION
Oracle supports the JSON table syntax, but Druid is currently not supported. Referring to the implementation mechanism for the JSON table syntax in MySQL, the Oracle version of JSON table parsing has been implemented