### PR TITLE
fix duckDb getHoldability error while init connections

### DIFF
--- a/core/src/main/java/com/alibaba/druid/DbType.java
+++ b/core/src/main/java/com/alibaba/druid/DbType.java
@@ -100,6 +100,7 @@ public enum DbType {
      */
     polardb2(1L << 57),
     synapse(1L << 58),
+    duckdb(1L << 59),
 
     ingres(0),
     cloudscape(0),

--- a/core/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
+++ b/core/src/main/java/com/alibaba/druid/pool/DruidConnectionHolder.java
@@ -179,6 +179,7 @@ public final class DruidConnectionHolder {
                     || dbType == DbType.db2 //
                     || dbType == DbType.hive //
                     || dbType == DbType.odps //
+                    || dbType == DbType.duckdb //
             ) {
                 initUnderlyHoldability = false;
             }


### PR DESCRIPTION
**一. 修复问题：**
 修复duckDb 初始化连接时 getHoldability 异常。

**二. 异常备注：**
java.sql.SQLFeatureNotSupportedException: getHoldability
	at org.duckdb.DuckDBConnection.getHoldability(DuckDBConnection.java:369) ~[duckdb_jdbc-1.4.1.0.jar:na]
	at com.alibaba.druid.pool.DruidConnectionHolder.<init>(DruidConnectionHolder.java:123) [druid-1.1.22.jar:1.1.22]
	at com.alibaba.druid.pool.DruidConnectionHolder.<init>(DruidConnectionHolder.java:79) [druid-1.1.22.jar:1.1.22]
	at com.alibaba.druid.pool.DruidDataSource.init(DruidDataSource.java:924) [druid-1.1.22.jar:1.1.22]