### PR TITLE
fix: SQLDeleteStatement.accept0 missing from/using children (#6563)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLDeleteStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLDeleteStatement.java
@@ -155,6 +155,14 @@ public class SQLDeleteStatement extends SQLStatementImpl implements SQLReplaceab
                 tableSource.accept(visitor);
             }
 
+            if (from != null) {
+                from.accept(visitor);
+            }
+
+            if (using != null) {
+                using.accept(visitor);
+            }
+
             if (where != null) {
                 where.accept(visitor);
             }
@@ -170,6 +178,12 @@ public class SQLDeleteStatement extends SQLStatementImpl implements SQLReplaceab
             children.add(with);
         }
         children.add(tableSource);
+        if (from != null) {
+            children.add(from);
+        }
+        if (using != null) {
+            children.add(using);
+        }
         if (where != null) {
             children.add(where);
         }
@@ -209,6 +223,9 @@ public class SQLDeleteStatement extends SQLStatementImpl implements SQLReplaceab
     }
 
     public void setUsing(SQLTableSource using) {
+        if (using != null) {
+            using.setParent(this);
+        }
         this.using = using;
     }
 

--- a/core/src/test/java/com/alibaba/druid/sql/issues/Issue6563.java
+++ b/core/src/test/java/com/alibaba/druid/sql/issues/Issue6563.java
@@ -1,0 +1,94 @@
+package com.alibaba.druid.sql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SQLDeleteStatement.accept0 / getChildren skipped the {@code from} and
+ * {@code using} children, so generic visitors that rely on the default
+ * tree walk never reached identifiers inside
+ * {@code DELETE ... FROM ...} or {@code DELETE ... USING ...}.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6563">#6563</a>
+ */
+public class Issue6563 {
+    /** Collects every SQLIdentifierExpr name seen during a default tree walk. */
+    private static class NameCollector extends SQLASTVisitorAdapter {
+        final List<String> names = new ArrayList<>();
+
+        @Override
+        public boolean visit(SQLIdentifierExpr x) {
+            names.add(x.getSimpleName());
+            return true;
+        }
+    }
+
+    @Test
+    public void test_snowflake_delete_using_visited() {
+        // Snowflake parser sets `using` on the base SQLDeleteStatement,
+        // but the base accept0 used to skip it.
+        // Reference table 't_using_only' ONLY from the USING clause so it
+        // can only be reached if accept0 walks the using subtree.
+        String sql = "DELETE FROM t1 USING t_using_only WHERE t1.id = 1";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.snowflake);
+        SQLStatement stmt = parser.parseStatement();
+        assertNotNull(((SQLDeleteStatement) stmt).getUsing());
+
+        NameCollector collector = new NameCollector();
+        stmt.accept(collector);
+        assertTrue(collector.names.contains("t_using_only"),
+                "USING-only table should be reachable via default tree walk, names=" + collector.names);
+    }
+
+    @Test
+    public void test_db2_delete_from_visited() {
+        // DB2 parser writes setFrom for the secondary FROM clause and uses base accept0.
+        // Reference 't_from_only' ONLY in the secondary FROM so reaching it requires
+        // walking the from subtree.
+        String sql = "DELETE FROM t FROM t_from_only WHERE t.id = 1";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.db2);
+        SQLStatement stmt = parser.parseStatement();
+        assertNotNull(((SQLDeleteStatement) stmt).getFrom());
+
+        NameCollector collector = new NameCollector();
+        stmt.accept(collector);
+        assertTrue(collector.names.contains("t_from_only"),
+                "FROM-only table should be reachable via default tree walk, names=" + collector.names);
+    }
+
+    @Test
+    public void test_getChildren_includes_from_and_using() {
+        SQLDeleteStatement delete = new SQLDeleteStatement(DbType.mysql);
+        delete.setTableSource(new SQLExprTableSource("t1"));
+        delete.setFrom(new SQLExprTableSource("t_from"));
+        delete.setUsing(new SQLExprTableSource("t_using"));
+
+        List<SQLObject> children = delete.getChildren();
+        assertTrue(children.contains(delete.getFrom()), "getChildren must include from");
+        assertTrue(children.contains(delete.getUsing()), "getChildren must include using");
+    }
+
+    @Test
+    public void test_setUsing_sets_parent() {
+        SQLDeleteStatement delete = new SQLDeleteStatement(DbType.mysql);
+        SQLExprTableSource using = new SQLExprTableSource("t_using");
+        delete.setUsing(using);
+        assertNotNull(using.getParent(), "setUsing must wire parent for tree walk");
+        assertSame(delete, using.getParent());
+    }
+}


### PR DESCRIPTION
## Problem

The base `SQLDeleteStatement.accept0` walked only `with` / `tableSource` / `where`, silently skipping the `from` and `using` sub-trees. As a result, dialects that fall back to the base implementation (DB2, Snowflake, etc.) cannot be fully traversed by visitors that rely on the default tree walk - any AST node reachable only via `DELETE ... FROM <ts>` or `DELETE ... USING <ts>` was invisible to AST consumers.

`getChildren()` had the same omission, and `setUsing()` failed to wire the parent pointer (`setFrom` already does), breaking parent-chain traversal for that branch.

Reported in #6563 (DELETE statement visitor cannot reach the FROM sub-tree when modifying table names).

## Root Cause

Compare with `MySqlDeleteStatement.accept0`, which correctly walks `with`, `tableSource`, `where`, `from`, `using`, `orderBy`, `limit`. The base class - used directly by Snowflake, DB2 and any future dialect that does not override - was missing `from` and `using`. Snowflake and PG/Oscar parsers populate the `using` slot via `setUsing()`, but no parent was assigned, so even reverse-traversal would not work.

## Fix

In `SQLDeleteStatement`:

- `accept0`: walk `from` and `using` in addition to the previously-visited children.
- `getChildren`: include `from` and `using`.
- `setUsing`: wire the parent pointer, mirroring `setFrom`.

No changes to dialect-specific subclasses - they already override `accept0` and were unaffected.

## Tests Added

`core/src/test/java/com/alibaba/druid/sql/issues/Issue6563.java`:

- `test_snowflake_delete_using_visited` - parses `DELETE FROM t1 USING t_using_only WHERE ...`, walks the AST with a generic identifier collector, and asserts `t_using_only` (referenced ONLY through the USING clause) is reached.
- `test_db2_delete_from_visited` - parses `DELETE FROM t FROM t_from_only WHERE ...` for DB2, asserts `t_from_only` (reachable only through the secondary FROM) is visited.
- `test_getChildren_includes_from_and_using` - structural test on the AST API.
- `test_setUsing_sets_parent` - verifies the parent pointer is wired so reverse traversal works.

All four tests fail on master (4 failures, no errors) and pass with the fix.

Full `mvn test` for the `core` module: 4222 tests, 0 failures, 0 errors.

Fixes #6563