### PR TITLE
[Feature] support PolarDB-Oracle 2.0

### DIFF
--- a/core/src/main/java/com/alibaba/druid/DbType.java
+++ b/core/src/main/java/com/alibaba/druid/DbType.java
@@ -45,6 +45,9 @@ public enum DbType {
 
     spark(1 << 30),
     oceanbase_oracle(1 << 31),
+    /**
+     * Alibaba Cloud PolarDB-Oracle 1.0
+     */
     polardb(1L << 32),
 
     ali_oracle(1L << 33),
@@ -92,6 +95,10 @@ public enum DbType {
     supersql(1L << 54),
     databricks(1L << 55),
     adb_mysql(1L << 56),
+    /**
+     * Alibaba Cloud PolarDB-Oracle 2.0
+     */
+    polardb2(1L << 57),
 
     ingres(0),
     cloudscape(0),

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -1217,7 +1217,8 @@ public class DruidDataSource extends DruidAbstractDataSource
         } else if (realDriverClassName.equals(JdbcConstants.POSTGRESQL_DRIVER)
                 || realDriverClassName.equals(JdbcConstants.ENTERPRISEDB_DRIVER)
                 || realDriverClassName.equals(JdbcConstants.OPENGAUSS_DRIVER)
-                || realDriverClassName.equals(JdbcConstants.POLARDB_DRIVER)) {
+                || realDriverClassName.equals(JdbcConstants.POLARDB_DRIVER)
+                || realDriverClassName.equals(JdbcConstants.POLARDB2_DRIVER)) {
             this.validConnectionChecker = new PGValidConnectionChecker();
         } else if (realDriverClassName.equals(JdbcConstants.OCEANBASE_DRIVER)
                 || (realDriverClassName.equals(JdbcConstants.OCEANBASE_DRIVER2))) {
@@ -1260,7 +1261,8 @@ public class DruidDataSource extends DruidAbstractDataSource
 
             } else if (realDriverClassName.equals(JdbcConstants.POSTGRESQL_DRIVER)
                     || realDriverClassName.equals(JdbcConstants.ENTERPRISEDB_DRIVER)
-                    || realDriverClassName.equals(JdbcConstants.POLARDB_DRIVER)) {
+                    || realDriverClassName.equals(JdbcConstants.POLARDB_DRIVER)
+                    || realDriverClassName.equals(JdbcConstants.POLARDB2_DRIVER)) {
                 this.exceptionSorter = new PGExceptionSorter();
 
             } else if (realDriverClassName.equals("com.alibaba.druid.mock.MockDriver")) {

--- a/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/PagerUtils.java
@@ -173,6 +173,7 @@ public class PagerUtils {
                 return limitSQLQueryBlock(queryBlock, dbType, offset, count, check);
             case oracle:
             case oceanbase_oracle:
+            case polardb2:
                 return limitOracle(select, dbType, offset, count, check);
             default:
                 throw new UnsupportedOperationException();
@@ -553,6 +554,7 @@ public class PagerUtils {
             case polardbx:
                 return new MySqlSelectQueryBlock();
             case oracle:
+            case polardb2:
                 return new OracleSelectQueryBlock();
             case postgresql:
             case greenplum:

--- a/core/src/main/java/com/alibaba/druid/sql/SQLUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/SQLUtils.java
@@ -530,6 +530,7 @@ public class SQLUtils {
         switch (dbType) {
             case oracle:
             case oceanbase_oracle:
+            case polardb2:
                 if (statementList == null || statementList.size() == 1) {
                     return new OracleOutputVisitor(out, false);
                 } else {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserUtils.java
@@ -150,6 +150,7 @@ public class SQLParserUtils {
         switch (dbType) {
             case oracle:
             case oceanbase_oracle:
+            case polardb2:
                 return new OracleStatementParser(sql, features);
             case mysql:
             case tidb:

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/ParameterizedOutputVisitorUtils.java
@@ -408,6 +408,7 @@ public class ParameterizedOutputVisitorUtils {
         switch (dbType) {
             case oracle:
             case oceanbase_oracle:
+            case polardb2:
                 return new OracleParameterizedOutputVisitor(out);
             case mysql:
             case tidb:

--- a/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcConstants.java
@@ -140,10 +140,15 @@ public interface JdbcConstants {
     String KDB_DRIVER = "com.inspur.jdbc.KdDriver";
 
     /**
-     * Aliyun PolarDB
+     * Alibaba Cloud PolarDB-Oracle 1.0
      */
     DbType POLARDB = DbType.polardb;
     String POLARDB_DRIVER = "com.aliyun.polardb.Driver";
+    /**
+     * Alibaba Cloud PolarDB-Oracle 2.0
+     */
+    DbType POLARDB2 = DbType.polardb2;
+    String POLARDB2_DRIVER = "com.aliyun.polardb2.Driver";
     /**
      * GreenPlum
      */

--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -528,7 +528,9 @@ public final class JdbcUtils implements JdbcConstants {
         } else if (rawUrl.startsWith("jdbc:inspur:")) {
             return JdbcConstants.KDB_DRIVER;
         } else if (rawUrl.startsWith("jdbc:polardb")) {
-            if (rawUrl.startsWith("jdbc:polardbx:")) {
+            if (rawUrl.startsWith("jdbc:polardb2:")) {
+                return JdbcConstants.POLARDB2_DRIVER;
+            } else if (rawUrl.startsWith("jdbc:polardbx:")) {
                 return JdbcConstants.POLARDBX_DRIVER;
             }
             return JdbcConstants.POLARDB_DRIVER;
@@ -660,7 +662,9 @@ public final class JdbcUtils implements JdbcConstants {
         } else if (rawUrl.startsWith("jdbc:inspur:")) {
             return DbType.kdb;
         } else if (rawUrl.startsWith("jdbc:polardb")) {
-            if (rawUrl.startsWith("jdbc:polardbx:")) {
+            if (rawUrl.startsWith("jdbc:polardb2:")) {
+                return DbType.polardb2;
+            } else if (rawUrl.startsWith("jdbc:polardbx:")) {
                 return DbType.polardbx;
             }
             return DbType.polardb;
@@ -934,7 +938,7 @@ public final class JdbcUtils implements JdbcConstants {
             return OracleUtils.showTables(conn);
         }
 
-        if (dbType == DbType.postgresql) {
+        if (dbType == DbType.postgresql || dbType == DbType.polardb2) {
             return PGUtils.showTables(conn);
         }
         throw new SQLException("show tables dbType not support for " + dbType);

--- a/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
+++ b/core/src/main/java/com/alibaba/druid/wall/WallFilter.java
@@ -148,6 +148,7 @@ public class WallFilter extends FilterAdapter implements WallFilterMBean {
             case oracle:
             case ali_oracle:
             case oceanbase_oracle:
+            case polardb2:
             //case dm:
                 if (config == null) {
                     config = new WallConfig(OracleWallProvider.DEFAULT_CONFIG_DIR);

--- a/core/src/test/java/com/alibaba/druid/polardb/PolarDBDataSourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/polardb/PolarDBDataSourceTest.java
@@ -38,10 +38,11 @@ public class PolarDBDataSourceTest extends TestCase {
         Assert.assertTrue(JdbcConstants.POLARDB.equals(DbType.of(dataSource.getDbType())));
         Assert.assertTrue(JdbcConstants.POLARDB_DRIVER.equals(dataSource.getDriverClassName()));
 
-        Connection conn = dataSource.getConnection();
+        Connection conn = dataSource.getConnection(1000);
         PreparedStatement stmt = conn.prepareStatement("SELECT 1");
         ResultSet rs = stmt.executeQuery();
         while (rs.next()) {
+            System.out.println("result: " + rs.getInt(1));
         }
         JdbcUtils.close(rs);
         JdbcUtils.close(stmt);

--- a/core/src/test/java/com/alibaba/druid/polardb/PolarDBWallFilterTest.java
+++ b/core/src/test/java/com/alibaba/druid/polardb/PolarDBWallFilterTest.java
@@ -1,0 +1,87 @@
+package com.alibaba.druid.polardb;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.wall.WallConfig;
+import com.alibaba.druid.wall.WallFilter;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+public class PolarDBWallFilterTest extends TestCase {
+    private DruidDataSource dataSource;
+
+    protected void setUp() throws Exception {
+        String jdbcUrl = "jdbc:polardb://a.b.c.d:5432/polardb";
+        String user = "polardb";
+        String password = "polardb";
+        dataSource = new DruidDataSource();
+        dataSource.setDbType(DbType.polardb);
+        dataSource.setUrl(jdbcUrl);
+        dataSource.setUsername(user);
+        dataSource.setPassword(password);
+        dataSource.setFilters("stat");
+
+        WallConfig wallConfig = new WallConfig();
+        wallConfig.setStrictSyntaxCheck(true);
+        WallFilter wallFilter = new WallFilter();
+        wallFilter.setConfig(wallConfig);
+        dataSource.getProxyFilters().add(wallFilter);
+    }
+
+    /*
+     * PolarDB-Oracle 1.0 is regarded as PostgreSQL in Druid
+     * and it only accepts PostgreSQL style grammar.
+     */
+    public void testWallFilter() throws Exception {
+        String sql = null;
+        Connection connect = dataSource.getConnection();
+        PreparedStatement pstmt = null;
+        ResultSet resultSet = null;
+
+        /*
+         * 1. Simple query ok
+         */
+        sql = "SELECT sysdate FROM dual";
+        pstmt = connect.prepareStatement(sql);
+        resultSet = pstmt.executeQuery();
+        while (resultSet.next()) {
+            Timestamp timestamp = resultSet.getTimestamp("sysdate");
+            System.out.println("sysdate: " + timestamp);
+        }
+        pstmt.close();
+
+        /*
+         * 2. PostgreSQL style SET ok
+         */
+        sql = "SET seq_page_cost TO 1";
+        pstmt = connect.prepareStatement(sql);
+        pstmt.execute();
+        pstmt.close();
+
+        /*
+         * 3. Oracle style ALTER SESSION filtered by wall filter
+         */
+        boolean sql_filtered = false;
+        try {
+            sql = "ALTER SESSION SET seq_page_cost = 1";
+            pstmt = connect.prepareStatement(sql);
+            pstmt.execute();
+        } catch (SQLException e) {
+            sql_filtered = true;
+            e.printStackTrace();
+            System.out.println("SQL filtered by wall filter");
+        } finally {
+            pstmt.close();
+        }
+
+        Assert.assertTrue(sql_filtered);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/polardb2/PolarDB2DbTypeTest.java
+++ b/core/src/test/java/com/alibaba/druid/polardb2/PolarDB2DbTypeTest.java
@@ -1,0 +1,142 @@
+package com.alibaba.druid.polardb2;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.util.JdbcConstants;
+import com.alibaba.druid.util.JdbcUtils;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+public class PolarDB2DbTypeTest extends TestCase {
+    private String jdbcUrl;
+    private String jdbcUrl1;
+    private String jdbcUrl2;
+    private String user;
+    private String password;
+    private String validateQuery;
+    private DruidDataSource dataSource;
+
+    protected void setUp() throws Exception {
+        jdbcUrl1 = "jdbc:polardb://a.b.c.d:5432/polardb";
+        jdbcUrl2 = "jdbc:polardb2://a.b.c.d:5432/polardb";
+        user = "polardb";
+        password = "polardb";
+        validateQuery = "select 1";
+    }
+
+    private void configDataSource() throws Exception {
+        dataSource.setUrl(jdbcUrl);
+        dataSource.setUsername(user);
+        dataSource.setPassword(password);
+        dataSource.setValidationQuery(validateQuery);
+        dataSource.setFilters("stat");
+    }
+
+    /**
+     * Init datasource without setting DbType and druid will get DbType
+     * from jdbc url prefix "jdbc:polardb2".
+     */
+    public void testDefaultDbType() throws Exception {
+        dataSource = new DruidDataSource();
+        jdbcUrl = jdbcUrl2;
+        configDataSource();
+        dataSource.init();
+
+        Assert.assertTrue(JdbcConstants.POLARDB2.equals(DbType.of(dataSource.getDbType())));
+        Assert.assertTrue(JdbcConstants.POLARDB2_DRIVER.equals(dataSource.getDriverClassName()));
+
+        Connection conn = dataSource.getConnection();
+        PreparedStatement stmt = conn.prepareStatement(validateQuery);
+        ResultSet rs = stmt.executeQuery();
+        while (rs.next()) {
+            System.out.println("result: " + rs.getInt(1));
+        }
+        JdbcUtils.close(rs);
+        JdbcUtils.close(stmt);
+        JdbcUtils.close(conn);
+        dataSource.close();
+    }
+
+    /**
+     * Init datasource without setting DbType and druid will get DbType
+     * from jdbc url. url with prefix "jdbc:polardb" is recognized as PolarDB-Oracle 1.0
+     * for backward compatibility. If the user want to use SQL firewall in this
+     * case, set DbType to PolarDB-Oracle 2.0 explicitly.
+     */
+    public void testSetDbType() throws Exception {
+        /*
+         * Case 1: set DbType and driver name after initializing data source.
+         * DbType could be changed after initializing, while driver name not.
+         */
+        dataSource = new DruidDataSource();
+        // JDBC url in PolarDB-Oracle 1.0 format
+        jdbcUrl = jdbcUrl1;
+        configDataSource();
+        dataSource.init();
+
+        // Driver and DbType are set to PolarDB-Oracle 1.0 automatically
+        Assert.assertTrue(JdbcConstants.POLARDB.equals(DbType.of(dataSource.getDbType())));
+        Assert.assertTrue(JdbcConstants.POLARDB_DRIVER.equals(dataSource.getDriverClassName()));
+
+        boolean conn_failed = false;
+        try {
+            Connection conn = dataSource.getConnection(1000);
+        } catch (Exception e) {
+            // Fail to connect to PolarDB-Oracle 2.0 with PolarDB-Oracle 1.0 driver
+            conn_failed = true;
+            e.printStackTrace();
+            System.out.println("failed to connect to PolarDB-Oracle 2.0 with PolarDB-Oracle 1.0 DbType and driver");
+        }
+        Assert.assertTrue(conn_failed);
+
+        // Set new DbType with string
+        dataSource.setDbType("polardb2");
+        Assert.assertTrue(JdbcConstants.POLARDB2.equals(DbType.of(dataSource.getDbType())));
+
+        // Reset
+        dataSource.setDbType("polardb");
+        Assert.assertTrue(JdbcConstants.POLARDB.equals(DbType.of(dataSource.getDbType())));
+
+        // Set new DbType with const
+        dataSource.setDbType(DbType.polardb2);
+        Assert.assertTrue(JdbcConstants.POLARDB2.equals(DbType.of(dataSource.getDbType())));
+
+        // Failed to set driver name after init
+        // dataSource.setDriverClassName(JdbcConstants.POLARDB2_DRIVER);
+        Assert.assertTrue(JdbcConstants.POLARDB_DRIVER.equals(dataSource.getDriverClassName()));
+
+        dataSource.clone();
+
+        /*
+         * Case 2: set DbType and driver name after initializing data source.
+         */
+        dataSource = new DruidDataSource();
+        // JDBC url in PolarDB-Oracle 1.0 format
+        jdbcUrl = jdbcUrl1;
+        configDataSource();
+        // Set DbType and driver to PolarDB-Oracle 2.0 before init data source
+        dataSource.setDbType(DbType.polardb2);
+        dataSource.setDriverClassName(JdbcConstants.POLARDB2_DRIVER);
+        dataSource.init();
+
+        Assert.assertTrue(JdbcConstants.POLARDB2.equals(DbType.of(dataSource.getDbType())));
+        Assert.assertTrue(JdbcConstants.POLARDB2_DRIVER.equals(dataSource.getDriverClassName()));
+
+        Connection conn = dataSource.getConnection();
+        PreparedStatement stmt = conn.prepareStatement(validateQuery);
+        ResultSet rs = stmt.executeQuery();
+        while (rs.next()) {
+            System.out.println("result: " + rs.getInt(1));
+        }
+        JdbcUtils.close(rs);
+        JdbcUtils.close(stmt);
+        JdbcUtils.close(conn);
+        dataSource.close();
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/polardb2/PolarDB2WallFilterTest.java
+++ b/core/src/test/java/com/alibaba/druid/polardb2/PolarDB2WallFilterTest.java
@@ -1,0 +1,86 @@
+package com.alibaba.druid.polardb2;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.wall.WallConfig;
+import com.alibaba.druid.wall.WallFilter;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+public class PolarDB2WallFilterTest extends TestCase {
+    private DruidDataSource dataSource;
+
+    protected void setUp() throws Exception {
+        String jdbcUrl = "jdbc:polardb2://a.b.c.d:5432/polardb";
+        String user = "polardb";
+        String password = "polardb";
+        dataSource = new DruidDataSource();
+        dataSource.setDbType(DbType.polardb2);
+        dataSource.setUrl(jdbcUrl);
+        dataSource.setUsername(user);
+        dataSource.setPassword(password);
+        dataSource.setFilters("stat");
+
+        WallConfig wallConfig = new WallConfig();
+        wallConfig.setStrictSyntaxCheck(true);
+        WallFilter wallFilter = new WallFilter();
+        wallFilter.setConfig(wallConfig);
+        dataSource.getProxyFilters().add(wallFilter);
+    }
+
+    /*
+     * PolarDB-Oracle 2.0 only accepts Oracle style grammar now.
+     */
+    public void testWallFilter() throws Exception {
+        String sql = null;
+        Connection connect = dataSource.getConnection();
+        PreparedStatement pstmt = null;
+        ResultSet resultSet = null;
+
+        /*
+         * 1. Simple query ok
+         */
+        sql = "SELECT sysdate FROM dual";
+        pstmt = connect.prepareStatement(sql);
+        resultSet = pstmt.executeQuery();
+        while (resultSet.next()) {
+            Timestamp timestamp = resultSet.getTimestamp("sysdate");
+            System.out.println("sysdate: " + timestamp);
+        }
+        pstmt.close();
+
+        /*
+         * 2. Oracle style ALTER SESSION ok
+         */
+        sql = "ALTER SESSION SET seq_page_cost = 1";
+        pstmt = connect.prepareStatement(sql);
+        pstmt.execute();
+        pstmt.close();
+
+        /*
+         * 3. PostgreSQL style SET filtered by wall filter
+         */
+        boolean sql_filtered = false;
+        try {
+            sql = "SET seq_page_cost TO 1";
+            pstmt = connect.prepareStatement(sql);
+            pstmt.execute();
+        } catch (SQLException e) {
+            sql_filtered = true;
+            e.printStackTrace();
+            System.out.println("SQL filtered by wall filter");
+        } finally {
+            pstmt.close();
+        }
+
+        Assert.assertTrue(sql_filtered);
+    }
+}


### PR DESCRIPTION
PolarDB-Oracle 2.0 is a cloud-native relational database developed by Alibaba Cloud. It's grammar is compatible with Oracle, for more details about it, please refer to the docs:
https://help.aliyun.com/zh/polardb/polardb-for-oracle. It's JDBC driver is com.aliyun.polardb2.Driver which could be downloaded from https://help.aliyun.com/zh/polardb/polardb-for-oracle/jdbc-o-2-0.

In this patch we introdure a new DbType polardb2 to represent PolarDB-Oracle 2.0 since DbType polardb is already occupied by PolarDB-Oracle 1.0. polardb2's wall filter works like Oracle and it can protect your application from non-Oracle syntax SQL injection.