### PR TITLE
fix: support BigQuery UNNEST WITH OFFSET without AS alias (#6547)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnnestTableSource.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnnestTableSource.java
@@ -13,6 +13,7 @@ public class SQLUnnestTableSource extends SQLTableSourceImpl
     private final List<SQLExpr> items = new ArrayList<SQLExpr>();
     protected List<SQLName> columns = new ArrayList<SQLName>();
     private boolean ordinality;
+    private boolean withOffset;
     private SQLExpr offset;
 
     public SQLUnnestTableSource() {
@@ -70,6 +71,14 @@ public class SQLUnnestTableSource extends SQLTableSourceImpl
         this.offset = x;
     }
 
+    public boolean isWithOffset() {
+        return withOffset;
+    }
+
+    public void setWithOffset(boolean withOffset) {
+        this.withOffset = withOffset;
+    }
+
     public SQLUnnestTableSource clone() {
         SQLUnnestTableSource x = new SQLUnnestTableSource();
 
@@ -90,6 +99,8 @@ public class SQLUnnestTableSource extends SQLTableSourceImpl
         if (offset != null) {
             x.setOffset(offset);
         }
+
+        x.withOffset = withOffset;
 
         return x;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1400,10 +1400,19 @@ public class SQLSelectParser extends SQLParser {
 
                 if (lexer.nextIf(Token.WITH)) {
                     acceptIdentifier("OFFSET");
-                    lexer.nextIf(Token.AS);
-                    unnest.setOffset(
-                            this.exprParser.expr()
-                    );
+                    unnest.setWithOffset(true);
+                    if (lexer.nextIf(Token.AS)) {
+                        unnest.setOffset(
+                                this.exprParser.expr()
+                        );
+                    } else {
+                        String offsetAlias = this.tableAlias(false);
+                        if (offsetAlias != null) {
+                            unnest.setOffset(
+                                    new com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr(offsetAlias)
+                            );
+                        }
+                    }
                 }
                 return unnest;
             } else {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -5152,6 +5152,8 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         if (x.getOffset() != null) {
             print0(ucase ? " WITH OFFSET AS " : " with offset as ");
             x.getOffset().accept(this);
+        } else if (x.isWithOffset()) {
+            print0(ucase ? " WITH OFFSET" : " with offset");
         }
         printPivot(x.getPivot());
         printUnpivot(x.getUnpivot());


### PR DESCRIPTION
## Problem / 问题

BigQuery SQL `SELECT * FROM UNNEST([10,20,30]) as numbers WITH OFFSET` fails with `ParserException` because the parser unconditionally calls `exprParser.expr()` after `WITH OFFSET`, even when no `AS alias` is specified.

BigQuery SQL `SELECT * FROM UNNEST([10,20,30]) as numbers WITH OFFSET` 解析失败，抛出 `ParserException`。原因是解析器在 `WITH OFFSET` 后无条件调用 `exprParser.expr()`，即使没有 `AS alias`。

## Root Cause / 根因

In `SQLSelectParser.parseUnnestTableSource()`, the code was:
```java
lexer.nextIf(Token.AS);  // AS is optional
unnest.setOffset(this.exprParser.expr());  // always called — fails on ";"
```

When `WITH OFFSET` has no `AS alias`, the next token is `;` (or EOF), and `expr()` cannot parse it.

在 `SQLSelectParser.parseUnnestTableSource()` 中，`AS` 是可选的，但 `expr()` 总是被调用。当 `WITH OFFSET` 后面没有 `AS alias` 时，下一个 token 是 `;`（或 EOF），`expr()` 无法解析。

## Fix / 修复

1. **`SQLSelectParser.java`**: Make the offset alias truly optional — only parse an alias expression when `AS` is present or a valid identifier follows.
2. **`SQLUnnestTableSource.java`**: Add `boolean withOffset` field to distinguish "has `WITH OFFSET` but no alias" from "no `WITH OFFSET` at all".
3. **`SQLASTOutputVisitor.java`**: Output `WITH OFFSET` (without `AS`) when `withOffset` is true but no alias expression exists.

## Tests / 测试

Added 3 test cases to `UnnestTest.java`:
- `test_unnest_with_offset_no_alias`: `WITH OFFSET` without any alias (the reported bug)
- `test_unnest_with_offset_as_alias`: `WITH OFFSET AS off` (existing behavior, regression check)
- `test_unnest_with_offset_implicit_alias`: `WITH OFFSET off` (without `AS` keyword, but with alias)

All 4 tests pass (including the original `test_0`).

Closes #6547