### PR TITLE
fix SQL Server ALTER PROCEDURE parsing with WITH EXECUTE AS (#6590)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
@@ -606,6 +606,107 @@ public class SQLServerStatementParser extends SQLStatementParser {
         return stmt;
     }
 
+    @Override
+    public SQLCreateProcedureStatement parseCreateProcedure() {
+        SQLCreateProcedureStatement stmt = new SQLCreateProcedureStatement();
+        stmt.setDbType(dbType);
+
+        if (lexer.token() == Token.CREATE) {
+            lexer.nextToken();
+            if (lexer.token() == Token.OR) {
+                lexer.nextToken();
+                accept(Token.REPLACE);
+                stmt.setOrReplace(true);
+            }
+        } else {
+            stmt.setCreate(false);
+        }
+
+        if (lexer.token() == Token.PROCEDURE || lexer.identifierEquals("PROC")) {
+            lexer.nextToken();
+        }
+
+        stmt.setName(this.exprParser.name());
+
+        // SQL Server parameters: @param type, @param2 type ...  (no parentheses)
+        if (lexer.token() == Token.VARIANT || lexer.token() == Token.LPAREN) {
+            boolean useParen = lexer.token() == Token.LPAREN;
+            if (useParen) {
+                lexer.nextToken();
+            }
+            parseSQLServerProcedureParameters(stmt);
+            if (useParen) {
+                accept(Token.RPAREN);
+            }
+        }
+
+        // WITH EXECUTE AS { CALLER | SELF | OWNER | 'user_name' }
+        // or WITH RECOMPILE, ENCRYPTION, etc.
+        if (lexer.token() == Token.WITH) {
+            lexer.nextToken();
+            if (lexer.identifierEquals(FnvHash.Constants.EXECUTE)) {
+                lexer.nextToken();
+                accept(Token.AS);
+                SQLName executeAs = this.exprParser.name();
+                stmt.setAuthid(executeAs);
+            } else {
+                // skip other WITH options like RECOMPILE, ENCRYPTION
+                this.exprParser.name();
+                while (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    this.exprParser.name();
+                }
+            }
+        }
+
+        if (lexer.token() == Token.AS) {
+            lexer.nextToken();
+        }
+
+        SQLStatement block = this.parseBlock();
+        stmt.setBlock(block);
+
+        return stmt;
+    }
+
+    @Override
+    protected SQLStatement alterProcedure() {
+        accept(Token.ALTER);
+        return parseCreateProcedure();
+    }
+
+    private void parseSQLServerProcedureParameters(SQLCreateProcedureStatement stmt) {
+        for (; ; ) {
+            if (lexer.token() == Token.RPAREN || lexer.token() == Token.AS
+                    || lexer.token() == Token.WITH || lexer.token() == Token.EOF) {
+                break;
+            }
+
+            SQLParameter parameter = new SQLParameter();
+            parameter.setParamType(SQLParameter.ParameterType.DEFAULT);
+            parameter.setName(this.exprParser.name());
+            parameter.setDataType(this.exprParser.parseDataType());
+
+            if (lexer.token() == Token.EQ) {
+                lexer.nextToken();
+                parameter.setDefaultValue(this.exprParser.expr());
+            }
+
+            if (lexer.token() == Token.OUT || lexer.identifierEquals("OUTPUT")) {
+                parameter.setParamType(SQLParameter.ParameterType.OUT);
+                lexer.nextToken();
+            }
+
+            stmt.getParameters().add(parameter);
+
+            if (lexer.token() == Token.COMMA) {
+                lexer.nextToken();
+            } else {
+                break;
+            }
+        }
+    }
+
     public void parseAlterDrop(SQLAlterTableStatement stmt) {
         lexer.nextToken();
         if (lexer.token() == Token.CONSTRAINT) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
@@ -567,6 +567,53 @@ public class SQLServerOutputVisitor extends SQLASTOutputVisitor implements SQLSe
     }
 
     @Override
+    public boolean visit(SQLCreateProcedureStatement x) {
+        if (x.isCreate()) {
+            if (x.isOrReplace()) {
+                print0(ucase ? "CREATE OR ALTER PROCEDURE " : "create or alter procedure ");
+            } else {
+                print0(ucase ? "CREATE PROCEDURE " : "create procedure ");
+            }
+        } else {
+            print0(ucase ? "ALTER PROCEDURE " : "alter procedure ");
+        }
+
+        x.getName().accept(this);
+
+        int paramSize = x.getParameters().size();
+        if (paramSize > 0) {
+            this.indentCount++;
+            for (int i = 0; i < paramSize; ++i) {
+                println();
+                SQLParameter param = x.getParameters().get(i);
+                param.accept(this);
+                if (i < paramSize - 1) {
+                    print(',');
+                }
+            }
+            this.indentCount--;
+        }
+
+        SQLName authid = x.getAuthid();
+        if (authid != null) {
+            println();
+            print0(ucase ? "WITH EXECUTE AS " : "with execute as ");
+            authid.accept(this);
+        }
+
+        println();
+        print0(ucase ? "AS" : "as");
+        println();
+
+        SQLStatement block = x.getBlock();
+        if (block != null) {
+            block.accept(this);
+        }
+
+        return false;
+    }
+
+    @Override
     protected void printAfterFetch(SQLSelectQueryBlock queryBlock) {
         if (queryBlock instanceof SQLServerSelectQueryBlock) {
             SQLServerSelectQueryBlock sqlServerSelectQueryBlock = ((SQLServerSelectQueryBlock) queryBlock);

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6590.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6590.java
@@ -1,0 +1,101 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLCreateProcedureStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6590">Issue 6590: SQL Server ALTER PROCEDURE with WITH EXECUTE AS CALLER</a>
+ */
+public class Issue6590 {
+    @Test
+    public void test_alter_procedure_with_execute_as_caller() {
+        String sql = "ALTER PROCEDURE [dbo].[sp_FJZ_UKB]\n" +
+                "    @OIS_Flag INT,\n" +
+                "    @OIS_Type INT,\n" +
+                "    @OIS_Style INT,\n" +
+                "    @VoucherCode VARCHAR(100),\n" +
+                "    @VoucherCodeNew VARCHAR(100),\n" +
+                "    @ExecutedBy VARCHAR(20)\n" +
+                "    WITH EXECUTE AS CALLER\n" +
+                "AS\n" +
+                "BEGIN\n" +
+                "    SET NOCOUNT ON;\n" +
+                "    SET XACT_ABORT ON;\n" +
+                "    BEGIN TRY\n" +
+                "        BEGIN TRANSACTION;\n" +
+                "        SELECT 1;\n" +
+                "        COMMIT TRANSACTION;\n" +
+                "    END TRY\n" +
+                "    BEGIN CATCH\n" +
+                "        ROLLBACK TRANSACTION;\n" +
+                "    END CATCH\n" +
+                "END";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        assertEquals(1, statementList.size());
+
+        SQLStatement stmt = statementList.get(0);
+        assertTrue(stmt instanceof SQLCreateProcedureStatement);
+
+        SQLCreateProcedureStatement proc = (SQLCreateProcedureStatement) stmt;
+        assertFalse(proc.isCreate());
+        assertEquals("[dbo].[sp_FJZ_UKB]", proc.getName().toString());
+        assertEquals(6, proc.getParameters().size());
+        assertNotNull(proc.getAuthid());
+        assertEquals("CALLER", proc.getAuthid().toString());
+        assertNotNull(proc.getBlock());
+    }
+
+    @Test
+    public void test_create_procedure() {
+        String sql = "CREATE PROCEDURE [dbo].[sp_Test]\n" +
+                "    @Param1 INT,\n" +
+                "    @Param2 VARCHAR(100)\n" +
+                "AS\n" +
+                "BEGIN\n" +
+                "    SET NOCOUNT ON;\n" +
+                "END";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        assertEquals(1, statementList.size());
+
+        SQLStatement stmt = statementList.get(0);
+        assertTrue(stmt instanceof SQLCreateProcedureStatement);
+
+        SQLCreateProcedureStatement proc = (SQLCreateProcedureStatement) stmt;
+        assertTrue(proc.isCreate());
+        assertEquals(2, proc.getParameters().size());
+        assertNotNull(proc.getBlock());
+    }
+
+    @Test
+    public void test_alter_procedure_simple() {
+        String sql = "ALTER PROCEDURE [dbo].[sp_Test]\n" +
+                "    @Param1 INT\n" +
+                "AS\n" +
+                "BEGIN\n" +
+                "    SELECT 1;\n" +
+                "END";
+
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        assertEquals(1, statementList.size());
+
+        SQLCreateProcedureStatement proc = (SQLCreateProcedureStatement) statementList.get(0);
+        assertFalse(proc.isCreate());
+        assertEquals(1, proc.getParameters().size());
+    }
+}


### PR DESCRIPTION
Override parseCreateProcedure() and alterProcedure() in SQLServerStatementParser to handle SQL Server procedure syntax including parameters without parentheses and WITH EXECUTE AS clause. Add corresponding output visitor support.