### PR TITLE
Fix bug remove count

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -3097,6 +3097,9 @@ public class DruidDataSource extends DruidAbstractDataSource
 
             // shrink connections by HotSpot intrinsic function _arraycopy for performance optimization.
             int removeCount = evictCount + keepAliveCount;
+            if (removeCount > poolingCount) {
+                removeCount = poolingCount;
+            }
             if (removeCount > 0) {
                 int breakedCount = poolingCount - i;
                 if (breakedCount > 0) {

--- a/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidDataSource.java
@@ -3201,7 +3201,9 @@ public class DruidDataSource extends DruidAbstractDataSource
             lock.lock();
             try {
                 int fillCount = minIdle - (activeCount + poolingCount + createTaskCount);
-                emptySignal(fillCount);
+                if (fillCount > 0) {
+                    emptySignal(fillCount);
+                }
             } finally {
                 lock.unlock();
             }


### PR DESCRIPTION
新增解决1个问题：
闲置线程可能同时满足evictCount 和 keepAliveCount计算条件，导致计算出来的removeCount大于闲置线程数，进而导致计算出来的poolingCount小于0，影响后续判断。