### PR TITLE
依赖驱动自己设置socketTimeout，防止postgresql单位不一致等导致socketTimeout被覆盖

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidAbstractDataSource.java
@@ -1818,18 +1818,6 @@ public abstract class DruidAbstractDataSource extends WrapperAdapter implements 
             initPhysicalConnection(conn, variables, globalVariables);
             initedNanos = System.nanoTime();
 
-            boolean skipSocketTimeout = "odps".equals(dbTypeName);
-            if (socketTimeout > 0 && !netTimeoutError && !skipSocketTimeout) {
-                try {
-                    // As SQLServer-jdbc-driver 6.1.7 can use this, see https://github.com/microsoft/mssql-jdbc/wiki/SocketTimeout
-                    conn.setNetworkTimeout(netTimeoutExecutor, socketTimeout); // here is milliseconds defined by JDBC
-                } catch (SQLFeatureNotSupportedException | AbstractMethodError e) {
-                    netTimeoutError = true;
-                } catch (Exception ignored) {
-                    // ignored
-                }
-            }
-
             // call initSqls after completing socketTimeout setting.
             if (!initSqls(conn, variables, globalVariables)) {
                 // if no SQL has been executed yet.


### PR DESCRIPTION
sqlserver 在 [v6.1.2](2017年1月12发布)中已经支持在url中设置 socketTimeout，不需要再外部重新设置，重新设置还会引入postgresql单位不一致问题，可以直接废弃掉这段代码。