### PR TITLE
JdbcUtils支持华为高斯

### DIFF
--- a/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/JdbcUtils.java
@@ -550,6 +550,8 @@ public final class JdbcUtils implements JdbcConstants {
             return JdbcConstants.GBASE8S_DRIVER;
         } else if (rawUrl.startsWith("jdbc:sundb:")) {
             return JdbcConstants.SUNDB_DRIVER;
+        } else if (rawUrl.startsWith("jdbc:gaussdb:")) {
+            return "com.huawei.gaussdb.jdbc.Driver";
         } else {
             throw new SQLException("unknown jdbc driver : " + rawUrl);
         }


### PR DESCRIPTION
在JdbcUtils通过URL识别驱动时能识别华为高斯驱动，解决引入shardingsphere后，华为高斯数据库报错的问题

<img width="1803" height="304" alt="image" src="https://github.com/user-attachments/assets/52ae63cb-6872-4c49-a66f-03660695b67a" />
