### PR TITLE
[Feature] Support KeepUnicodeEscape feature to fix Hive regex parsing…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveLexer.java
@@ -57,6 +57,7 @@ public class HiveLexer extends Lexer {
                     PrimaryBangBangSupport
             )
     );
+
     static {
         Map<String, Token> map = new HashMap<>();
 
@@ -216,7 +217,10 @@ public class HiveLexer extends Lexer {
                         putChar('_');
                         break;
                     case 'u':
-                        if ((features & SQLParserFeature.SupportUnicodeCodePoint.mask) != 0) {
+                        if ((features & SQLParserFeature.KeepUnicodeEscape.mask) != 0) {
+                            putChar('\\');
+                            putChar('u');
+                        } else if ((features & SQLParserFeature.SupportUnicodeCodePoint.mask) != 0) {
                             int codePointSize = 0;
                             for (int i = 0; i < 4; i++, codePointSize++) {
                                 char c = charAt(pos + 1 + i);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/visitor/HiveOutputVisitor.java
@@ -463,7 +463,7 @@ public class HiveOutputVisitor extends SQLASTOutputVisitor implements HiveASTVis
                 char ch = text.charAt(i);
                 switch (ch) {
                     case '\\':
-                        buf.append("\\\\");
+                        buf.append("\\");
                         break;
                     case '\'':
                         buf.append("\\'");

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserFeature.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParserFeature.java
@@ -54,7 +54,8 @@ public enum SQLParserFeature {
     Presto,
     MySQLSupportStandardComment,
 
-    Template;
+    Template,
+    KeepUnicodeEscape;
 
     SQLParserFeature() {
         mask = (1 << ordinal());

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveRegContainUnicodeTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/hive/HiveRegContainUnicodeTest.java
@@ -1,0 +1,52 @@
+package com.alibaba.druid.bvt.sql.hive;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserFeature;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import com.alibaba.druid.util.JdbcConstants;
+import junit.framework.TestCase;
+
+import java.util.List;
+
+public class HiveRegContainUnicodeTest extends TestCase {
+    public void test_select() throws Exception {
+        String sql = "SELECT page_views.* " +
+                "FROM page_views " +
+                "WHERE page_views.name REGEXP '[\\u4e00-\\u9fa5]{2,}' and page_views.date >= '2008-03-01'";
+        {
+            SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.hive);
+            List<SQLStatement> statementList = parser.parseStatementList();
+            String sqlString = SQLUtils.toSQLString(statementList, DbType.hive);
+            assertEquals("SELECT page_views.*\n" +
+                    "FROM page_views\n" +
+                    "WHERE page_views.name REGEXP '[一-龥]{2,}'\n" +
+                    "\tAND page_views.date >= '2008-03-01'", sqlString);
+        }
+
+        {
+            SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.hive);
+            parser.config(SQLParserFeature.KeepUnicodeEscape, true);
+            List<SQLStatement> statementList = parser.parseStatementList();
+            String sqlString = SQLUtils.toSQLString(statementList, DbType.hive);
+
+            assertEquals("SELECT page_views.*\n" +
+                    "FROM page_views\n" +
+                    "WHERE page_views.name REGEXP '[\\u4e00-\\u9fa5]{2,}'\n" +
+                    "\tAND page_views.date >= '2008-03-01'", sqlString);
+        }
+
+        {
+            String fotmat = SQLUtils.format(sql, DbType.hive, null, null, new SQLParserFeature[]{SQLParserFeature.KeepUnicodeEscape});
+
+            assertEquals("SELECT page_views.*\n" +
+                    "FROM page_views\n" +
+                    "WHERE page_views.name REGEXP '[\\u4e00-\\u9fa5]{2,}'\n" +
+                    "\tAND page_views.date >= '2008-03-01'", fotmat);
+        }
+
+    }
+}


### PR DESCRIPTION
### 1. Problem Description
In Hive SQL, regular expressions often use Unicode escape sequences to match specific character ranges, for example:
```sql
-- Matching Chinese characters
SELECT * FROM table WHERE col REGEXP '[\u4e00-\u9fa5]+';
```

**Current Issue:**
When formatting this SQL, the parser currently converts Unicode escapes (starting with `\u`) into actual characters (e.g., converting `\u4e00` to `一`).
However, **SQL formatting should only beautify the layout** (such as newlines and indentation) and **should not alter the original content** or literal values of the SQL. Converting these escapes can break the semantics of regular expressions or cause encoding issues.

### 2. Changes
I have introduced a new feature `SQLParserFeature.KeepUnicodeEscape` to address this issue.

- **New Feature:** Added `KeepUnicodeEscape`.
- **Logic:** When this feature is enabled, the Lexer will **not** decode Unicode sequences starting with `\u` into specific characters (overriding the behavior of `SupportUnicodeCodePoint`).
- **Result:** The escape sequences are preserved as-is (raw string), ensuring the SQL content remains unchanged during formatting or parsing.

### 3. Verification
I have added a new unit test class `HiveRegContainUnicodeTest` to verify the fix.

- **Test Case 1 (Feature Disabled):** Verifies that without `KeepUnicodeEscape`, the parser follows the default `SupportUnicodeCodePoint` behavior (legacy behavior).
- **Test Case 2 (Feature Enabled):** Verifies that when `KeepUnicodeEscape` is enabled, the Unicode escapes (e.g., `\u4e00`) are **not** escaped/decoded and are output exactly as the original input string.
