### PR TITLE
fix infinite loop parsing PostgreSQL ANALYZE/VACUUM without table nam…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -1195,6 +1195,13 @@ public class PGSQLStatementParser extends SQLStatementParser {
         Lexer.SavePoint mark = lexer.mark();
         String strVal = lexer.stringVal();
         for (; ; ) {
+            if (Token.SEMI.equals(lexer.token())) {
+                stmt.setAfterSemi(true);
+                return stmt;
+            }
+            if (Token.EOF.equals(lexer.token())) {
+                return stmt;
+            }
             if (strVal.equalsIgnoreCase("VERBOSE")) {
                 stmt.setVerbose(true);
                 lexer.nextToken();
@@ -1233,8 +1240,7 @@ public class PGSQLStatementParser extends SQLStatementParser {
                 stmt.setAfterSemi(true);
                 return stmt;
             }
-            if (lexer.isEOF()) {
-                lexer.nextToken();
+            if (Token.EOF.equals(lexer.token())) {
                 return stmt;
             }
             if (strVal.equalsIgnoreCase("FULL")) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6595.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6595.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Fix infinite loop when parsing PostgreSQL ANALYZE/VACUUM without trailing table names or semicolons.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6595">Issue #6595</a>
+ */
+public class Issue6595 {
+    @Test
+    public void test_analyze_skip_locked_no_semicolon() {
+        for (DbType dbType : new DbType[]{DbType.postgresql, DbType.greenplum, DbType.edb}) {
+            for (String sql : new String[]{
+                "ANALYZE SKIP_LOCKED",
+                "ANALYZE VERBOSE",
+                "ANALYZE VERBOSE SKIP_LOCKED",
+                "ANALYZE SKIP_LOCKED VERBOSE",
+            }) {
+                SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                List<SQLStatement> stmtList = parser.parseStatementList();
+                assertEquals(1, stmtList.size());
+                assertNotNull(stmtList.get(0));
+            }
+        }
+    }
+
+    @Test
+    public void test_vacuum_options_no_semicolon() {
+        for (DbType dbType : new DbType[]{DbType.postgresql, DbType.greenplum, DbType.edb}) {
+            for (String sql : new String[]{
+                "VACUUM FULL",
+                "VACUUM VERBOSE",
+                "VACUUM FREEZE",
+                "VACUUM FULL VERBOSE FREEZE",
+            }) {
+                SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, dbType);
+                List<SQLStatement> stmtList = parser.parseStatementList();
+                assertEquals(1, stmtList.size());
+                assertNotNull(stmtList.get(0));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…es (#6595)

When parsing `ANALYZE SKIP_LOCKED` or `ANALYZE VERBOSE` without trailing table names or semicolons, the parser entered an infinite loop because the lexer's stringVal is not cleared at EOF, causing the for-loop to repeatedly match the same keyword.

Add Token.EOF and Token.SEMI checks to parseAnalyzeTable() (matching the pattern in parseVacuumTable()), and fix parseVacuumTable() to use Token.EOF instead of lexer.isEOF() which returns true prematurely based on position rather than token state.