### PR TITLE
optimized for DruidPooledStatement

### DIFF
--- a/core/src/main/java/com/alibaba/druid/pool/DruidPooledStatement.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidPooledStatement.java
@@ -56,6 +56,16 @@ public class DruidPooledStatement extends PoolableWrapper implements Statement {
                 if (lastResultSet.isClosed()) {
                     resultSetTrace.set(lastIndex, resultSet);
                     return;
+                } else if (resultSet instanceof DruidPooledResultSet) {
+                    // Check if the raw result set has been closed
+                    // By default, only one ResultSet object per Statement object can be open at the same time
+                    DruidPooledResultSet druidPooledResultSet = (DruidPooledResultSet) lastResultSet;
+                    ResultSet rawResultSet = druidPooledResultSet.getRawResultSet();
+                    if (rawResultSet.isClosed()) {
+                        druidPooledResultSet.closed = true;
+                        resultSetTrace.set(lastIndex, resultSet);
+                        return;
+                    }
                 }
             } catch (SQLException ex) {
                 // skip

--- a/core/src/test/java/com/alibaba/druid/pool/DruidPooledStatementTest.java
+++ b/core/src/test/java/com/alibaba/druid/pool/DruidPooledStatementTest.java
@@ -1,0 +1,54 @@
+package com.alibaba.druid.pool;
+
+import com.alibaba.druid.util.JdbcUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DruidPooledStatementTest {
+
+    private static DruidDataSource dataSource;
+
+    @BeforeClass
+    public static void init() throws Exception {
+
+        dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:h2:mem:test");
+
+        dataSource.setPoolPreparedStatements(true);
+        dataSource.setMaxPoolPreparedStatementPerConnectionSize(20);
+
+        JdbcUtils.execute(dataSource,
+                "CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, name VARCHAR(100), age INT);");
+        JdbcUtils.execute(dataSource, "INSERT INTO users(id, name, age) VALUES (1, 'test1', 10);");
+        JdbcUtils.execute(dataSource, "INSERT INTO users(id, name, age) VALUES (2, 'test2', 20);");
+    }
+
+    @AfterClass
+    public static void destroy() throws Exception {
+        JdbcUtils.execute(dataSource, "DROP TABLE users;");
+        dataSource.close();
+    }
+
+    @Test
+    public void test_resultSetTrace() throws Exception {
+        DruidPooledConnection connection = dataSource.getConnection();
+        DruidPooledStatement statement = (DruidPooledStatement) connection.createStatement();
+        ResultSet lastResultSet = null;
+        ResultSet nowResultSet = statement.executeQuery("SELECT * FROM users;");
+        for (int i = 0; i < 100; i++) {
+            lastResultSet = nowResultSet;
+            nowResultSet = statement.executeQuery("SELECT * FROM users;");
+        }
+        assertTrue(lastResultSet.isClosed());
+        assertFalse(nowResultSet.isClosed());
+        assertEquals(1, statement.resultSetTrace.size());
+    }
+
+}


### PR DESCRIPTION
在原来的实现中,如果复用了同一个`statement` 并且没有显示关闭结果集的话或者延迟关闭了会导致`resultSetTrace`保存大量没有必要的`resultSet`。
大部分的数据库的jdbc实现都是一个statement只能持有一个打开的`resultSet`，在打开新`resultSet`的时候会隐式关闭旧的连接，但是`DruidPooledResultSet`的实现又包裹了一层`closed`，就会出现实际上`rawResultSet`已经关闭了但是外层`DruidPooledResultSet`的closed还是false的状态出现。
虽然这个pr不能完全解决因为各种奇奇怪怪的问题导致的`DruidPooledResultSet`的关闭状态内外不一致的情况，但是可以在一定程度上减轻resultSetTrace的泄露问题。
并且这样可以保持和底层数据库使用同一个`statement`的行为是一致的。(包括非标准情况，如果底层的`rawResultSet`没有被关闭我们还是可以继续跟踪他们，如果被关闭了，也没有必要跟踪了)
```java
DruidPooledConnection connection = dataSource.getConnection();
DruidPooledStatement statement = (DruidPooledStatement) connection.createStatement();
for (int i = 0; i < 100; i++) {
  statement.executeQuery(sql);
}
// 这个时候resultSetTrace里面会跟踪100个resultSet
// 前99个都处于上文提到的状态中，只有最后一个是可用的
```