### PR TITLE
fix parse mysql json_table() 'on_error' clause

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -5499,7 +5499,7 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         SQLExpr onError = x.getOnError();
         if (onError != null) {
             print(' ');
-            if (!(onEmpty instanceof SQLNullExpr || onEmpty instanceof SQLIdentifierExpr)) {
+            if (!(onError instanceof SQLNullExpr || onError instanceof SQLIdentifierExpr)) {
                 print0(ucase ? "DEFAULT " : "default ");
             }
             onError.accept(this);


### PR DESCRIPTION
修复 mysql json_table()函数的on error 子句在组装sql时的错误