### PR TITLE
check if sqlPropertyExpr column exist before add unknown column

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SchemaStatVisitor.java
@@ -1498,7 +1498,10 @@ public class SchemaStatVisitor extends SQLASTVisitorAdapter {
                 }
             }
             if (!skip) {
-                column = handleUnknownColumn(ident);
+                column = getColumn(x);
+                if (column == null) {
+                    column = handleUnknownColumn(ident);
+                }
             }
         }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveSelectTest_13_cluster_by.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveSelectTest_13_cluster_by.java
@@ -61,7 +61,9 @@ public class HiveSelectTest_13_cluster_by
         System.out.println("groupBy : " + visitor.getGroupByColumns());
 
         assertEquals(1, visitor.getTables().size());
-        assertEquals(5, visitor.getColumns().size());
+        // before:[LD_aly.fct_pay_ord_cn_di.buyer_id, LD_aly.fct_pay_ord_cn_di.seller_id, LD_aly.fct_pay_ord_cn_di.order_id, LD_aly.fct_pay_ord_cn_di.div_pay_amt, UNKNOWN.member_id]
+        // after:[LD_aly.fct_pay_ord_cn_di.buyer_id, LD_aly.fct_pay_ord_cn_di.seller_id, LD_aly.fct_pay_ord_cn_di.order_id, LD_aly.fct_pay_ord_cn_di.div_pay_amt, t1.dim_seller.member_id, t1.dim_buyer.member_id]
+        assertEquals(6, visitor.getColumns().size());
         assertEquals(0, visitor.getConditions().size());
         assertEquals(0, visitor.getGroupByColumns().size());
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsSelectTest24.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsSelectTest24.java
@@ -208,7 +208,9 @@ public class OdpsSelectTest24 extends TestCase {
 //      System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         assertEquals(3, visitor.getTables().size());
-        assertEquals(19, visitor.getColumns().size());
+        // before:[bds_order_base_d.order_id, bds_order_base_d.member_id, bds_order_base_d.order_price, bds_order_base_d.region_id, bds_order_base_d.appoint_method, bds_order_base_d.category, bds_order_base_d.serve_types, bds_order_base_d.add_time, bds_order_base_d.dt, ods_order_tracking_time_d.order_id, ods_order_tracking_time_d.status, ods_order_tracking_time_d.dt, d_prov_city_district.region_id, d_prov_city_district.lvl2region_id, UNKNOWN.member_id, UNKNOWN.city_id, ta.add_date, UNKNOWN.add_date, UNKNOWN.is_open_order]
+        // after:[bds_order_base_d.order_id, bds_order_base_d.member_id, bds_order_base_d.order_price, bds_order_base_d.region_id, bds_order_base_d.appoint_method, bds_order_base_d.category, bds_order_base_d.serve_types, bds_order_base_d.add_time, bds_order_base_d.dt, ods_order_tracking_time_d.order_id, ods_order_tracking_time_d.status, ods_order_tracking_time_d.dt, d_prov_city_district.region_id, d_prov_city_district.lvl2region_id, ta.member_id, ta.city_id, ta.add_date, ta.is_open_order]
+        assertEquals(18, visitor.getColumns().size());
         assertEquals(13, visitor.getConditions().size());
 
 //        System.out.println(SQLUtils.formatOdps(sql));

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/createTable/OracleCreateTableTest31.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/createTable/OracleCreateTableTest31.java
@@ -57,8 +57,9 @@ public class OracleCreateTableTest31 extends OracleTest {
         System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         assertEquals(1, visitor.getTables().size());
-
-        assertEquals(6, visitor.getColumns().size());
+        // before:[students.name, students.age, name.first_name, UNKNOWN.first_name, name.last_name, UNKNOWN.last_name]
+        // after:[students.name, students.age, name.first_name, name.last_name]
+        assertEquals(4, visitor.getColumns().size());
 
         assertTrue(visitor.getColumns().contains(new TableStat.Column("students", "name")));
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest86_comment.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest86_comment.java
@@ -73,7 +73,9 @@ public class OracleSelectTest86_comment extends OracleTest {
         System.out.println("orderBy : " + visitor.getOrderByColumns());
 
         assertEquals(1, visitor.getTables().size());
-        assertEquals(8, visitor.getColumns().size());
+        //before:[SYS.KU$_HTABLE_VIEW.KU$, SYS.KU$_HTABLE_VIEW.OBJ_NUM, SYS.KU$_HTABLE_VIEW.PROPERTY, UNKNOWN.FLAGS, KU$.SCHEMA_OBJ.NAME, UNKNOWN.NAME, KU$.SCHEMA_OBJ.OWNER_NAME, UNKNOWN.OWNER_NAME]
+        //after:[SYS.KU$_HTABLE_VIEW.KU$, SYS.KU$_HTABLE_VIEW.OBJ_NUM, SYS.KU$_HTABLE_VIEW.PROPERTY, KU$.SCHEMA_OBJ.FLAGS, KU$.SCHEMA_OBJ.NAME, KU$.SCHEMA_OBJ.OWNER_NAME]
+        assertEquals(6, visitor.getColumns().size());
         assertEquals(2, visitor.getConditions().size());
         assertEquals(0, visitor.getRelationships().size());
         assertEquals(0, visitor.getOrderByColumns().size());

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/visitor/SchemaStatVisitorTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/visitor/SchemaStatVisitorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.bvt.sql.visitor;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SchemaStatVisitorTest {
+    @Test
+    public void test() {
+        String sql = "UPDATE Store_Information\n"
+                + "SET shop_money = (\n"
+                + "SELECT shop_money\n"
+                + "FROM build_info2\n"
+                + "WHERE build_info2.id = Store_Information.id)\n"
+                + "WHERE Store_Information.user = build_info2.user\n"
+                + "AND Store_Information.user = 'test3'";
+        DbType dbType = DbType.mysql;
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType, false);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SchemaStatVisitor schemaStatVisitor = SQLUtils.createSchemaStatVisitor(dbType);
+        statementList.get(0).accept(schemaStatVisitor);
+        // before change:
+        // assertEquals(7, schemaStatVisitor.getColumns().size());
+        // assertNotNull(schemaStatVisitor.getColumn("UNKNOWN", "user"));
+        assertEquals(6, schemaStatVisitor.getColumns().size());
+        assertNotNull(schemaStatVisitor.getColumn("Store_Information", "shop_money"));
+        assertNotNull(schemaStatVisitor.getColumn("build_info2", "shop_money"));
+        assertNotNull(schemaStatVisitor.getColumn("build_info2", "id"));
+        assertNotNull(schemaStatVisitor.getColumn("Store_Information", "id"));
+        assertNotNull(schemaStatVisitor.getColumn("Store_Information", "user"));
+        assertNotNull(schemaStatVisitor.getColumn("build_info2", "user"));
+        assertEquals(2, schemaStatVisitor.getTables().size());
+        assertTrue(schemaStatVisitor.containsTable("Store_Information"));
+        assertTrue(schemaStatVisitor.containsTable("build_info2"));
+    }
+}


### PR DESCRIPTION
check if sqlPropertyExpr column exist before add unknown column，can avoid additional unknown column