### PR TITLE
Support DB2 sql: create table as (select) with [no] data

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/db2/ast/stmt/DB2CreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/db2/ast/stmt/DB2CreateTableStatement.java
@@ -29,6 +29,9 @@ public class DB2CreateTableStatement extends SQLCreateTableStatement implements 
     protected SQLName validproc;
     protected SQLName indexIn;
 
+    protected boolean withData;
+    protected boolean withNoData;
+
     public boolean isDataCaptureNone() {
         return dataCaptureNone;
     }
@@ -76,6 +79,22 @@ public class DB2CreateTableStatement extends SQLCreateTableStatement implements 
             x.setParent(this);
         }
         this.indexIn = x;
+    }
+
+    public boolean isWithData() {
+        return withData;
+    }
+
+    public void setWithData(boolean withData) {
+        this.withData = withData;
+    }
+
+    public boolean isWithNoData() {
+        return withNoData;
+    }
+
+    public void setWithNoData(boolean withNoData) {
+        this.withNoData = withNoData;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/db2/parser/DB2CreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/db2/parser/DB2CreateTableParser.java
@@ -92,4 +92,21 @@ public class DB2CreateTableParser extends SQLCreateTableParser {
     protected DB2CreateTableStatement newCreateStatement() {
         return new DB2CreateTableStatement();
     }
+
+    @Override
+    public void createTableAfterQuery(SQLCreateTableStatement stmt) {
+        Token token = lexer.token();
+        if (token != Token.EOF) {
+            if (lexer.nextIf(Token.WITH)) {
+                if (lexer.nextIfIdentifier("NO")) {
+                    acceptIdentifier("DATA");
+                    ((DB2CreateTableStatement) stmt).setWithNoData(true);
+                } else if (lexer.nextIfIdentifier("DATA")) {
+                    ((DB2CreateTableStatement) stmt).setWithData(true);
+                } else {
+                    throw new ParserException("TODO " + lexer.info());
+                }
+            }
+        }
+    }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/db2/visitor/DB2OutputVisitor.java
@@ -129,6 +129,14 @@ public class DB2OutputVisitor extends SQLASTOutputVisitor implements DB2ASTVisit
             }
         }
 
+        if (x.isWithData()) {
+            println();
+            print0(ucase ? "WITH DATA" : "with data");
+        } else if (x.isWithNoData()) {
+            println();
+            print0(ucase ? "WITH NO DATA" : "with no data");
+        }
+
         return false;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
@@ -70,7 +70,7 @@ public class SQLCreateTableParser extends SQLDDLParser {
         createTableBody(createTable);
         parseCreateTableRest(createTable);
         createTableQuery(createTable);
-
+        createTableAfterQuery(createTable);
         return createTable;
     }
 
@@ -275,5 +275,8 @@ public class SQLCreateTableParser extends SQLDDLParser {
         }
 
         accept(Token.RPAREN);
+    }
+
+    protected void createTableAfterQuery(SQLCreateTableStatement stmt) {
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/db2/DB2CreateTableTest_08.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/db2/DB2CreateTableTest_08.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.db2;
+
+import com.alibaba.druid.sql.DB2Test;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.db2.parser.DB2StatementParser;
+import com.alibaba.druid.sql.dialect.db2.visitor.DB2SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+
+import java.util.List;
+
+public class DB2CreateTableTest_08 extends DB2Test {
+
+    public void test_0() throws Exception {
+        String sql = "CREATE TABLE test.EAST_JRG_0911 \n" +
+                "AS ( SELECT * FROM test.EAST_JRGJXXB a WHERE 1=2 ) \n" +
+                "WITH NO DATA";
+
+        DB2StatementParser parser = new DB2StatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement stmt = statementList.get(0);
+        System.out.println(SQLUtils.toDB2String(stmt));
+
+        assertEquals(1, statementList.size());
+
+        DB2SchemaStatVisitor visitor = new DB2SchemaStatVisitor();
+        stmt.accept(visitor);
+
+        assertEquals(2, visitor.getTables().size());
+        assertEquals(1, visitor.getColumns().size());
+        assertEquals(0, visitor.getConditions().size());
+
+        assertTrue(visitor.containsTable("test.EAST_JRG_0911"));
+
+        assertEquals("CREATE TABLE test.EAST_JRG_0911\n" +
+                        "AS\n" +
+                        "(SELECT *\n" +
+                        "FROM test.EAST_JRGJXXB a\n" +
+                        "WHERE 1 = 2)\n" +
+                        "WITH NO DATA",
+                SQLUtils.toSQLString(stmt, JdbcConstants.DB2));
+
+        assertEquals("create table test.EAST_JRG_0911\n" +
+                        "as\n" +
+                        "(select *\n" +
+                        "from test.EAST_JRGJXXB a\n" +
+                        "where 1 = 2)\n" +
+                        "with no data",
+                SQLUtils.toSQLString(stmt, JdbcConstants.DB2, SQLUtils.DEFAULT_LCASE_FORMAT_OPTION));
+    }
+}


### PR DESCRIPTION
Support DB2 to only create table structures without inserting data or to create tables and insert query result data. 
Sql like: CREATE TABLE [schema.]table_name AS (fullselect)  [ WITH NO DATA ]