### PR TITLE
fix SQL Server ALTER VIEW / CREATE VIEW parsing without AS keyword (#…

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -2212,7 +2212,7 @@ public class SQLStatementParser extends SQLParser {
             break;
         }
 
-        if (lexer.nextIf(AS)) {
+        if (lexer.nextIf(AS) || lexer.token() == SELECT) {
             if (lexer.token() == SELECT) {
                 alterView.setSubQuery(
                         createSQLSelectParser()
@@ -5143,7 +5143,9 @@ public class SQLStatementParser extends SQLParser {
     }
 
     protected void createViewAs(SQLCreateViewStatement createView) {
-        accept(Token.AS);
+        if (lexer.token == Token.AS) {
+            lexer.nextToken();
+        }
 
         if (lexer.identifierEquals(Constants.BEGIN)) {
             SQLBlockStatement block = (SQLBlockStatement) this.parseBlock();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6591.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6591.java
@@ -1,0 +1,60 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Fix SQL Server ALTER VIEW parsing when AS keyword is omitted before SELECT.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6591">Issue #6591</a>
+ */
+public class Issue6591 {
+    @Test
+    public void test_alter_view_without_as() {
+        String sql = "ALTER VIEW [dbo].[V_CollectInstock]\n"
+                + "    SELECT a.Supplier AS 'Customer',\n"
+                + "           a.VoucherCode AS VoucherCode,\n"
+                + "           '采购入库' AS TYPE\n"
+                + "    FROM T_Oper_InStockVoucher a";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertNotNull(stmtList.get(0));
+    }
+
+    @Test
+    public void test_alter_view_with_as() {
+        String sql = "ALTER VIEW [dbo].[V_CollectInstock] AS\n"
+                + "    SELECT a.Supplier AS 'Customer',\n"
+                + "           a.VoucherCode AS VoucherCode,\n"
+                + "           '采购入库' AS TYPE\n"
+                + "    FROM T_Oper_InStockVoucher a";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertNotNull(stmtList.get(0));
+    }
+
+    @Test
+    public void test_create_view_without_as() {
+        String sql = "CREATE VIEW [dbo].[V_CollectInstock]\n"
+                + "    SELECT a.Supplier AS 'Customer',\n"
+                + "           a.VoucherCode AS VoucherCode\n"
+                + "    FROM T_Oper_InStockVoucher a";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertNotNull(stmtList.get(0));
+    }
+}


### PR DESCRIPTION
…6591)

Make the AS keyword optional before SELECT in ALTER VIEW and CREATE VIEW statements, so that scripts omitting AS are parsed without errors.