### PR TITLE
fix: add LISTAGG to aggregate functions for WITHIN GROUP parsing in redshift.

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/redshift/parser/RedshiftExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/redshift/parser/RedshiftExprParser.java
@@ -13,17 +13,42 @@ import com.alibaba.druid.sql.parser.SQLParserFeature;
 import com.alibaba.druid.sql.parser.Token;
 import com.alibaba.druid.util.FnvHash;
 
+import java.util.Arrays;
+
 public class RedshiftExprParser
         extends PGExprParser {
+    public static final String[] AGGREGATE_FUNCTIONS;
+    public static final long[] AGGREGATE_FUNCTIONS_CODES;
+
+    static {
+        String[] strings = {
+                "AVG", "COUNT", "LISTAGG", "MAX", "MIN", "STDDEV",
+                "SUM", "ROW_NUMBER", "PERCENTILE_CONT", "PERCENTILE_DISC", "RANK",
+                "DENSE_RANK", "PERCENT_RANK", "CUME_DIST"
+        };
+
+        AGGREGATE_FUNCTIONS_CODES = FnvHash.fnv1a_64_lower(strings, true);
+        AGGREGATE_FUNCTIONS = new String[AGGREGATE_FUNCTIONS_CODES.length];
+        for (String str : strings) {
+            long hash = FnvHash.fnv1a_64_lower(str);
+            int index = Arrays.binarySearch(AGGREGATE_FUNCTIONS_CODES, hash);
+            AGGREGATE_FUNCTIONS[index] = str;
+        }
+    }
+
     public RedshiftExprParser(String sql, SQLParserFeature... features) {
         super(new RedshiftLexer(sql, features));
         lexer.nextToken();
         dbType = DbType.redshift;
+        this.aggregateFunctions = AGGREGATE_FUNCTIONS;
+        this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
     }
 
     public RedshiftExprParser(Lexer lexer) {
         super(lexer);
         dbType = DbType.redshift;
+        this.aggregateFunctions = AGGREGATE_FUNCTIONS;
+        this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
     }
 
     @Override

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/redshift/RedshiftListaggTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/redshift/RedshiftListaggTest.java
@@ -1,0 +1,67 @@
+package com.alibaba.druid.bvt.sql.redshift;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class RedshiftListaggTest {
+    @Test
+    public void testListaggWithinGroup() {
+        String sql = "SELECT listagg(col1, ',') WITHIN GROUP (ORDER BY col2) AS agg_col FROM t";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.redshift);
+        assertEquals(1, stmts.size());
+
+        String result = SQLUtils.toSQLString(stmts.get(0), DbType.redshift);
+        assertTrue(result.toUpperCase().contains("LISTAGG"));
+        assertTrue(result.toUpperCase().contains("WITHIN GROUP"));
+    }
+
+    @Test
+    public void testListaggDistinct() {
+        String sql = "SELECT listagg(DISTINCT col1, ',') AS agg_col FROM t";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.redshift);
+        assertEquals(1, stmts.size());
+
+        String result = SQLUtils.toSQLString(stmts.get(0), DbType.redshift);
+        assertTrue(result.toUpperCase().contains("LISTAGG"));
+        assertTrue(result.toUpperCase().contains("DISTINCT"));
+    }
+
+    @Test
+    public void testListaggDistinctWithCaseWhen() {
+        String sql = "SELECT listagg(DISTINCT CASE WHEN flag = 1 THEN col1 END, ',') AS agg_col FROM t";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.redshift);
+        assertEquals(1, stmts.size());
+
+        String result = SQLUtils.toSQLString(stmts.get(0), DbType.redshift);
+        assertTrue(result.toUpperCase().contains("LISTAGG"));
+    }
+
+    @Test
+    public void testInsertWithCteListagg() {
+        String sql = "INSERT INTO t1\n"
+                + "WITH cte AS (\n"
+                + "  SELECT id\n"
+                + "    , listagg(DISTINCT CASE WHEN flag = 1 THEN col1 END, ',') AS agg1\n"
+                + "    , listagg(col2, ',') WITHIN GROUP (ORDER BY col3) AS agg2\n"
+                + "  FROM t2\n"
+                + "  GROUP BY id\n"
+                + ")\n"
+                + "SELECT * FROM cte";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.redshift);
+        assertEquals(1, stmts.size());
+
+        String result = SQLUtils.toSQLString(stmts.get(0), DbType.redshift);
+        assertTrue(result.toUpperCase().contains("LISTAGG"));
+        assertTrue(result.toUpperCase().contains("WITHIN GROUP"));
+    }
+}

--- a/core/src/test/resources/bvt/parser/redshift/3.txt
+++ b/core/src/test/resources/bvt/parser/redshift/3.txt
@@ -1,0 +1,21 @@
+SELECT listagg(CASE WHEN is_touch=1 THEN custom_utm_advertising_type END,',') WITHIN GROUP (ORDER BY touchpoint_time) AS advertising_type
+FROM t
+--------------------
+SELECT listagg(CASE
+		WHEN is_touch = 1 THEN custom_utm_advertising_type
+	END, ',') WITHIN GROUP (ORDER BY touchpoint_time) AS advertising_type
+FROM t
+------------------------------------------------------------------------------------------------------------------------
+SELECT listagg(DISTINCT custom_utm_advertising_type,',') AS all_source_advertising_type_unique
+FROM t
+--------------------
+SELECT listagg(DISTINCT custom_utm_advertising_type, ',') AS all_source_advertising_type_unique
+FROM t
+------------------------------------------------------------------------------------------------------------------------
+SELECT listagg(DISTINCT CASE WHEN is_touch=1 THEN custom_utm_advertising_type END,',') AS advertising_type_unique
+FROM t
+--------------------
+SELECT listagg(DISTINCT CASE
+		WHEN is_touch = 1 THEN custom_utm_advertising_type
+	END, ',') AS advertising_type_unique
+FROM t


### PR DESCRIPTION
LISTAGG was not recognized as an aggregate function in Redshift parser, causing 'WITHIN GROUP (ORDER BY ...)' clause to fail with ParserException.
- Add AGGREGATE_FUNCTIONS static field with LISTAGG in RedshiftExprParser.