### PR TITLE
逻辑运算符括号补充bug修复，issue6408,其他相关issue5847已测试通过

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -1176,10 +1176,13 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 if (leftRational) {
                     this.indentCount++;
                 }
-                //print('(');
+                if (!((SQLBinaryOpExpr) left).isParenthesized()) {
+                    print('(');
+                }
                 printExpr(left, parameterized);
-               // print(')');
-
+                if (!((SQLBinaryOpExpr) left).isParenthesized()) {
+                    print(')');
+                }
                 if (leftRational) {
                     this.indentCount--;
                 }

--- a/core/src/test/java/com/alibaba/druid/sql/issues/Issue6408.java
+++ b/core/src/test/java/com/alibaba/druid/sql/issues/Issue6408.java
@@ -1,0 +1,31 @@
+package com.alibaba.druid.sql.issues;
+
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import junit.framework.TestCase;
+/**
+ * @auther nojavacc
+ * @see <a href="https://github.com/alibaba/druid/issues/6408">...</a >
+ */
+public class Issue6408 extends TestCase {
+    public void testSQLBuild() {
+
+// 加法表达式 5+3
+        SQLBinaryOpExpr addExpr = new SQLBinaryOpExpr();
+        addExpr.setLeft(new SQLIntegerExpr(5));
+        addExpr.setOperator(SQLBinaryOperator.Add);
+        addExpr.setRight(new SQLIntegerExpr(3));
+
+//除法表达式 (5 + 3) / 2
+        SQLBinaryOpExpr deviceExpr = new SQLBinaryOpExpr();
+        deviceExpr.setLeft(addExpr);
+        deviceExpr.setOperator(SQLBinaryOperator.Divide);
+        deviceExpr.setRight(new SQLIntegerExpr(2));
+
+// 期望输出(5 + 3) / 2，实际输出为 5 + 3 / 2
+        System.out.println(deviceExpr);
+
+
+    }
+}


### PR DESCRIPTION
修复自己创建SQLBinaryOpExpr sql生成规则，当判断运算符优先级需要添加括号时，判断子SQLBinaryOpExpr 是否具备新增括号配置，如果没有则手动拼接括号
https://github.com/alibaba/druid/issues/6408
