### PR TITLE
Fix pg refresh materialized view concurrently

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -1037,11 +1037,12 @@ public class SQLStatementParser extends SQLParser {
 
         acceptIdentifier("MATERIALIZED");
 
+        accept(Token.VIEW);
+
         if (lexer.identifierEquals("CONCURRENTLY")) {
             lexer.nextToken();
             stmt.setConcurrently(true);
         }
-        accept(Token.VIEW);
 
         stmt.setName(this.exprParser.name());
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -9302,11 +9302,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     public boolean visit(SQLRefreshMaterializedViewStatement x) {
         print0(ucase ? "REFRESH MATERIALIZED" : "refresh materialized");
 
-        if (x.isConcurrently()) {
-            print0(ucase ? " CONCURRENTLY" : " concurrently");
-        }
-
         print0(ucase ? " VIEW " : " view ");
+
+        if (x.isConcurrently()) {
+            print0(ucase ? "CONCURRENTLY " : "concurrently ");
+        }
 
         x.getName().accept(this);
 

--- a/core/src/test/resources/bvt/parser/postgresql/15.txt
+++ b/core/src/test/resources/bvt/parser/postgresql/15.txt
@@ -1,3 +1,3 @@
-refresh materialized concurrently view v1 with no data
+refresh materialized view concurrently v1 with no data
 --------------------
-REFRESH MATERIALIZED CONCURRENTLY VIEW v1 WITH NO DATA
+REFRESH MATERIALIZED VIEW CONCURRENTLY v1 WITH NO DATA


### PR DESCRIPTION
pg的刷新物化视图语法错误，正确语法为：REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] name [ WITH [ NO ] DATA ]