### PR TITLE
chore: DruidWebUtils jakarta相关方法移入DruidWebUtilsJakarta

### DIFF
--- a/core/src/main/java/com/alibaba/druid/support/jakarta/AbstractWebStatImpl.java
+++ b/core/src/main/java/com/alibaba/druid/support/jakarta/AbstractWebStatImpl.java
@@ -21,7 +21,7 @@ import com.alibaba.druid.support.http.stat.WebRequestStat;
 import com.alibaba.druid.support.http.stat.WebSessionStat;
 import com.alibaba.druid.support.logging.Log;
 import com.alibaba.druid.support.logging.LogFactory;
-import com.alibaba.druid.util.DruidWebUtils;
+import com.alibaba.druid.util.DruidWebUtilsJakarta;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -128,7 +128,7 @@ public class AbstractWebStatImpl {
             ip = request.getHeader(realIpHeader);
         }
         if (ip == null || ip.length() == 0) {
-            ip = DruidWebUtils.getRemoteAddr(request);
+            ip = DruidWebUtilsJakarta.getRemoteAddr(request);
         }
         return ip;
     }

--- a/core/src/main/java/com/alibaba/druid/support/jakarta/WebStatFilter.java
+++ b/core/src/main/java/com/alibaba/druid/support/jakarta/WebStatFilter.java
@@ -22,7 +22,7 @@ import com.alibaba.druid.support.logging.LogFactory;
 import com.alibaba.druid.support.profile.ProfileEntryKey;
 import com.alibaba.druid.support.profile.ProfileEntryReqStat;
 import com.alibaba.druid.support.profile.Profiler;
-import com.alibaba.druid.util.DruidWebUtils;
+import com.alibaba.druid.util.DruidWebUtilsJakarta;
 import com.alibaba.druid.util.PatternMatcher;
 import com.alibaba.druid.util.ServletPathMatcher;
 import jakarta.servlet.*;
@@ -276,7 +276,7 @@ public class WebStatFilter extends AbstractWebStatImpl implements Filter {
 
         StatFilterContext.getInstance().addContextListener(statFilterContextListener);
 
-        this.contextPath = DruidWebUtils.getContextPath(config.getServletContext());
+        this.contextPath = DruidWebUtilsJakarta.getContextPath(config.getServletContext());
         if (webAppStat == null) {
             webAppStat = new WebAppStat(contextPath, this.sessionStatMaxCount);
         }

--- a/core/src/main/java/com/alibaba/druid/util/DruidWebUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/DruidWebUtils.java
@@ -53,40 +53,7 @@ public class DruidWebUtils {
         return ip;
     }
 
-    public static String getRemoteAddr(jakarta.servlet.http.HttpServletRequest request) {
-        String ip = request.getHeader("x-forwarded-for");
-        if (ip != null && ip.contains(",")) { //截取逗号前第一个ip视为源头ip
-            ip = ip.substring(0, ip.indexOf(",")).trim();
-        }
-        if (ip != null && !isValidAddress(ip)) {
-            ip = null;
-        }
-
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("Proxy-Client-IP");
-            if (ip != null && !isValidAddress(ip)) {
-                ip = null;
-            }
-        }
-
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-            if (ip != null && !isValidAddress(ip)) {
-                ip = null;
-            }
-        }
-
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-            if (ip != null && !isValidAddress(ip)) {
-                ip = null;
-            }
-        }
-
-        return ip;
-    }
-
-    private static boolean isValidAddress(String ip) {
+    static boolean isValidAddress(String ip) {
         if (ip == null) {
             return false;
         }
@@ -119,29 +86,7 @@ public class DruidWebUtils {
         return contextPath;
     }
 
-    private static String getContextPath_2_5(jakarta.servlet.ServletContext context) {
-        String contextPath = context.getContextPath();
-
-        if (contextPath == null || contextPath.length() == 0) {
-            contextPath = "/";
-        }
-
-        return contextPath;
-    }
-
     public static String getContextPath(ServletContext context) {
-        if (context.getMajorVersion() == 2 && context.getMinorVersion() < 5) {
-            return null;
-        }
-
-        try {
-            return getContextPath_2_5(context);
-        } catch (NoSuchMethodError error) {
-            return null;
-        }
-    }
-
-    public static String getContextPath(jakarta.servlet.ServletContext context) {
         if (context.getMajorVersion() == 2 && context.getMinorVersion() < 5) {
             return null;
         }

--- a/core/src/main/java/com/alibaba/druid/util/DruidWebUtilsJakarta.java
+++ b/core/src/main/java/com/alibaba/druid/util/DruidWebUtilsJakarta.java
@@ -1,0 +1,65 @@
+package com.alibaba.druid.util;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class DruidWebUtilsJakarta {
+    private DruidWebUtilsJakarta() {
+    }
+
+  public static String getRemoteAddr(final HttpServletRequest request) {
+        String ip = request.getHeader("x-forwarded-for");
+        if (ip != null && ip.contains(",")) { //截取逗号前第一个ip视为源头ip
+            ip = ip.substring(0, ip.indexOf(",")).trim();
+        }
+        if (ip != null && !DruidWebUtils.isValidAddress(ip)) {
+            ip = null;
+        }
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+            if (ip != null && !DruidWebUtils.isValidAddress(ip)) {
+                ip = null;
+            }
+        }
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+            if (ip != null && !DruidWebUtils.isValidAddress(ip)) {
+                ip = null;
+            }
+        }
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+            if (ip != null && !DruidWebUtils.isValidAddress(ip)) {
+                ip = null;
+            }
+        }
+
+        return ip;
+    }
+
+    private static String getContextPath_2_5(final ServletContext context) {
+        String contextPath = context.getContextPath();
+
+        if (contextPath == null || contextPath.length() == 0) {
+            contextPath = "/";
+        }
+
+        return contextPath;
+    }
+
+    public static String getContextPath(final ServletContext context) {
+        if (context.getMajorVersion() == 2 && context.getMinorVersion() < 5) {
+            return null;
+        }
+
+        try {
+            return getContextPath_2_5(context);
+        } catch (NoSuchMethodError error) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
目的是为了方便旧代码j迁移到jakarta环境时，可直接使用工具完成jaxax-to-jakarta迁移而不用改代码。ie: https://projects.eclipse.org/projects/technology.transformer 原来javax/jakarta方 if都在在DruidWebUtils内进工具进行包改名后方法就重名了，会导致不兼容