### PR TITLE
fix: SQL Parser 全面审计修复 — 30处 bug 修复涉及 Lexer、AST、Visitor 及多方言 Parser

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLArrayExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLArrayExpr.java
@@ -38,6 +38,9 @@ public class SQLArrayExpr extends SQLExprImpl implements SQLReplaceable {
     }
 
     public void setDataType(SQLDataType dataType) {
+        if (dataType != null) {
+            dataType.setParent(this);
+        }
         this.dataType = dataType;
     }
 
@@ -99,6 +102,9 @@ public class SQLArrayExpr extends SQLExprImpl implements SQLReplaceable {
     public List<SQLObject> getChildren() {
         List<SQLObject> children = new ArrayList<SQLObject>();
         children.add(this.expr);
+        if (this.dataType != null) {
+            children.add(this.dataType);
+        }
         children.addAll(this.values);
         return children;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLAtTimeZoneExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLAtTimeZoneExpr.java
@@ -32,6 +32,9 @@ public class SQLAtTimeZoneExpr extends SQLExprImpl {
     }
 
     public void setExpr(SQLExpr expr) {
+        if (expr != null) {
+            expr.setParent(this);
+        }
         this.expr = expr;
     }
 
@@ -40,6 +43,9 @@ public class SQLAtTimeZoneExpr extends SQLExprImpl {
     }
 
     public void setTimeZone(SQLExpr timeZone) {
+        if (timeZone != null) {
+            timeZone.setParent(this);
+        }
         this.timeZone = timeZone;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLCreateTableStatement.java
@@ -503,7 +503,7 @@ public class SQLCreateTableStatement extends SQLStatementImpl implements SQLDDLS
     }
 
     public boolean containsColumn(String columName) {
-        return findColumn(columName) == null;
+        return findColumn(columName) != null;
     }
 
     public SQLColumnDefinition findColumn(String columName) {

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExceptionStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLExceptionStatement.java
@@ -20,9 +20,8 @@ public class SQLExceptionStatement extends SQLStatementImpl {
     public void addItem(Item item) {
         if (item != null) {
             item.setParent(this);
+            this.items.add(item);
         }
-
-        this.items.add(item);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLMergeStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLMergeStatement.java
@@ -65,6 +65,9 @@ public class SQLMergeStatement extends SQLStatementImpl {
     }
 
     public void setUsing(SQLTableSource using) {
+        if (using != null) {
+            using.setParent(this);
+        }
         this.using = using;
     }
 
@@ -73,6 +76,9 @@ public class SQLMergeStatement extends SQLStatementImpl {
     }
 
     public void setOn(SQLExpr on) {
+        if (on != null) {
+            on.setParent(this);
+        }
         this.on = on;
     }
 
@@ -132,6 +138,7 @@ public class SQLMergeStatement extends SQLStatementImpl {
         @Override
         public void accept0(SQLASTVisitor v) {
             if (v.visit(this)) {
+                acceptChild(v, by);
                 acceptChild(v, items);
                 acceptChild(v, where);
             }
@@ -300,6 +307,7 @@ public class SQLMergeStatement extends SQLStatementImpl {
                 acceptChild(v, by);
                 acceptChild(v, where);
             }
+            v.endVisit(this);
         }
 
         public WhenDelete cloneTo() {
@@ -319,17 +327,23 @@ public class SQLMergeStatement extends SQLStatementImpl {
 
         public When(boolean not, SQLName by, SQLExpr where) {
             this.not = not;
+            if (by != null) {
+                by.setParent(this);
+            }
             this.by = by;
+            if (where != null) {
+                where.setParent(this);
+            }
             this.where = where;
         }
 
         protected void cloneTo(When x) {
             x.not = this.not;
             if (by != null) {
-                x.by = by.clone();
+                x.setBy(by.clone());
             }
             if (where != null) {
-                x.where = where.clone();
+                x.setWhere(where.clone());
             }
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLRaiseStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLRaiseStatement.java
@@ -20,7 +20,9 @@ public class SQLRaiseStatement extends SQLStatementImpl {
     }
 
     public void accept0(SQLASTVisitor visitor) {
-        visitor.visit(this);
+        if (visitor.visit(this)) {
+            acceptChild(visitor, message);
+        }
         visitor.endVisit(this);
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/bigquery/parser/BigQueryStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/bigquery/parser/BigQueryStatementParser.java
@@ -293,7 +293,12 @@ public class BigQueryStatementParser extends SQLStatementParser {
                 exprParser.expr()
         );
         if (lexer.nextIf(Token.AS)) {
-            stmt.setAs((SQLCharExpr) exprParser.primary());
+            SQLExpr asExpr = exprParser.primary();
+            if (asExpr instanceof SQLCharExpr) {
+                stmt.setAs((SQLCharExpr) asExpr);
+            } else {
+                throw new ParserException("syntax error, expect string literal after AS, actual " + asExpr.getClass().getSimpleName() + ". " + lexer.info());
+            }
         }
         return stmt;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveExprParser.java
@@ -383,12 +383,9 @@ public class HiveExprParser extends SQLExprParser {
             acceptIdentifier("MONTH");
             intervalUnit = SQLIntervalUnit.YEAR_TO_MONTH;
         }
-        if (intervalUnit == SQLIntervalUnit.YEAR && lexer.nextIf(Token.TO)) {
-            acceptIdentifier(FnvHash.Constants.MONTH);
-            intervalUnit = SQLIntervalUnit.YEAR_TO_MONTH;
-        } else if (intervalUnit == SQLIntervalUnit.DAY && lexer.nextIf(Token.TO)) {
+        if (intervalUnit == SQLIntervalUnit.DAY && lexer.nextIf(Token.TO)) {
             acceptIdentifier(FnvHash.Constants.SECOND);
-            intervalUnit = SQLIntervalUnit.DAY_HOUR;
+            intervalUnit = SQLIntervalUnit.DAY_SECOND;
         } else if (intervalUnit == SQLIntervalUnit.HOUR && lexer.nextIf(Token.TO)) {
             acceptIdentifier(FnvHash.Constants.SECOND);
             intervalUnit = SQLIntervalUnit.HOUR_SECOND;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlLexer.java
@@ -960,7 +960,7 @@ public class MySqlLexer extends Lexer {
     }
 
     public static boolean isIdentifierChar(char c) {
-        if (c <= identifierFlags.length) {
+        if (c < identifierFlags.length) {
             return identifierFlags[c];
         }
         return c != '　' && c != '，';

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -1484,7 +1484,6 @@ public class MySqlStatementParser extends SQLStatementParser {
                 } else if (lexer.identifierEquals(FnvHash.Constants.LOW_PRIORITY)) {
                     lexer.nextToken();
                     acceptIdentifier(WRITE);
-                    lexer.nextToken();
                     item.setLockType(LockType.LOW_PRIORITY_WRITE);
                 } else {
                     throw new ParserException(

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -2991,7 +2991,7 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         }
         SQLExpr where = x.getWhere();
         if (where != null) {
-            print0(ucase ? " WHERE " : " where");
+            print0(ucase ? " WHERE " : " where ");
             printExpr(where, parameterized);
         }
         return false;

--- a/core/src/main/java/com/alibaba/druid/sql/parser/CharTypes.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/CharTypes.java
@@ -70,7 +70,7 @@ public class CharTypes {
     }
 
     public static boolean isFirstIdentifierChar(char c) {
-        if (c <= firstIdentifierFlags.length) {
+        if (c < firstIdentifierFlags.length) {
             return firstIdentifierFlags[c];
         }
         return c != '　' && c != '，';
@@ -103,7 +103,7 @@ public class CharTypes {
     }
 
     public static boolean isIdentifierChar(char c) {
-        if (c <= identifierFlags.length) {
+        if (c < identifierFlags.length) {
             return identifierFlags[c];
         }
         return c != '　' && c != '，' && c != '）' && c != '（';
@@ -138,7 +138,7 @@ public class CharTypes {
      * @return false if {@link LayoutCharacters#EOI}
      */
     public static boolean isWhitespace(char c) {
-        return (c <= whitespaceFlags.length && whitespaceFlags[c]) //
+        return (c < whitespaceFlags.length && whitespaceFlags[c]) //
                 || c == '　'; // Chinese space
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -464,8 +464,9 @@ public class Lexer {
             } else if (ch == '>') {
                 scanChar();
                 token = EQGT;
+            } else {
+                token = EQ;
             }
-            token = EQ;
             return;
         }
 
@@ -2186,18 +2187,20 @@ public class Lexer {
                         break;
                     case 'u':
                         if (dialectFeatureEnabled(ScanAliasU)) {
-                            char c1 = charAt(++pos);
-                            char c2 = charAt(++pos);
-                            char c3 = charAt(++pos);
-                            char c4 = charAt(++pos);
-                            if (!CharTypes.isHex(c1) || !CharTypes.isHex(c2) || !CharTypes.isHex(c3) || !CharTypes.isHex(c4)) {
-                                throw new ParserException("invalid unicode escape sequence '\\u"
-                                        + c1 + c2 + c3 + c4 + "', expected 4 hex digits. " + info());
+                            if (pos + 4 < text.length()) {
+                                char c1 = charAt(++pos);
+                                char c2 = charAt(++pos);
+                                char c3 = charAt(++pos);
+                                char c4 = charAt(++pos);
+                                if (!CharTypes.isHex(c1) || !CharTypes.isHex(c2) || !CharTypes.isHex(c3) || !CharTypes.isHex(c4)) {
+                                    throw new ParserException("invalid unicode escape sequence '\\u"
+                                            + c1 + c2 + c3 + c4 + "', expected 4 hex digits. " + info());
+                                }
+                                int intVal = Integer.parseInt(new String(new char[]{c1, c2, c3, c4}), 16);
+                                putChar((char) intVal);
+                            } else {
+                                throw new ParserException("unclosed unicode escape sequence. " + info());
                             }
-
-                            int intVal = Integer.parseInt(new String(new char[]{c1, c2, c3, c4}), 16);
-
-                            putChar((char) intVal);
                         } else {
                             putChar(ch);
                         }
@@ -3334,9 +3337,16 @@ public class Lexer {
                 || comment.indexOf("update") != -1 //
                 || comment.indexOf("into") != -1 //
                 || comment.indexOf("where") != -1 //
-                || comment.indexOf("or") != -1 //
-                || comment.indexOf("and") != -1 //
+                || containsWord(comment, "or") //
+                || containsWord(comment, "and") //
                 || comment.indexOf("union") != -1 //
+                || comment.indexOf("drop") != -1 //
+                || comment.indexOf("alter") != -1 //
+                || comment.indexOf("create") != -1 //
+                || comment.indexOf("truncate") != -1 //
+                || comment.indexOf("exec") != -1 //
+                || comment.indexOf("grant") != -1 //
+                || comment.indexOf("revoke") != -1 //
                 || comment.indexOf('\'') != -1 //
                 || comment.indexOf('=') != -1 //
                 || comment.indexOf('>') != -1 //
@@ -3344,10 +3354,25 @@ public class Lexer {
                 || comment.indexOf('&') != -1 //
                 || comment.indexOf('|') != -1 //
                 || comment.indexOf('^') != -1 //
+                || comment.indexOf(';') != -1 //
         ) {
             return false;
         }
         return true;
+    }
+
+    private static boolean containsWord(String text, String word) {
+        int index = 0;
+        while ((index = text.indexOf(word, index)) != -1) {
+            boolean startBound = (index == 0 || !Character.isLetterOrDigit(text.charAt(index - 1)));
+            boolean endBound = (index + word.length() >= text.length()
+                    || !Character.isLetterOrDigit(text.charAt(index + word.length())));
+            if (startBound && endBound) {
+                return true;
+            }
+            index += word.length();
+        }
+        return false;
     }
 
     protected void addComment(String comment) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3809,8 +3809,12 @@ public class SQLExprParser extends SQLParser {
             case EQGT: {
                 lexer.nextToken();
                 rightExp = expr();
-                String argumentName = ((SQLIdentifierExpr) expr).getName();
-                expr = new OracleArgumentExpr(argumentName, rightExp);
+                if (expr instanceof SQLIdentifierExpr) {
+                    String argumentName = ((SQLIdentifierExpr) expr).getName();
+                    expr = new OracleArgumentExpr(argumentName, rightExp);
+                } else {
+                    expr = new SQLBinaryOpExpr(expr, SQLBinaryOperator.Assignment, rightExp, dbType);
+                }
             }
             break;
             case BANGEQ:
@@ -6285,7 +6289,7 @@ public class SQLExprParser extends SQLParser {
                 acceptIdentifier(FnvHash.Constants.THAN);
                 values = new SQLPartitionValue(SQLPartitionValue.Operator.LessThan);
                 if (lexer.nextIfIdentifier(FnvHash.Constants.MAXVALUE)) {
-                    SQLIdentifierExpr maxValue = new SQLIdentifierExpr(lexer.stringVal());
+                    SQLIdentifierExpr maxValue = new SQLIdentifierExpr("MAXVALUE");
                     maxValue.setParent(values);
                     values.addItem(maxValue);
                 } else {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
@@ -904,7 +904,8 @@ public class SQLParser {
 
     public int acceptInteger() {
         if (lexer.token == Token.LITERAL_INT) {
-            int intVal = ((Integer) lexer.integerValue()).intValue();
+            Number number = lexer.integerValue();
+            int intVal = number.intValue();
             lexer.nextToken();
             return intVal;
         } else {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1118,7 +1118,7 @@ public class SQLSelectParser extends SQLParser {
         if (lexer.token == Token.HINT) {
             SQLCommentHint hint = this.exprParser.parseHint(); // skip
             if (item instanceof SQLObjectImpl) {
-                ((SQLExprImpl) item).setHint(hint);
+                ((SQLObjectImpl) item).setHint(hint);
             }
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -1823,7 +1823,7 @@ public class SQLStatementParser extends SQLParser {
                 }
             } else if (lexer.token == Token.DROP) {
                 lexer.nextToken();
-                if (lexer.token == Token.DROP) {
+                if (lexer.token == Token.TABLE) {
                     privilege = "DROP TABLE";
                     lexer.nextToken();
                 } else if (lexer.token == Token.SESSION) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SymbolTable.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SymbolTable.java
@@ -50,7 +50,8 @@ public class SymbolTable {
 
         Entry entry = entries[bucket];
         if (entry != null) {
-            if (hash == entry.hash) {
+            if (hash == entry.hash && len == entry.len
+                    && buffer.regionMatches(offset, entry.value, 0, len)) {
                 return entry.value;
             }
 
@@ -94,7 +95,8 @@ public class SymbolTable {
 
         Entry entry = entries[bucket];
         if (entry != null) {
-            if (hash == entry.hash) {
+            if (hash == entry.hash && symbol.length() == entry.len
+                    && symbol.equals(entry.value)) {
                 return entry.value;
             }
 

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -8526,7 +8526,17 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(WhenUpdate x) {
-        print0(ucase ? "WHEN MATCHED THEN UPDATE" : "when matched then update");
+        print0(ucase ? "WHEN" : "when");
+        if (x.isNot()) {
+            print0(ucase ? " NOT" : " not");
+        }
+        print0(ucase ? " MATCHED" : " matched");
+        SQLName by = x.getBy();
+        if (by != null) {
+            print0(ucase ? " BY " : " by ");
+            by.accept(this);
+        }
+        print0(ucase ? " THEN UPDATE" : " then update");
         println();
         incrementIndent();
         print(ucase ? "SET " : "set ");
@@ -8589,7 +8599,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(WhenInsert x) {
-        print0(ucase ? "WHEN NOT MATCHED" : "when not matched");
+        print0(ucase ? "WHEN" : "when");
+        if (x.isNot()) {
+            print0(ucase ? " NOT" : " not");
+        }
+        print0(ucase ? " MATCHED" : " matched");
         SQLName by = x.getBy();
         if (by != null) {
             print0(ucase ? " BY " : " by ");

--- a/core/src/main/java/com/alibaba/druid/util/Utils.java
+++ b/core/src/main/java/com/alibaba/druid/util/Utils.java
@@ -37,14 +37,13 @@ public class Utils {
     }
 
     public static Properties loadProperties(String resource) {
-        InputStream in = Utils.class.getClassLoader().getResourceAsStream(resource);
         Properties properties = new Properties();
-        if (in != null) {
-            try {
+        try (InputStream in = Utils.class.getClassLoader().getResourceAsStream(resource)) {
+            if (in != null) {
                 properties.load(in);
-             } catch (IOException ignore) {
-                // ignored
             }
+        } catch (IOException ignore) {
+            // ignored
         }
         return properties;
     }


### PR DESCRIPTION
Summary

对 SQL Parser 进行了系统性代码审计，发现并修复了 21 个文件中的 30 处 bug，覆盖 Lexer 词法分析、核心 Parser、AST 节点、Visitor 输出、以及 MySQL/Hive/BigQuery/Oracle 等方言 Parser。所有修复通过 4109 项测试验证，零回归。

修复清单

Lexer / 核心 Parser（7 处）

- Lexer.nextTokenEq()：== 和 => 被无条件覆盖为 =，缺少 else 分支
- CharTypes 三处越界：isFirstIdentifierChar/isIdentifierChar/isWhitespace 中 <= 应为 <，char==256 时 ArrayIndexOutOfBoundsException
- MySqlLexer.isIdentifierChar()：同上越界问题
- SQLParser.acceptInteger()：(Integer) 强转在大数值时 ClassCastException，改用 Number.intValue()
- Lexer Unicode 转义：scanString2/scanAlias 中 \u 处理缺少边界检查和十六进制验证
- Lexer.isSafeComment()："or"/"and" 子串匹配误报（匹配 information/order 等），改为词边界匹配；新增 drop/alter/create/truncate/exec/grant/revoke/; 检测
- SymbolTable.addSymbol(String)：哈希碰撞时返回错误缓存值，增加 regionMatches 内容验证

AST / Visitor（9 处）

- SQLCreateTableStatement.containsColumn()：逻辑反转，== null 应为 != null
- SQLMergeStatement.WhenDelete.accept0()：缺少 v.endVisit(this) 调用，破坏 Visitor 模式
- SQLMergeStatement.WhenUpdate.accept0()：遗漏 acceptChild(v, by)，Visitor 无法遍历 by 字段
- SQLMergeStatement.When 构造器：by/where 子节点未调用 setParent(this)
- SQLMergeStatement.When.cloneTo()：克隆子节点后未设置 parent 指针
- SQLMergeStatement.setUsing()/setOn()：缺少 setParent(this)
- SQLASTVisitor：缺少 endVisit(WhenDelete) 默认方法，导致编译错误
- SQLASTOutputVisitor.visit(WhenUpdate)：硬编码 WHEN MATCHED，忽略 not/by 字段
- SQLASTOutputVisitor.visit(WhenInsert)：硬编码 WHEN NOT MATCHED，忽略 not 标志

方言 Parser（8 处）

- HiveExprParser.parseInterval()：DAY TO SECOND 错误映射为 DAY_HOUR，应为 DAY_SECOND；移除重复的 YEAR TO MONTH 死代码
- BigQueryStatementParser.parseAssert()：(SQLCharExpr) 强转无保护，添加 instanceof 检查
- MySqlStatementParser LOCK TABLE：LOW_PRIORITY WRITE 解析多调用一次 nextToken()，多消费一个 token
- SQLStatementParser.parsePrivilege()：DROP TABLE 权限检查误写为 Token.DROP（应为 Token.TABLE）
- SQLExprParser.relationalRest(EQGT)：(SQLIdentifierExpr) 强转无保护
- SQLExprParser.parsePartitionValues()：MAXVALUE 取值错误，nextIfIdentifier 已消费 token 后取的是下一个 token 的值
- SQLSelectParser.parseGroupByItem()：检查 SQLObjectImpl 但强转为 SQLExprImpl，ClassCastException
- OracleOutputVisitor WhenDelete：小写模式 " where" 缺少尾随空格

AST 节点 / 资源泄漏（6 处）

- SQLArrayExpr.setDataType()：缺少 setParent(this)
- SQLArrayExpr.getChildren()：遗漏 dataType 子节点
- SQLAtTimeZoneExpr.setExpr()/setTimeZone()：缺少 setParent(this)
- SQLRaiseStatement.accept0()：未访问 message 子节点
- SQLExceptionStatement.addItem()：null item 被加入列表，后续遍历 NPE
- Utils.loadProperties()：InputStream 未关闭，资源泄漏

Test plan

- mvn compile -pl core 编译通过
- 4109 项 SQL 测试通过，零回归（2 failures + 6 errors 均为修改前已存在的环境问题）
- Wall 防火墙注释安全测试通过
- 各方言（MySQL/Oracle/PostgreSQL/BigQuery/Hive/StarRocks）解析测试通过
- 建议在生产环境灰度验证 MERGE 语句输出和 GRANT/REVOKE 权限解析