### PR TITLE
Fix SQL parser bugs: PG ANALYZE loop, FOR XML, UNION alias, COLLATE, DM IDENTITY

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>druid-parent</artifactId>
-		<version>1.2.25-SNAPSHOT</version>
+		<version>1.2.28-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>druid</artifactId>

--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLMethodInvokeExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLMethodInvokeExpr.java
@@ -170,6 +170,12 @@ public class SQLMethodInvokeExpr extends SQLExprImpl implements SQLReplaceable, 
         this.arguments.add(arg);
     }
 
+    public void addArguments(List<SQLExpr> args) {
+        for (SQLExpr arg : args) {
+            addArgument(arg);
+        }
+    }
+
     public SQLExpr getOwner() {
         return this.owner;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/bigquery/parser/BigQueryExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/bigquery/parser/BigQueryExprParser.java
@@ -31,6 +31,8 @@ public class BigQueryExprParser extends SQLExprParser {
                 "FIRST_VALUE",
                 "GROUPING",
                 "LAST_VALUE",
+                "LAG",
+                "LEAD",
                 "LOGICAL_AND",
                 "LOGICAL_OR",
                 "MAX",

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -363,6 +363,24 @@ public class PGExprParser extends SQLExprParser {
             castExpr.setExpr(expr);
             castExpr.setDataType(dataType);
 
+            // If parseDataType consumed a COLLATE clause (e.g., ::text COLLATE "zh-Hans-x-icu"),
+            // extract it and wrap the cast in a COLLATE binary expression
+            if (dataType instanceof com.alibaba.druid.sql.ast.statement.SQLCharacterDataType) {
+                com.alibaba.druid.sql.ast.statement.SQLCharacterDataType charType =
+                        (com.alibaba.druid.sql.ast.statement.SQLCharacterDataType) dataType;
+                String collate = charType.getCollate();
+                if (collate != null) {
+                    charType.setCollate(null);
+                    SQLBinaryOpExpr collateExpr = new SQLBinaryOpExpr(
+                            castExpr,
+                            SQLBinaryOperator.COLLATE,
+                            new SQLIdentifierExpr(collate),
+                            dbType
+                    );
+                    return primaryRest(collateExpr);
+                }
+            }
+
             return primaryRest(castExpr);
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -1027,6 +1027,13 @@ public class PGSQLStatementParser extends SQLStatementParser {
         Lexer.SavePoint mark = lexer.mark();
         String strVal = lexer.stringVal();
         for (; ; ) {
+            if (Token.SEMI.equals(lexer.token())) {
+                stmt.setAfterSemi(true);
+                return stmt;
+            }
+            if (Token.EOF == lexer.token()) {
+                return stmt;
+            }
             if (strVal.equalsIgnoreCase("VERBOSE")) {
                 stmt.setVerbose(true);
                 lexer.nextToken();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
@@ -371,21 +371,23 @@ public class SQLServerOutputVisitor extends SQLASTOutputVisitor implements SQLSe
             print0(ucase ? "FOR BROWSE" : "for browse");
         }
 
-        if (x.getForXmlOptionsSize() > 0) {
+        if (x.getForXmlOptionsSize() > 0 || x.getXmlPath() != null) {
             println();
             print0(ucase ? "FOR XML " : "for xml ");
-            for (int i = 0; i < x.getForXmlOptions().size(); ++i) {
-                if (i != 0) {
-                    print0(", ");
-                    print0(x.getForXmlOptions().get(i));
-                }
-            }
-        }
 
-        if (x.getXmlPath() != null) {
-            println();
-            print0(ucase ? "FOR XML " : "for xml ");
-            x.getXmlPath().accept(this);
+            boolean first = true;
+            if (x.getXmlPath() != null) {
+                x.getXmlPath().accept(this);
+                first = false;
+            }
+
+            for (int i = 0; i < x.getForXmlOptions().size(); ++i) {
+                if (!first) {
+                    print0(", ");
+                }
+                print0(x.getForXmlOptions().get(i));
+                first = false;
+            }
         }
 
         if (x.getOffset() != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Keywords.java
@@ -176,6 +176,7 @@ public class Keywords {
             sqlitemap.put("MERGE", Token.MERGE);
             sqlitemap.put("MATCHED", Token.MATCHED);
             sqlitemap.put("USING", Token.USING);
+            sqlitemap.put("IDENTITY", Token.IDENTITY);
             DM_KEYWORDS = new Keywords(sqlitemap);
         }
     }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -1984,7 +1984,7 @@ public class SQLExprParser extends SQLParser {
         if (lexer.token == Token.OVER) {
             if (aggregateExpr == null) {
                 aggregateExpr = new SQLAggregateExpr(methodName);
-                aggregateExpr.getArguments().addAll(methodInvokeExpr.getArguments());
+                aggregateExpr.addArguments(methodInvokeExpr.getArguments());
             }
             over(aggregateExpr);
         }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -4878,6 +4878,21 @@ public class SQLExprParser extends SQLParser {
                 SQLColumnCheck check = parseColumnCheck();
                 column.addConstraint(check);
                 return parseColumnRest(column);
+            case IDENTITY: {
+                lexer.nextToken();
+                SQLColumnDefinition.Identity identity = new SQLColumnDefinition.Identity();
+                if (lexer.token() == Token.LPAREN) {
+                    lexer.nextToken();
+                    SQLIntegerExpr seed = (SQLIntegerExpr) this.primary();
+                    accept(Token.COMMA);
+                    SQLIntegerExpr increment = (SQLIntegerExpr) this.primary();
+                    accept(Token.RPAREN);
+                    identity.setSeed((Integer) seed.getNumber());
+                    identity.setIncrement((Integer) increment.getNumber());
+                }
+                column.setIdentity(identity);
+                return parseColumnRest(column);
+            }
             case IDENTIFIER:
                 long hash = lexer.hashLCase();
                 if (hash == FnvHash.Constants.AUTO_INCREMENT) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1820,6 +1820,7 @@ public class SQLSelectParser extends SQLParser {
                     SQLTableSource unnestTableSource = parseUnnestTableSource();
                     if (unnestTableSource != null) {
                         if (lexer.identifierEquals(FnvHash.Constants.CROSS)
+                                || lexer.token == Token.CROSS
                                 || lexer.token == Token.LEFT
                                 || lexer.token == Token.RIGHT
                                 || lexer.token == Token.COMMA

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1237,6 +1237,13 @@ public class SQLSelectParser extends SQLParser {
                         this.exprParser.names(values.getColumns(), values);
                         accept(Token.RPAREN);
                     }
+                } else if (tableSource instanceof SQLUnionQueryTableSource) {
+                    SQLUnionQueryTableSource union = (SQLUnionQueryTableSource) tableSource;
+                    if (lexer.token == Token.LPAREN) {
+                        lexer.nextToken();
+                        this.exprParser.names(union.getColumns(), union);
+                        accept(Token.RPAREN);
+                    }
                 }
             }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/bigquery/AggregateTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/bigquery/AggregateTest.java
@@ -1,0 +1,30 @@
+package com.alibaba.druid.bvt.sql.bigquery;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+public class AggregateTest {
+    @Test
+    public void test_agg() {
+        String sql = "SELECT lag(date(d,'Asia/Jakarta')) over(partition by id order by n) FROM t1";
+        SQLSelectStatement stmt = (SQLSelectStatement) SQLUtils.parseSingleStatement(sql, DbType.bigquery);
+        SQLSelectQueryBlock queryBlock = stmt.getSelect().getQueryBlock();
+        SQLAggregateExpr expr = (SQLAggregateExpr) queryBlock.getSelectList().get(0).getExpr();
+        assertSame(expr, expr.getArgument(0).getParent());
+    }
+
+    @Test
+    public void test_agg_1() {
+        String sql = "SELECT xx(date(d,'Asia/Jakarta')) over(partition by id order by n) FROM t1";
+        SQLSelectStatement stmt = (SQLSelectStatement) SQLUtils.parseSingleStatement(sql, DbType.bigquery);
+        SQLSelectQueryBlock queryBlock = stmt.getSelect().getQueryBlock();
+        SQLAggregateExpr expr = (SQLAggregateExpr) queryBlock.getSelectList().get(0).getExpr();
+        assertSame(expr, expr.getArgument(0).getParent());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/DM_IdentityTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/DM_IdentityTest.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.bvt.sql.dm;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6583">Issue来源</a>
+ */
+public class DM_IdentityTest {
+
+    @Test
+    public void test_identity() {
+        String sql = "CREATE TABLE TEST.TEST_CREATE (\n"
+                + "    id INT IDENTITY(1,1),\n"
+                + "    name VARCHAR(64) NOT NULL,\n"
+                + "    PRIMARY KEY (id)\n"
+                + ")";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.dm);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_identity_with_not_null() {
+        String sql = "CREATE TABLE t (id INT IDENTITY(1,1) NOT NULL PRIMARY KEY, val VARCHAR(100))";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.dm);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6572.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6572.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6572">Issue来源</a>
+ */
+public class Issue6572 {
+
+    @Test
+    public void test_union_column_alias() {
+        String sql = "select * from (select 1 union all select 2) AS serise_table(time)";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        // Verify column alias is preserved
+        assert output.contains("serise_table");
+    }
+
+    @Test
+    public void test_union_multiple_column_aliases() {
+        String sql = "select * from (select 1, 'a' union all select 2, 'b') AS t(id, name)";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6573.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6573.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6573">Issue来源</a>
+ */
+public class Issue6573 {
+
+    @Test
+    public void test_order_by_collate() {
+        String sql = "SELECT * FROM t ORDER BY col COLLATE \"zh-Hans-x-icu\" DESC";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        System.out.println("OUTPUT1: " + output.replace("\n", " | "));
+        assertTrue("COLLATE clause should be preserved, got: " + output, output.contains("COLLATE"));
+    }
+
+    @Test
+    public void test_order_by_cast_collate() {
+        // From the original issue - cast with COLLATE
+        String sql = "SELECT * FROM t ORDER BY col::text COLLATE \"zh-Hans-x-icu\" DESC LIMIT 10";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        System.out.println("OUTPUT3: " + output.replace("\n", " | "));
+        assertTrue("COLLATE clause should be preserved in cast expr, got: " + output, output.contains("COLLATE"));
+    }
+
+    @Test
+    public void test_order_by_collate_simple() {
+        String sql = "SELECT * FROM t ORDER BY col COLLATE \"C\" DESC";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        System.out.println("OUTPUT2: " + output.replace("\n", " | "));
+        assertTrue("COLLATE clause should be preserved, got: " + output, output.contains("COLLATE"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6595.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6595.java
@@ -1,0 +1,58 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6595">Issue来源</a>
+ */
+public class Issue6595 {
+
+    @Test
+    public void test_analyze_skip_locked() {
+        String sql = "ANALYZE SKIP_LOCKED";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_analyze_verbose() {
+        String sql = "ANALYZE VERBOSE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_analyze_verbose_skip_locked() {
+        String sql = "ANALYZE VERBOSE SKIP_LOCKED";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_analyze_verbose_table() {
+        String sql = "ANALYZE VERBOSE my_table";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_analyze_bare() {
+        String sql = "ANALYZE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6564.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6564.java
@@ -1,0 +1,56 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import java.util.List;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @see <a href="https://github.com/alibaba/druid/issues/6564">Issue来源</a>
+ */
+public class Issue6564 {
+
+    @Test
+    public void test_for_xml_path_type() {
+        String sql = "SELECT ',' + Name FROM Employees FOR XML PATH(''), TYPE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        assertTrue("Output should contain FOR XML", output.toUpperCase().contains("FOR XML"));
+        assertTrue("Output should contain PATH('')", output.contains("PATH('')"));
+        assertTrue("Output should contain TYPE", output.toUpperCase().contains("TYPE"));
+        // FOR XML should appear only once
+        int idx1 = output.toUpperCase().indexOf("FOR XML");
+        int idx2 = output.toUpperCase().indexOf("FOR XML", idx1 + 1);
+        assertEquals("FOR XML should appear only once", -1, idx2);
+    }
+
+    @Test
+    public void test_for_xml_auto() {
+        String sql = "SELECT * FROM t FOR XML AUTO";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        assertTrue("Output should contain FOR XML AUTO", output.toUpperCase().contains("FOR XML AUTO"));
+    }
+
+    @Test
+    public void test_for_xml_path_elements() {
+        String sql = "SELECT * FROM t FOR XML PATH('root'), ELEMENTS";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.sqlserver);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        String output = stmtList.get(0).toString();
+        assertTrue("Output should contain PATH('root')", output.contains("PATH('root')"));
+        assertTrue("Output should contain ELEMENTS", output.toUpperCase().contains("ELEMENTS"));
+    }
+}

--- a/core/src/test/resources/bvt/parser/sqlserver/0.txt
+++ b/core/src/test/resources/bvt/parser/sqlserver/0.txt
@@ -269,7 +269,7 @@ FROM Person.Person p
 	JOIN Person.PersonPhone pph ON p.BusinessEntityID = pph.BusinessEntityID
 WHERE LastName LIKE 'G%'
 ORDER BY LastName, FirstName
-FOR XML , TYPE, XMLSCHEMA, ELEMENTS XSINIL
+FOR XML AUTO, TYPE, XMLSCHEMA, ELEMENTS XSINIL
 ------------------------------------------------------------------------------------------------------------------------
 SELECT First_Name + ' ' + Last Name FROM Employees ORDER BY First_Name OFFSET 10 ROWS
 --------------------

--- a/druid-demo-petclinic/pom.xml
+++ b/druid-demo-petclinic/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.alibaba</groupId>
       <artifactId>druid-spring-boot-starter</artifactId>
-      <version>1.2.25-SNAPSHOT</version>
+      <version>1.2.28-SNAPSHOT</version>
     </dependency>
     <!-- Spring and Spring Boot dependencies -->
     <dependency>

--- a/druid-spring-boot-3-starter/pom.xml
+++ b/druid-spring-boot-3-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>druid-parent</artifactId>
-        <version>1.2.25-SNAPSHOT</version>
+        <version>1.2.28-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>druid-spring-boot-3-starter</artifactId>

--- a/druid-spring-boot-starter/pom.xml
+++ b/druid-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>druid-parent</artifactId>
-        <version>1.2.25-SNAPSHOT</version>
+        <version>1.2.28-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>druid-spring-boot-starter</artifactId>

--- a/druid-wrapper/pom.xml
+++ b/druid-wrapper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>druid-parent</artifactId>
-		<version>1.2.25-SNAPSHOT</version>
+		<version>1.2.28-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<groupId>com.alibaba</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.alibaba</groupId>
 	<artifactId>druid-parent</artifactId>
-	<version>1.2.25-SNAPSHOT</version>
+	<version>1.2.28-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A JDBC datasource implementation.</description>
 	<packaging>pom</packaging>


### PR DESCRIPTION
## Summary

- **#6595 [P0]**: Fix PostgreSQL `ANALYZE VERBOSE` / `ANALYZE SKIP_LOCKED` causing infinite loop by adding `Token.EOF` guard in `parseAnalyzeTable()` loop
- **#6564 [P1]**: Fix SQL Server `FOR XML PATH(''), TYPE` output — off-by-one error dropping first option + duplicate `FOR XML` prefix
- **#6572 [P1]**: Fix PostgreSQL `AS table_name(column_name)` for UNION subqueries being falsely rejected as SQL injection by adding `SQLUnionQueryTableSource` column alias parsing
- **#6573 [P1]**: Fix PostgreSQL `ORDER BY col::text COLLATE "zh-Hans-x-icu"` losing COLLATE clause by extracting collate from charType after `::` cast
- **#6583 [P2]**: Fix DM (达梦) `IDENTITY(1,1)` parse failure by adding IDENTITY keyword to DM_KEYWORDS and handling in base `parseColumnRest`

## Test plan

- [x] Added `Issue6595` test: 5 cases (ANALYZE bare, VERBOSE, SKIP_LOCKED, combined, with table)
- [x] Added `Issue6564` test: 3 cases (FOR XML PATH+TYPE, AUTO, PATH+ELEMENTS)
- [x] Added `Issue6572` test: 2 cases (single/multiple column aliases on UNION subquery)
- [x] Added `Issue6573` test: 3 cases (simple COLLATE, double-quoted COLLATE, `::text COLLATE`)
- [x] Added `DM_IdentityTest`: 2 cases (IDENTITY with PRIMARY KEY, with NOT NULL)
- [x] Full core test suite: **6004 tests passed, 0 failures, 0 errors**
- [x] PostgreSQL tests: 65 passed
- [x] SQL Server tests: 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)