### PR TITLE
fix: 批量修复 18 处 SQL 解析 bug（PG/Oracle/MySQL/SqlServer/BigQuery/Presto 等多方言）

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLBinaryOperator.java
@@ -92,6 +92,7 @@ public enum SQLBinaryOperator {
     NotRegExp("NOT REGEXP", 110),
     Equality("=", 110),
     EqEq("==", 110),
+    MemberOf("MEMBER OF", 110), // mysql json: value MEMBER OF (json_array)
 
     BitwiseNot("!", 130),
     Concat("||", 140),

--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLUnaryOperator.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLUnaryOperator.java
@@ -25,6 +25,7 @@ public enum SQLUnaryOperator {
     BINARY("BINARY"),
     RAW("RAW"),
     NOT("NOT"),
+    VARIADIC("VARIADIC"), // postgresql variadic function argument
     // Number of points in path or polygon
     Pound("#");
 

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnnestTableSource.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLUnnestTableSource.java
@@ -14,8 +14,18 @@ public class SQLUnnestTableSource extends SQLTableSourceImpl
     protected List<SQLName> columns = new ArrayList<SQLName>();
     private boolean ordinality;
     private SQLExpr offset;
+    // BigQuery: WITH OFFSET present (the offset field holds the optional alias, which may be null)
+    private boolean withOffset;
 
     public SQLUnnestTableSource() {
+    }
+
+    public boolean isWithOffset() {
+        return withOffset || offset != null;
+    }
+
+    public void setWithOffset(boolean withOffset) {
+        this.withOffset = withOffset;
     }
 
     @Override
@@ -86,6 +96,8 @@ public class SQLUnnestTableSource extends SQLTableSourceImpl
         }
 
         x.alias = alias;
+        x.ordinality = ordinality;
+        x.withOffset = withOffset;
 
         if (offset != null) {
             x.setOffset(offset);

--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLWithSubqueryClause.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLWithSubqueryClause.java
@@ -92,6 +92,8 @@ public class SQLWithSubqueryClause extends SQLObjectImpl {
         protected SQLStatement returningStatement;
         protected SQLExpr expr;
         protected boolean prefixAlias;
+        // PostgreSQL CTE materialization hint: TRUE = MATERIALIZED, FALSE = NOT MATERIALIZED, null = unspecified
+        protected Boolean materialized;
 
         public Entry() {
         }
@@ -124,6 +126,15 @@ public class SQLWithSubqueryClause extends SQLObjectImpl {
             x.alias = alias;
             x.expr = expr;
             x.prefixAlias = prefixAlias;
+            x.materialized = materialized;
+        }
+
+        public Boolean getMaterialized() {
+            return materialized;
+        }
+
+        public void setMaterialized(Boolean materialized) {
+            this.materialized = materialized;
         }
 
         public SQLObject resolveColumn(long columnNameHash) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlCreateTableParser.java
@@ -332,7 +332,8 @@ public class MySqlCreateTableParser extends SQLCreateTableParser {
                             lexer.reset(mark);
                         }
                     }
-                    if (lexer.identifierEquals(FnvHash.Constants.CLUSTERED)) {
+                    if (lexer.identifierEquals(FnvHash.Constants.CLUSTERED)
+                            && lexer.stringVal().charAt(0) != '`') {
                         lexer.nextToken();
                         if (lexer.token() == Token.KEY) {
                             MySqlKey clsKey = new MySqlKey();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -686,10 +686,10 @@ public class OracleExprParser extends SQLExprParser {
                     lexer.nextToken();
                     accept(Token.RPAREN);
                 }
-            } else if (lexer.identifierEquals("HOUR")) {
+            } else if (lexer.identifierEquals(FnvHash.Constants.HOUR)) {
                 lexer.nextToken();
                 interval.setToType(OracleIntervalType.HOUR);
-            } else if (lexer.identifierEquals("MINUTE")) {
+            } else if (lexer.identifierEquals(FnvHash.Constants.MINUTE)) {
                 lexer.nextToken();
                 interval.setToType(OracleIntervalType.MINUTE);
             } else {
@@ -1225,8 +1225,8 @@ public class OracleExprParser extends SQLExprParser {
             OracleCreateIndexStatement createIndex = new OracleStatementParser(lexer).parseCreateIndex();
             using.setIndex(createIndex);
             accept(Token.RPAREN);
-        } else if (lexer.token() == Token.LITERAL_ALIAS) {
-            // USING INDEX <existing_index_name>, possibly schema-qualified (see issue #6458)
+        } else if (lexer.token() == Token.LITERAL_ALIAS || lexer.token() == Token.IDENTIFIER) {
+            // USING INDEX <existing_index_name>, quoted or unquoted, possibly schema-qualified (issue #6458)
             using.setIndex(this.name());
         }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -686,6 +686,12 @@ public class OracleExprParser extends SQLExprParser {
                     lexer.nextToken();
                     accept(Token.RPAREN);
                 }
+            } else if (lexer.identifierEquals("HOUR")) {
+                lexer.nextToken();
+                interval.setToType(OracleIntervalType.HOUR);
+            } else if (lexer.identifierEquals("MINUTE")) {
+                lexer.nextToken();
+                interval.setToType(OracleIntervalType.MINUTE);
             } else {
                 interval.setToType(OracleIntervalType.MONTH);
                 lexer.nextToken();
@@ -1058,6 +1064,15 @@ public class OracleExprParser extends SQLExprParser {
                     interval.setToFactionalSecondsPrecision(primary());
                     accept(Token.RPAREN);
                 }
+            } else if (lexer.identifierEquals(FnvHash.Constants.HOUR)) {
+                lexer.nextToken();
+                interval.setToType(OracleIntervalType.HOUR);
+            } else if (lexer.identifierEquals(FnvHash.Constants.MINUTE)) {
+                lexer.nextToken();
+                interval.setToType(OracleIntervalType.MINUTE);
+            } else if (lexer.identifierEquals(FnvHash.Constants.DAY)) {
+                lexer.nextToken();
+                interval.setToType(OracleIntervalType.DAY);
             } else {
                 interval.setToType(OracleIntervalType.MONTH);
                 lexer.nextToken();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleExprParser.java
@@ -1225,6 +1225,9 @@ public class OracleExprParser extends SQLExprParser {
             OracleCreateIndexStatement createIndex = new OracleStatementParser(lexer).parseCreateIndex();
             using.setIndex(createIndex);
             accept(Token.RPAREN);
+        } else if (lexer.token() == Token.LITERAL_ALIAS) {
+            // USING INDEX <existing_index_name>, possibly schema-qualified (see issue #6458)
+            using.setIndex(this.name());
         }
 
         for (; ; ) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -423,7 +423,14 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         }
         println();
         print0(ucase ? "INTO " : "into ");
-        into.accept(this);
+        // multiple INTO targets are stored as a SQLListExpr; PL/SQL writes them comma-separated
+        // without surrounding parentheses (see issue #6435).
+        SQLExpr expr = into.getExpr();
+        if (expr instanceof SQLListExpr && into.getAlias() == null) {
+            printAndAccept(((SQLListExpr) expr).getItems(), ", ");
+        } else {
+            into.accept(this);
+        }
     }
 
     private void printModel(OracleSelectQueryBlock x) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGDeleteStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGDeleteStatement.java
@@ -16,22 +16,39 @@
 package com.alibaba.druid.sql.dialect.postgresql.ast.stmt;
 
 import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLAllColumnExpr;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.postgresql.visitor.PGASTVisitor;
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
 public class PGDeleteStatement extends SQLDeleteStatement implements PGSQLStatement {
-    private boolean returning;
+    private SQLExpr returning;
 
     public PGDeleteStatement() {
         super(DbType.postgresql);
     }
 
     public boolean isReturning() {
-        return returning;
+        return returning != null;
     }
 
     public void setReturning(boolean returning) {
+        if (returning && this.returning == null) {
+            setReturning(new SQLAllColumnExpr());
+        } else if (!returning) {
+            this.returning = null;
+        }
+    }
+
+    public SQLExpr getReturning() {
+        return returning;
+    }
+
+    public void setReturning(SQLExpr returning) {
+        if (returning != null) {
+            returning.setParent(this);
+        }
         this.returning = returning;
     }
 
@@ -61,6 +78,7 @@ public class PGDeleteStatement extends SQLDeleteStatement implements PGSQLStatem
             acceptChild(visitor, tableSource);
             acceptChild(visitor, using);
             acceptChild(visitor, where);
+            acceptChild(visitor, returning);
         }
 
         visitor.endVisit(this);
@@ -70,7 +88,9 @@ public class PGDeleteStatement extends SQLDeleteStatement implements PGSQLStatem
         PGDeleteStatement x = new PGDeleteStatement();
         cloneTo(x);
 
-        x.returning = returning;
+        if (returning != null) {
+            x.setReturning(returning.clone());
+        }
 
         return x;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -249,10 +249,25 @@ public class PGExprParser extends SQLExprParser {
 
     public SQLExpr primary() {
         if (lexer.token() == Token.IDENTIFIER && lexer.identifierEquals("VARIADIC")) {
-            // postgresql variadic function argument, e.g. func(VARIADIC ARRAY[...]) (issue #6393)
+            // postgresql variadic function argument, e.g. func(VARIADIC ARRAY[...]) (issue #6393).
+            // Only treat VARIADIC as a prefix when a value expression actually follows; otherwise it
+            // is an ordinary identifier (e.g. a column named "variadic") and must be left intact.
+            Lexer.SavePoint mark = lexer.mark();
             lexer.nextToken();
-            SQLExpr arg = primary();
-            return primaryRest(new SQLUnaryExpr(SQLUnaryOperator.VARIADIC, arg));
+            switch (lexer.token()) {
+                case ARRAY:
+                case LBRACKET:
+                case LPAREN:
+                case IDENTIFIER:
+                case LITERAL_INT:
+                case LITERAL_CHARS:
+                case LITERAL_FLOAT:
+                case QUES:
+                case VARIANT:
+                    return primaryRest(new SQLUnaryExpr(SQLUnaryOperator.VARIADIC, primary()));
+                default:
+                    lexer.reset(mark);
+            }
         }
         if (lexer.token() == Token.ARRAY) {
             String ident = lexer.stringVal();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -218,8 +218,10 @@ public class PGExprParser extends SQLExprParser {
 
     @Override
     protected void parseDataTypeDouble(StringBuilder typeName) {
-        typeName.append(' ').append(lexer.stringVal());
-        lexer.nextToken();
+        if (lexer.identifierEquals(FnvHash.Constants.PRECISION)) {
+            typeName.append(' ').append(lexer.stringVal());
+            lexer.nextToken();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGExprParser.java
@@ -248,6 +248,12 @@ public class PGExprParser extends SQLExprParser {
     }
 
     public SQLExpr primary() {
+        if (lexer.token() == Token.IDENTIFIER && lexer.identifierEquals("VARIADIC")) {
+            // postgresql variadic function argument, e.g. func(VARIADIC ARRAY[...]) (issue #6393)
+            lexer.nextToken();
+            SQLExpr arg = primary();
+            return primaryRest(new SQLUnaryExpr(SQLUnaryOperator.VARIADIC, arg));
+        }
         if (lexer.token() == Token.ARRAY) {
             String ident = lexer.stringVal();
             lexer.nextToken();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -965,11 +965,24 @@ public class PGSQLStatementParser extends SQLStatementParser {
                     lexer.nextToken();
                     accept(Token.NULL);
                     alterColumn.setSetNotNull(true);
+                } else if (lexer.identifierEquals("DATA")) {
+                    // ALTER COLUMN col SET DATA TYPE <type>
+                    lexer.nextToken();
+                    if (lexer.token() == Token.TYPE) {
+                        lexer.nextToken();
+                    } else {
+                        acceptIdentifier("TYPE");
+                    }
+                    alterColumn.setDataType(this.exprParser.parseDataType());
                 } else {
                     accept(Token.DEFAULT);
                     SQLExpr defaultValue = this.exprParser.expr();
                     alterColumn.setSetDefault(defaultValue);
                 }
+            } else if (lexer.token() == Token.TYPE || lexer.identifierEquals(FnvHash.Constants.TYPE)) {
+                // ALTER COLUMN col TYPE <type>
+                lexer.nextToken();
+                alterColumn.setDataType(this.exprParser.parseDataType());
             } else if (lexer.token() == Token.DROP) {
                 lexer.nextToken();
                 if (lexer.token() == Token.NOT) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -486,8 +486,20 @@ public class PGSQLStatementParser extends SQLStatementParser {
 
         if (lexer.token() == Token.RETURNING) {
             lexer.nextToken();
-            accept(Token.STAR);
-            deleteStatement.setReturning(true);
+            if (lexer.token() == Token.STAR) {
+                lexer.nextToken();
+                deleteStatement.setReturning(new SQLAllColumnExpr());
+            } else {
+                SQLExpr returning = this.exprParser.expr();
+                if (lexer.token() == Token.COMMA) {
+                    lexer.nextToken();
+                    SQLListExpr list = new SQLListExpr();
+                    list.addItem(returning);
+                    this.exprParser.exprList(list.getItems(), list);
+                    returning = list;
+                }
+                deleteStatement.setReturning(returning);
+            }
         }
 
         return deleteStatement;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -129,6 +129,10 @@ public class PGSelectParser extends SQLSelectParser {
 
         parseWhere(queryBlock);
 
+        // openGauss (registered as the postgresql dialect) supports Oracle-style hierarchical
+        // queries: CONNECT BY ... START WITH ... (see issue #6637)
+        parseHierachical(queryBlock);
+
         parseGroupBy(queryBlock);
 
         if (lexer.token() == Token.WINDOW) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -150,6 +150,7 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
 
         printFrom(x);
         printWhere(x);
+        printHierarchical(x);
         printGroupBy(x);
         printWindow(x);
         printOrderBy(x);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -448,6 +448,20 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
     }
 
     @Override
+    public boolean visit(SQLCharacterDataType x) {
+        super.visit(x);
+        // PostgreSQL stores the COLLATE clause on the character data type (e.g. text COLLATE "x"
+        // produced by a cast like (a)::text COLLATE "x", or a column definition); the generic
+        // data type output drops it, so render it here (see issue #6573).
+        String collate = x.getCollate();
+        if (collate != null) {
+            print0(ucase ? " COLLATE " : " collate ");
+            print0(collate);
+        }
+        return false;
+    }
+
+    @Override
     public boolean visit(PGExtractExpr x) {
         print0(ucase ? "EXTRACT(" : "extract(");
         print0(x.getField().name());

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -234,9 +234,15 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             this.indentCount--;
         }
 
-        if (x.isReturning()) {
+        SQLExpr returning = x.getReturning();
+        if (returning != null) {
             println();
-            print0(ucase ? "RETURNING *" : "returning *");
+            print0(ucase ? "RETURNING " : "returning ");
+            if (returning instanceof SQLListExpr) {
+                printAndAccept(((SQLListExpr) returning).getItems(), ", ");
+            } else {
+                returning.accept(this);
+            }
         }
 
         return false;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/presto/visitor/PrestoOutputVisitor.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLLimit;
 import com.alibaba.druid.sql.ast.expr.SQLArrayExpr;
 import com.alibaba.druid.sql.ast.expr.SQLDecimalExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.presto.Presto;
 import com.alibaba.druid.sql.dialect.presto.ast.PrestoColumnWith;
@@ -155,7 +156,17 @@ public class PrestoOutputVisitor extends SQLASTOutputVisitor implements PrestoAS
 
     @Override
     public boolean visit(SQLArrayExpr x) {
-        print0(ucase ? "ARRAY[" : "array[");
+        SQLExpr expr = x.getExpr();
+        // ARRAY[...] constructor vs subscript access base[...] (e.g. col['k']); see issue #6631
+        boolean arrayKeyword = expr == null
+                || (expr instanceof SQLIdentifierExpr
+                    && "ARRAY".equalsIgnoreCase(((SQLIdentifierExpr) expr).getName()));
+        if (arrayKeyword) {
+            print0(ucase ? "ARRAY[" : "array[");
+        } else {
+            expr.accept(this);
+            print('[');
+        }
         printAndAccept(x.getValues(), ", ");
         print(']');
         return false;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/ast/stmt/SQLServerExecStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/ast/stmt/SQLServerExecStatement.java
@@ -30,6 +30,15 @@ public class SQLServerExecStatement extends SQLServerStatementImpl implements SQ
     private SQLName returnStatus;
     private SQLName moduleName;
     private List<SQLServerParameter> parameters = new ArrayList<SQLServerParameter>();
+    private boolean recompile;
+
+    public boolean isRecompile() {
+        return recompile;
+    }
+
+    public void setRecompile(boolean recompile) {
+        this.recompile = recompile;
+    }
 
     public SQLName getModuleName() {
         return moduleName;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
@@ -73,9 +73,15 @@ public class SQLServerStatementParser extends SQLStatementParser {
                     execStmt.setModuleName(sqlNameName);
                 }
 
-                if (lexer.token() != Token.SEMI && lexer.token() != Token.EOF) {
+                if (lexer.token() != Token.SEMI && lexer.token() != Token.EOF && lexer.token() != Token.WITH) {
                     this.parseExecParameter(execStmt.getParameters(), execStmt);
                 }
+            }
+            // EXEC ... WITH RECOMPILE
+            if (lexer.token() == Token.WITH) {
+                lexer.nextToken();
+                acceptIdentifier("RECOMPILE");
+                execStmt.setRecompile(true);
             }
             statementList.add(execStmt);
             return true;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/parser/SQLServerStatementParser.java
@@ -77,11 +77,16 @@ public class SQLServerStatementParser extends SQLStatementParser {
                     this.parseExecParameter(execStmt.getParameters(), execStmt);
                 }
             }
-            // EXEC ... WITH RECOMPILE
+            // EXEC ... WITH RECOMPILE (leave other WITH options, e.g. WITH RESULT SETS, untouched)
             if (lexer.token() == Token.WITH) {
+                Lexer.SavePoint mark = lexer.mark();
                 lexer.nextToken();
-                acceptIdentifier("RECOMPILE");
-                execStmt.setRecompile(true);
+                if (lexer.identifierEquals("RECOMPILE")) {
+                    lexer.nextToken();
+                    execStmt.setRecompile(true);
+                } else {
+                    lexer.reset(mark);
+                }
             }
             statementList.add(execStmt);
             return true;

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
@@ -264,6 +264,9 @@ public class SQLServerOutputVisitor extends SQLASTOutputVisitor implements SQLSe
         if (moduleName == null) {
             print(')');
         }
+        if (x.isRecompile()) {
+            print0(ucase ? " WITH RECOMPILE" : " with recompile");
+        }
         return false;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/sqlserver/visitor/SQLServerOutputVisitor.java
@@ -381,21 +381,24 @@ public class SQLServerOutputVisitor extends SQLASTOutputVisitor implements SQLSe
             print0(ucase ? "FOR BROWSE" : "for browse");
         }
 
-        if (x.getForXmlOptionsSize() > 0) {
+        if (x.getForXmlOptionsSize() > 0 || x.getXmlPath() != null) {
             println();
             print0(ucase ? "FOR XML " : "for xml ");
-            for (int i = 0; i < x.getForXmlOptions().size(); ++i) {
-                if (i != 0) {
-                    print0(", ");
-                    print0(x.getForXmlOptions().get(i));
-                }
+            // single FOR XML clause: the mode/path comes first, then comma-separated options
+            // (including the first one). Previously the first option was dropped and the path was
+            // emitted as a second, duplicate "FOR XML" clause (see issue #6564).
+            boolean first = true;
+            if (x.getXmlPath() != null) {
+                x.getXmlPath().accept(this);
+                first = false;
             }
-        }
-
-        if (x.getXmlPath() != null) {
-            println();
-            print0(ucase ? "FOR XML " : "for xml ");
-            x.getXmlPath().accept(this);
+            for (int i = 0; i < x.getForXmlOptions().size(); ++i) {
+                if (!first) {
+                    print0(", ");
+                }
+                print0(x.getForXmlOptions().get(i));
+                first = false;
+            }
         }
 
         if (x.getOffset() != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3743,7 +3743,8 @@ public class SQLExprParser extends SQLParser {
         final SQLExpr initExpr = expr;
         SQLExpr rightExp = null;
 
-        if (lexer.token == Token.IDENTIFIER && lexer.identifierEquals(FnvHash.Constants.MEMBER)) {
+        if (dbType == DbType.mysql
+                && lexer.token == Token.IDENTIFIER && lexer.identifierEquals(FnvHash.Constants.MEMBER)) {
             // MySQL JSON predicate: value MEMBER OF (json_array)
             Lexer.SavePoint mark = lexer.mark();
             lexer.nextToken();

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -848,7 +848,10 @@ public class SQLExprParser extends SQLParser {
                 sqlExpr = primaryIn(sqlExpr);
                 break;
             case LBRACKET:
+                // subscript access on the preceding expression, e.g. col['k'] or arr[1];
+                // keep the base expression as the array expr so it is not lost on output (issue #6631)
                 SQLArrayExpr arrayTmp = new SQLArrayExpr();
+                arrayTmp.setExpr(sqlExpr);
                 lexer.nextToken();
                 this.exprList(arrayTmp.getValues(), arrayTmp);
                 accept(Token.RBRACKET);

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -3743,6 +3743,21 @@ public class SQLExprParser extends SQLParser {
         final SQLExpr initExpr = expr;
         SQLExpr rightExp = null;
 
+        if (lexer.token == Token.IDENTIFIER && lexer.identifierEquals(FnvHash.Constants.MEMBER)) {
+            // MySQL JSON predicate: value MEMBER OF (json_array)
+            Lexer.SavePoint mark = lexer.mark();
+            lexer.nextToken();
+            if (lexer.token == Token.OF || lexer.identifierEquals("OF")) {
+                lexer.nextToken();
+                accept(Token.LPAREN);
+                SQLExpr array = expr();
+                accept(Token.RPAREN);
+                return new SQLBinaryOpExpr(expr, SQLBinaryOperator.MemberOf, array, dbType);
+            } else {
+                lexer.reset(mark);
+            }
+        }
+
         Token token = lexer.token;
 
         switch (token) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
@@ -83,6 +83,21 @@ public class SQLParser {
         }
     }
 
+    /**
+     * PostgreSQL CTE materialization hint between AS and the opening paren: [ NOT ] MATERIALIZED.
+     * Shared by SQLSelectParser#parseWith and SQLStatementParser#parseWithQuery (issue #6560).
+     */
+    protected void parseCTEMaterializationHint(com.alibaba.druid.sql.ast.statement.SQLWithSubqueryClause.Entry entry) {
+        if (lexer.identifierEquals(FnvHash.Constants.MATERIALIZED)) {
+            lexer.nextToken();
+            entry.setMaterialized(Boolean.TRUE);
+        } else if (lexer.token == Token.NOT) {
+            lexer.nextToken();
+            acceptIdentifier("MATERIALIZED");
+            entry.setMaterialized(Boolean.FALSE);
+        }
+    }
+
     protected String tableAlias() {
         return tableAlias(false);
     }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1472,10 +1472,11 @@ public class SQLSelectParser extends SQLParser {
 
                 if (lexer.nextIf(Token.WITH)) {
                     acceptIdentifier("OFFSET");
-                    lexer.nextIf(Token.AS);
-                    unnest.setOffset(
-                            this.exprParser.expr()
-                    );
+                    unnest.setWithOffset(true);
+                    // the offset alias is optional: WITH OFFSET [AS alias] (see issue #6547)
+                    if (lexer.nextIf(Token.AS) || lexer.token == Token.IDENTIFIER) {
+                        unnest.setOffset(this.exprParser.expr());
+                    }
                 }
                 return unnest;
             } else {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -650,14 +650,7 @@ public class SQLSelectParser extends SQLParser {
             accept(Token.AS);
 
             // PostgreSQL: name AS [ NOT ] MATERIALIZED ( query )
-            if (lexer.identifierEquals(FnvHash.Constants.MATERIALIZED)) {
-                lexer.nextToken();
-                entry.setMaterialized(Boolean.TRUE);
-            } else if (lexer.token == Token.NOT) {
-                lexer.nextToken();
-                acceptIdentifier("MATERIALIZED");
-                entry.setMaterialized(Boolean.FALSE);
-            }
+            parseCTEMaterializationHint(entry);
 
             accept(Token.LPAREN);
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -1292,6 +1292,14 @@ public class SQLSelectParser extends SQLParser {
                         this.exprParser.names(values.getColumns(), values);
                         accept(Token.RPAREN);
                     }
+                } else if (tableSource instanceof SQLUnionQueryTableSource) {
+                    // derived table over a UNION: AS alias (col1, col2, ...)  (see issue #6572)
+                    SQLUnionQueryTableSource unionTableSource = (SQLUnionQueryTableSource) tableSource;
+                    if (lexer.token == Token.LPAREN) {
+                        lexer.nextToken();
+                        this.exprParser.names(unionTableSource.getColumns(), unionTableSource);
+                        accept(Token.RPAREN);
+                    }
                 }
             }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -648,6 +648,17 @@ public class SQLSelectParser extends SQLParser {
             }
 
             accept(Token.AS);
+
+            // PostgreSQL: name AS [ NOT ] MATERIALIZED ( query )
+            if (lexer.identifierEquals(FnvHash.Constants.MATERIALIZED)) {
+                lexer.nextToken();
+                entry.setMaterialized(Boolean.TRUE);
+            } else if (lexer.token == Token.NOT) {
+                lexer.nextToken();
+                acceptIdentifier("MATERIALIZED");
+                entry.setMaterialized(Boolean.FALSE);
+            }
+
             accept(Token.LPAREN);
 
             switch (lexer.token) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -5950,14 +5950,7 @@ public class SQLStatementParser extends SQLParser {
             accept(Token.AS);
 
             // PostgreSQL: name AS [ NOT ] MATERIALIZED ( query )
-            if (lexer.identifierEquals(FnvHash.Constants.MATERIALIZED)) {
-                lexer.nextToken();
-                entry.setMaterialized(Boolean.TRUE);
-            } else if (lexer.token == Token.NOT) {
-                lexer.nextToken();
-                acceptIdentifier("MATERIALIZED");
-                entry.setMaterialized(Boolean.FALSE);
-            }
+            parseCTEMaterializationHint(entry);
 
             accept(Token.LPAREN);
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -5948,6 +5948,17 @@ public class SQLStatementParser extends SQLParser {
             }
 
             accept(Token.AS);
+
+            // PostgreSQL: name AS [ NOT ] MATERIALIZED ( query )
+            if (lexer.identifierEquals(FnvHash.Constants.MATERIALIZED)) {
+                lexer.nextToken();
+                entry.setMaterialized(Boolean.TRUE);
+            } else if (lexer.token == Token.NOT) {
+                lexer.nextToken();
+                acceptIdentifier("MATERIALIZED");
+                entry.setMaterialized(Boolean.FALSE);
+            }
+
             accept(Token.LPAREN);
 
             switch (lexer.token) {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -7091,6 +7091,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                 print(' ');
             }
             print0(alias);
+            if (columns.size() > 0) {
+                print0(" (");
+                printAndAccept(columns, ", ");
+                print(')');
+            }
         }
         printPivot(x.getPivot());
         printUnpivot(x.getUnpivot());

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -890,12 +890,23 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
                     && rightOp.isLogical()
                     && op.isLogical()
             )) {
+                // precedence requires grouping; emit parentheses explicitly when the child is not
+                // already parenthesized (otherwise visitBinaryOpExpr would print them and we'd double up).
+                // Limited to arithmetic operators, where the priority table matches the parser and the
+                // parentheses are semantically required for programmatically-built ASTs (see issue #6408);
+                // other operators keep their historical output to avoid spurious parentheses.
+                boolean printParen = !binaryRight.isParenthesized()
+                        && rightOp.isArithmetic() && op.isArithmetic();
                 if (rightRational) { //这里需要验证
                     this.indentCount++;
                 }
-                //print('(');
+                if (printParen) {
+                    print('(');
+                }
                 printExpr(binaryRight, parameterized);
-                //print(')');
+                if (printParen) {
+                    print(')');
+                }
 
                 if (rightRational) {
                     this.indentCount--;
@@ -960,12 +971,21 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             }
 
             if (bracket) {
+                // precedence requires grouping; emit parentheses explicitly when the child is not
+                // already parenthesized (otherwise visitBinaryOpExpr would print them and we'd double up).
+                // Limited to arithmetic operators (see issue #6408 and visitorBinaryRight).
+                boolean printParen = !binaryLeft.isParenthesized()
+                        && leftOp.isArithmetic() && op.isArithmetic();
                 if (leftRational) {
                     this.indentCount++;
                 }
-                //print('(');
+                if (printParen) {
+                    print('(');
+                }
                 printExpr(left, parameterized);
-               // print(')');
+                if (printParen) {
+                    print(')');
+                }
 
                 if (leftRational) {
                     this.indentCount--;

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -5925,6 +5925,14 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         }
         print(' ');
         print0(ucase ? "AS " : "as ");
+        Boolean materialized = x.getMaterialized();
+        if (materialized != null) {
+            if (materialized) {
+                print0(ucase ? "MATERIALIZED " : "materialized ");
+            } else {
+                print0(ucase ? "NOT MATERIALIZED " : "not materialized ");
+            }
+        }
         print('(');
         this.indentCount++;
         println();

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4372,6 +4372,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             case Prior:
             case ConnectByRoot:
             case NOT:
+            case VARIADIC:
                 print(' ');
                 if (operator != SQLUnaryOperator.Prior && expr instanceof SQLBinaryOpExpr && !((SQLBinaryOpExpr) expr).isParenthesized()) {
                     print('(');

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -878,6 +878,16 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
     private void visitorBinaryRight(SQLBinaryOpExpr x) {
         SQLExpr right = x.getRight();
         SQLBinaryOperator op = x.getOperator();
+        if (op == SQLBinaryOperator.MemberOf) {
+            // MySQL: value MEMBER OF (json_array) — the parentheses are part of the syntax
+            print('(');
+            printExpr(right, parameterized);
+            print(')');
+            if (x.getHint() != null) {
+                x.getHint().accept(this);
+            }
+            return;
+        }
         if (right instanceof SQLBinaryOpExpr) {
             SQLBinaryOpExpr binaryRight = (SQLBinaryOpExpr) right;
             SQLBinaryOperator rightOp = binaryRight.getOperator();

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4995,9 +4995,12 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             print(')');
         }
 
-        if (x.getOffset() != null) {
-            print0(ucase ? " WITH OFFSET AS " : " with offset as ");
-            x.getOffset().accept(this);
+        if (x.isWithOffset()) {
+            print0(ucase ? " WITH OFFSET" : " with offset");
+            if (x.getOffset() != null) {
+                print0(ucase ? " AS " : " as ");
+                x.getOffset().accept(this);
+            }
         }
         printPivot(x.getPivot());
         printUnpivot(x.getUnpivot());

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/bigquery/issues/Issue6547.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/bigquery/issues/Issue6547.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.bvt.sql.bigquery.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * BigQuery UNNEST(...) WITH OFFSET, where the offset alias is optional.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6547">Issue #6547</a>
+ */
+public class Issue6547 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.bigquery);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.bigquery).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_with_offset_no_alias() {
+        assertEquals("SELECT * FROM UNNEST([10, 20, 30]) AS numbers WITH OFFSET",
+                rt("SELECT * FROM UNNEST([10,20,30]) as numbers WITH OFFSET"));
+    }
+
+    @Test
+    public void test_with_offset_alias() {
+        assertEquals("SELECT * FROM UNNEST([10, 20, 30]) AS numbers WITH OFFSET AS off",
+                rt("SELECT * FROM UNNEST([10,20,30]) as numbers WITH OFFSET AS off"));
+    }
+
+    @Test
+    public void test_unnest_without_offset_unchanged() {
+        assertEquals("SELECT * FROM UNNEST([1, 2]) AS n",
+                rt("SELECT * FROM UNNEST([1,2]) as n"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/Issue6583.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/Issue6583.java
@@ -1,0 +1,35 @@
+package com.alibaba.druid.bvt.sql.dm;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * DM (Dameng) CREATE TABLE with IDENTITY(seed, increment) column constraint.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6583">Issue #6583</a>
+ */
+public class Issue6583 {
+    @Test
+    public void test_create_table_with_identity() {
+        String sql = "CREATE TABLE TEST.TEST_CREATE (\n"
+                + "    id INT IDENTITY(1,1),\n"
+                + "    name VARCHAR(64) NOT NULL,\n"
+                + "    PRIMARY KEY (id)\n"
+                + ")";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.dm);
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_create_table_with_identity_default() {
+        String sql = "CREATE TABLE T (id INT IDENTITY)";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.dm);
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/issues/Issue6408.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/issues/Issue6408.java
@@ -1,0 +1,75 @@
+package com.alibaba.druid.bvt.sql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A programmatically-built SQLBinaryOpExpr must emit parentheses when operator precedence
+ * requires them, otherwise the SQL meaning changes (e.g. (5 + 3) / 2 vs 5 + 3 / 2).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6408">Issue #6408</a>
+ */
+public class Issue6408 {
+    private static SQLBinaryOpExpr bin(Object l, SQLBinaryOperator op, Object r) {
+        return new SQLBinaryOpExpr(
+                l instanceof Integer ? new SQLIntegerExpr((Integer) l) : (com.alibaba.druid.sql.ast.SQLExpr) l,
+                op,
+                r instanceof Integer ? new SQLIntegerExpr((Integer) r) : (com.alibaba.druid.sql.ast.SQLExpr) r);
+    }
+
+    @Test
+    public void test_left_add_under_divide() {
+        SQLBinaryOpExpr expr = bin(bin(5, SQLBinaryOperator.Add, 3), SQLBinaryOperator.Divide, 2);
+        assertEquals("(5 + 3) / 2", expr.toString());
+    }
+
+    @Test
+    public void test_right_add_under_divide() {
+        SQLBinaryOpExpr expr = bin(2, SQLBinaryOperator.Divide, bin(5, SQLBinaryOperator.Add, 3));
+        assertEquals("2 / (5 + 3)", expr.toString());
+    }
+
+    @Test
+    public void test_left_add_under_multiply() {
+        SQLBinaryOpExpr expr = bin(bin(5, SQLBinaryOperator.Add, 3), SQLBinaryOperator.Multiply, 2);
+        assertEquals("(5 + 3) * 2", expr.toString());
+    }
+
+    @Test
+    public void test_right_subtract_associativity() {
+        SQLBinaryOpExpr expr = bin(2, SQLBinaryOperator.Subtract, bin(5, SQLBinaryOperator.Subtract, 3));
+        assertEquals("2 - (5 - 3)", expr.toString());
+    }
+
+    @Test
+    public void test_no_spurious_parens_when_not_needed() {
+        // 5 + 3 / 2 : divide binds tighter, no parens needed
+        SQLBinaryOpExpr expr = bin(5, SQLBinaryOperator.Add, bin(3, SQLBinaryOperator.Divide, 2));
+        assertEquals("5 + 3 / 2", expr.toString());
+    }
+
+    @Test
+    public void test_parsed_sql_roundtrip_unchanged() {
+        // parsing must not introduce or drop parentheses (whitespace/newlines are normalized away)
+        for (String sql : new String[]{
+                "SELECT (5 + 3) / 2",
+                "SELECT 5 + 3 / 2",
+                "SELECT a - b - c FROM t",
+                "SELECT a - (b - c) FROM t",
+                "SELECT a + b * c FROM t",
+                "SELECT a * (b + c) FROM t"}) {
+            List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+            String actual = SQLUtils.toSQLString(stmts.get(0), DbType.mysql).replaceAll("\\s+", " ").trim();
+            assertEquals(sql, actual, "roundtrip: " + sql);
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6428.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6428.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A back-quoted column name that collides with the CLUSTERED keyword must be treated as an
+ * ordinary column, not a CLUSTERED KEY/INDEX clause.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6428">Issue #6428</a>
+ */
+public class Issue6428 {
+    @Test
+    public void test_backquoted_clustered_column() {
+        String sql = "CREATE TABLE t1 (`clustered` tinyint(1) DEFAULT NULL COMMENT 'abc')";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("`clustered` tinyint(1)"));
+    }
+
+    @Test
+    public void test_clustered_key_still_parses() {
+        // unquoted CLUSTERED KEY must still be recognized
+        String sql = "CREATE TABLE t1 (id int, CLUSTERED KEY idx (id))";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).toUpperCase().contains("CLUSTERED"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6534.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6534.java
@@ -1,0 +1,42 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MySQL 8 JSON predicate: value MEMBER OF (json_array).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6534">Issue #6534</a>
+ */
+public class Issue6534 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.mysql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_member_of_param() {
+        assertTrue(rt("select * from project p where ? member of(p.participants -> '$.*[*]') order by p.id desc")
+                .contains("? MEMBER OF (p.participants -> '$.*[*]')"));
+    }
+
+    @Test
+    public void test_member_of_column() {
+        assertEquals("SELECT * FROM t WHERE x MEMBER OF (arr)",
+                rt("select * from t where x member of (arr)"));
+    }
+
+    @Test
+    public void test_member_of_literal_in_and() {
+        assertTrue(rt("select * from t where a = 1 and 5 member of (data)")
+                .contains("5 MEMBER OF (data)"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6534.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6534.java
@@ -39,4 +39,11 @@ public class Issue6534 {
         assertTrue(rt("select * from t where a = 1 and 5 member of (data)")
                 .contains("5 MEMBER OF (data)"));
     }
+
+    @Test
+    public void test_member_as_column_name() {
+        // "member" not followed by OF must remain an ordinary identifier (mark/reset fallback)
+        assertEquals("SELECT member FROM t", rt("select member from t"));
+        assertEquals("SELECT * FROM t WHERE member = 1", rt("select * from t where member = 1"));
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6405.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6405.java
@@ -1,0 +1,51 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle INTERVAL DAY TO HOUR (and DAY TO MINUTE) must keep their TO unit; previously every
+ * TO unit other than SECOND was incorrectly rendered as MONTH.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6405">Issue #6405</a>
+ */
+public class Issue6405 {
+    private static String rt(String fragment) {
+        String sql = "INSERT INTO t (c) VALUES (INTERVAL '1 2' " + fragment + ")";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+    }
+
+    @Test
+    public void test_day_to_hour() {
+        assertTrue(rt("DAY(2) TO HOUR").contains("DAY(2) TO HOUR"), "should keep TO HOUR");
+    }
+
+    @Test
+    public void test_day_to_minute() {
+        assertTrue(rt("DAY TO MINUTE").contains("DAY TO MINUTE"), "should keep TO MINUTE");
+    }
+
+    @Test
+    public void test_day_to_second_unchanged() {
+        assertTrue(rt("DAY(3) TO SECOND(2)").contains("DAY(3) TO SECOND(2)"), "should keep TO SECOND");
+    }
+
+    @Test
+    public void test_year_to_month_unchanged() {
+        assertTrue(rt("YEAR TO MONTH").contains("YEAR TO MONTH"), "should keep TO MONTH");
+    }
+
+    @Test
+    public void test_hour_to_minute() {
+        assertTrue(rt("HOUR TO MINUTE").contains("HOUR TO MINUTE"), "should keep TO MINUTE");
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6435.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6435.java
@@ -1,0 +1,43 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle PL/SQL SELECT ... INTO with multiple targets must render the targets comma-separated
+ * without surrounding parentheses (INTO a, b), not INTO (a, b).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6435">Issue #6435</a>
+ */
+public class Issue6435 {
+    @Test
+    public void test_select_into_multiple_targets() {
+        String sql = "DECLARE\n"
+                + "\ta int;\n"
+                + "\tb VARCHAR(10);\n"
+                + "BEGIN\n"
+                + "\tSELECT 1, 'a' INTO a, b FROM dual;\n"
+                + "END;";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("INTO a, b"), "expected `INTO a, b`, got:\n" + out);
+        assertFalse(out.contains("INTO (a, b)"), "INTO targets must not be parenthesized:\n" + out);
+    }
+
+    @Test
+    public void test_select_into_single_target_unchanged() {
+        String sql = "BEGIN SELECT 1 INTO a FROM dual; END;";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.oracle).contains("INTO a"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6458.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6458.java
@@ -1,0 +1,32 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle ALTER TABLE ... ADD CONSTRAINT ... USING INDEX referencing an existing (possibly
+ * schema-qualified) index name.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6458">Issue #6458</a>
+ */
+public class Issue6458 {
+    @Test
+    public void test_using_index_qualified_name() {
+        String sql = "ALTER TABLE \"SC\".\"TB1\"\n"
+                + "\tADD CONSTRAINT \"PK_XXX\" PRIMARY KEY (\"ID\")\n"
+                + "\t\tUSING INDEX \"SC\".\"PK_XXX\"\n"
+                + "\t\tENABLE";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("USING INDEX \"SC\".\"PK_XXX\""), out);
+        assertTrue(out.contains("ENABLE"), out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6458.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6458.java
@@ -29,4 +29,14 @@ public class Issue6458 {
         assertTrue(out.contains("USING INDEX \"SC\".\"PK_XXX\""), out);
         assertTrue(out.contains("ENABLE"), out);
     }
+
+    @Test
+    public void test_using_index_unquoted_name() {
+        String sql = "ALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (id) USING INDEX my_index ENABLE";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("USING INDEX my_index"), out);
+        assertTrue(out.contains("ENABLE"), out);
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6393.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6393.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL VARIADIC function argument, e.g. func(VARIADIC ARRAY[...]).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6393">Issue #6393</a>
+ */
+public class Issue6393 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_variadic_array_argument() {
+        String out = rt("SELECT jsonb_extract_path_text(a.info, VARIADIC ARRAY['w'::text, 'v'::text])::numeric "
+                + "AS usage FROM t a");
+        assertTrue(out.contains("VARIADIC ARRAY['w'::text, 'v'::text]"), out);
+    }
+
+    @Test
+    public void test_variadic_simple() {
+        assertTrue(rt("SELECT concat_ws(',', VARIADIC arr) FROM t").contains("VARIADIC arr"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6393.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6393.java
@@ -33,4 +33,11 @@ public class Issue6393 {
     public void test_variadic_simple() {
         assertTrue(rt("SELECT concat_ws(',', VARIADIC arr) FROM t").contains("VARIADIC arr"));
     }
+
+    @Test
+    public void test_variadic_as_column_name() {
+        // a column literally named "variadic" must not be swallowed by the VARIADIC prefix
+        assertEquals("SELECT variadic FROM t", rt("select variadic from t"));
+        assertEquals("SELECT * FROM t WHERE variadic = 1", rt("select * from t where variadic = 1"));
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6467.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6467.java
@@ -1,0 +1,43 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE (and the equivalent TYPE form).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6467">Issue #6467</a>
+ */
+public class Issue6467 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_set_data_type() {
+        assertEquals("ALTER TABLE IF EXISTS tbl ALTER COLUMN col SET DATA TYPE varchar(20)",
+                rt("alter table if exists tbl alter column col set data type varchar(20)"));
+    }
+
+    @Test
+    public void test_type_shorthand() {
+        assertEquals("ALTER TABLE tbl ALTER COLUMN col TYPE varchar(20)",
+                rt("alter table tbl alter column col type varchar(20)"));
+    }
+
+    @Test
+    public void test_existing_set_forms_unchanged() {
+        assertTrue(rt("alter table tbl alter column col set default 1").contains("SET DEFAULT 1"));
+        assertTrue(rt("alter table tbl alter column col set not null").contains("SET NOT NULL"));
+        assertTrue(rt("alter table tbl alter column col drop default").contains("DROP DEFAULT"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6511.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6511.java
@@ -1,0 +1,71 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL DELETE ... RETURNING should accept specific column list, not only `*`.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6511">Issue #6511</a>
+ */
+public class Issue6511 {
+    @Test
+    public void test_delete_returning_single_column() {
+        String sql = "DELETE FROM xxx WHERE id IN (?) RETURNING id";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "DELETE FROM xxx\n"
+                        + "WHERE id IN (?)\n"
+                        + "RETURNING id",
+                SQLUtils.toPGString(stmtList.get(0)));
+    }
+
+    @Test
+    public void test_delete_returning_multiple_columns() {
+        String sql = "DELETE FROM xxx WHERE id = ? RETURNING id, name, age";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "DELETE FROM xxx\n"
+                        + "WHERE id = ?\n"
+                        + "RETURNING id, name, age",
+                SQLUtils.toPGString(stmtList.get(0)));
+    }
+
+    @Test
+    public void test_delete_returning_star_still_works() {
+        String sql = "DELETE FROM xxx WHERE id IN (?) RETURNING *";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "DELETE FROM xxx\n"
+                        + "WHERE id IN (?)\n"
+                        + "RETURNING *",
+                SQLUtils.toPGString(stmtList.get(0)));
+    }
+
+    @Test
+    public void test_delete_returning_qualified_column() {
+        String sql = "DELETE FROM xxx x WHERE x.id = ? RETURNING x.id, x.name";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "DELETE FROM xxx AS x\n"
+                        + "WHERE x.id = ?\n"
+                        + "RETURNING x.id, x.name",
+                SQLUtils.toPGString(stmtList.get(0)));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6540.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6540.java
@@ -1,0 +1,39 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL CREATE TABLE with VARCHAR2/DOUBLE column types (Oracle-compatibility).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6540">Issue #6540</a>
+ */
+public class Issue6540 {
+    @Test
+    public void test_create_table_with_varchar2_and_double() {
+        String sql = "create table STUDY_FINISH_C313F1B171F14BBEAFCC761BE74DA60B.t_els_course_study_record_0  "
+                + "( user_id VARCHAR2(256),course_id VARCHAR2(256),course_period DOUBLE,get_score DOUBLE,"
+                + "should_get_score DOUBLE,exam_count int,pass_exam_score VARCHAR2(128),last_exam_score VARCHAR2(128))";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_double_precision_still_parsed() {
+        String sql = "create table t (a DOUBLE PRECISION, b INT)";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "CREATE TABLE t (\n"
+                        + "\ta DOUBLE PRECISION,\n"
+                        + "\tb INT\n"
+                        + ")",
+                SQLUtils.toPGString(stmtList.get(0)));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6560.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6560.java
@@ -1,0 +1,51 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL CTE materialization hint: WITH name AS [NOT] MATERIALIZED (query).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6560">Issue #6560</a>
+ */
+public class Issue6560 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_materialized() {
+        assertTrue(rt("with t as materialized (select 1) select * from t")
+                .contains("AS MATERIALIZED ("), "should keep MATERIALIZED");
+    }
+
+    @Test
+    public void test_not_materialized() {
+        assertTrue(rt("with t as not materialized (select 1) select * from t")
+                .contains("AS NOT MATERIALIZED ("), "should keep NOT MATERIALIZED");
+    }
+
+    @Test
+    public void test_recursive_with_materialized() {
+        String out = rt("with t as materialized (with recursive tmp as "
+                + "(select id, parent from ml union all select c.id, c.parent from ml c join tmp p on c.parent = p.id) "
+                + "select * from tmp) select * from t");
+        assertTrue(out.contains("AS MATERIALIZED ("));
+        assertTrue(out.contains("WITH RECURSIVE tmp"));
+    }
+
+    @Test
+    public void test_plain_cte_unchanged() {
+        assertEquals("WITH t AS ( SELECT 1 ) SELECT * FROM t",
+                rt("with t as (select 1) select * from t"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6572.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6572.java
@@ -1,0 +1,48 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A derived table over a UNION must accept a column-alias list: (subquery) AS t(col, ...).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6572">Issue #6572</a>
+ */
+public class Issue6572 {
+    private static String rt(DbType db, String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, db);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), db).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_union_derived_table_column_alias() {
+        assertTrue(rt(DbType.postgresql, "select * from (select 1 union all select 2) AS t(time)")
+                .contains("AS t (time)"), "column alias list must be kept");
+    }
+
+    @Test
+    public void test_union_derived_table_alias_without_as() {
+        assertTrue(rt(DbType.postgresql, "select * from (select 1 union all select 2) t(c1)")
+                .contains("t (c1)"));
+    }
+
+    @Test
+    public void test_plain_subquery_column_alias_unchanged() {
+        assertEquals("SELECT * FROM ( SELECT 1 ) AS t (c1)",
+                rt(DbType.postgresql, "select * from (select 1) AS t(c1)"));
+    }
+
+    @Test
+    public void test_mysql_union_derived_table_column_alias() {
+        assertTrue(rt(DbType.mysql, "select * from (select 1 union all select 2) AS t(c1)")
+                .contains("AS t (c1)"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6573.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6573.java
@@ -1,0 +1,42 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL stores the COLLATE clause on the (character) data type. It was dropped on output for
+ * both casts in ORDER BY (e.g. (a)::text COLLATE "x") and column definitions.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6573">Issue #6573</a>
+ */
+public class Issue6573 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_order_by_cast_collate() {
+        assertEquals("SELECT id FROM t ORDER BY (a)::text COLLATE \"zh-Hans-x-icu\" DESC",
+                rt("SELECT id FROM t ORDER BY (a)::text COLLATE \"zh-Hans-x-icu\" DESC"));
+    }
+
+    @Test
+    public void test_order_by_simple_collate_unchanged() {
+        assertTrue(rt("SELECT id FROM t ORDER BY name COLLATE \"x\"").contains("COLLATE \"x\""));
+    }
+
+    @Test
+    public void test_column_definition_collate() {
+        String out = rt("CREATE TABLE t (a VARCHAR(10) COLLATE \"default\", b int)");
+        assertTrue(out.contains("VARCHAR(10) COLLATE \"default\""), "column COLLATE must be kept: " + out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6637.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6637.java
@@ -1,0 +1,44 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * openGauss (registered as the postgresql dialect) supports Oracle-style hierarchical queries
+ * CONNECT BY ... START WITH ...
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6637">Issue #6637</a>
+ */
+public class Issue6637 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_connect_by_start_with() {
+        String out = rt("select * from t connect by prior id = parent_id start with id = ''");
+        assertTrue(out.contains("CONNECT BY PRIOR id = parent_id"), out);
+        assertTrue(out.contains("START WITH id = ''"), out);
+    }
+
+    @Test
+    public void test_start_with_connect_by() {
+        String out = rt("select id, name from org start with parent_id is null connect by prior id = parent_id");
+        assertTrue(out.contains("START WITH parent_id IS NULL"), out);
+        assertTrue(out.contains("CONNECT BY PRIOR id = parent_id"), out);
+    }
+
+    @Test
+    public void test_plain_select_unaffected() {
+        assertEquals("SELECT * FROM t WHERE id = 1", rt("select * from t where id = 1"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/Issue6280Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/Issue6280Test.java
@@ -1,0 +1,52 @@
+package com.alibaba.druid.bvt.sql.presto;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Presto try_cast(expr AS type) parsing.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6280">Issue #6280</a>
+ */
+public class Issue6280Test {
+    @Test
+    public void test_try_cast_basic() {
+        String sql = "SELECT try_cast(dt_day AS int) FROM t";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "SELECT TRY_CAST(dt_day AS int)\n"
+                        + "FROM t",
+                SQLUtils.toSQLString(stmtList.get(0), DbType.presto));
+    }
+
+    @Test
+    public void test_try_cast_in_where() {
+        String sql = "SELECT * FROM t WHERE try_cast(c AS bigint) > 0";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+        assertEquals(
+                "SELECT *\n"
+                        + "FROM t\n"
+                        + "WHERE TRY_CAST(c AS bigint) > 0",
+                SQLUtils.toSQLString(stmtList.get(0), DbType.presto));
+    }
+
+    @Test
+    public void test_try_cast_with_complex_expr() {
+        String sql = "SELECT try_cast(dt_day AS int) FROM ads_test.employee_task_info_1d_f WHERE dt_day = '$[yyyyMMdd-1]'";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.presto);
+        List<SQLStatement> stmtList = parser.parseStatementList();
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/issues/Issue6631.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/issues/Issue6631.java
@@ -38,4 +38,10 @@ public class Issue6631 {
     public void test_array_constructor_still_works() {
         assertEquals("SELECT ARRAY[1, 2, 3]", rt("select ARRAY[1,2,3]"));
     }
+
+    @Test
+    public void test_nested_subscript() {
+        // nested map/array access must keep both levels and their bases
+        assertEquals("SELECT col['a']['b'] FROM t", rt("select col['a']['b'] from t"));
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/presto/issues/Issue6631.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/presto/issues/Issue6631.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.bvt.sql.presto.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Presto subscript access col['k'] must keep the base expression and not be rendered as an
+ * ARRAY[...] constructor.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6631">Issue #6631</a>
+ */
+public class Issue6631 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.presto);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.presto).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_map_subscript_in_select() {
+        assertEquals("SELECT ext['c1'] FROM test.test_table",
+                rt("select ext['c1'] from test.test_table"));
+    }
+
+    @Test
+    public void test_subscript_in_where() {
+        assertEquals("SELECT * FROM t WHERE ext['c1'] = 1",
+                rt("select * from t where ext['c1'] = 1"));
+    }
+
+    @Test
+    public void test_array_constructor_still_works() {
+        assertEquals("SELECT ARRAY[1, 2, 3]", rt("select ARRAY[1,2,3]"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6487.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6487.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * SQL Server stored-procedure execution option: EXEC proc ... WITH RECOMPILE.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6487">Issue #6487</a>
+ */
+public class Issue6487 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.sqlserver);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.sqlserver).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_exec_with_recompile() {
+        assertEquals("EXEC ProcName ?, ?, ?, ? WITH RECOMPILE",
+                rt("EXEC ProcName ?,?,?,? WITH RECOMPILE"));
+    }
+
+    @Test
+    public void test_exec_without_recompile_unchanged() {
+        assertEquals("EXEC ProcName ?, ?", rt("EXEC ProcName ?, ?"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6564.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6564.java
@@ -1,0 +1,43 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * SQL Server FOR XML clause must be rendered once, with the mode/path first and the options
+ * comma-separated (including the first option); previously the first option was dropped and the
+ * path was emitted as a duplicate "FOR XML" clause.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6564">Issue #6564</a>
+ */
+public class Issue6564 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.sqlserver);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.sqlserver).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_for_xml_path_with_type() {
+        assertEquals("SELECT ',' + Name FROM Employees FOR XML PATH(''), TYPE",
+                rt("SELECT ',' + Name FROM Employees FOR XML PATH(''), TYPE"));
+    }
+
+    @Test
+    public void test_for_xml_path_only() {
+        assertEquals("SELECT Name FROM Employees FOR XML PATH('')",
+                rt("SELECT Name FROM Employees FOR XML PATH('')"));
+    }
+
+    @Test
+    public void test_for_xml_auto_options_keep_first() {
+        assertEquals("SELECT id FROM t FOR XML AUTO, TYPE, XMLSCHEMA, ELEMENTS XSINIL",
+                rt("SELECT id FROM t FOR XML AUTO, TYPE, XMLSCHEMA, ELEMENTS XSINIL"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/starrocks/issues/Issue6365.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/starrocks/issues/Issue6365.java
@@ -10,29 +10,32 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * StarRocks map/array bracket index access: my_map[key].
+ * StarRocks map/array bracket index access: my_map[key]. The subscript must round-trip with its
+ * base expression (and not collapse to ARRAY[...]).
  *
  * @see <a href="https://github.com/alibaba/druid/issues/6365">Issue #6365</a>
  */
 public class Issue6365 {
-    @Test
-    public void test_map_bracket_in_select_and_where() {
-        String sql = "SELECT * FROM (SELECT exp_tags[111] FROM tablea WHERE exp_tags[111] = 22222) t";
+    private static String rt(String sql) {
         List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
         assertEquals(1, stmtList.size());
+        return SQLUtils.toSQLString(stmtList.get(0), DbType.starrocks).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_map_bracket_in_select_and_where() {
+        // subscript must be preserved (not collapsed to ARRAY[...]) in both SELECT and WHERE
+        String out = rt("SELECT * FROM (SELECT exp_tags[111] FROM tablea WHERE exp_tags[111] = 22222) t");
+        assertEquals(2, out.split("exp_tags\\[111\\]", -1).length - 1, "both subscripts kept: " + out);
     }
 
     @Test
     public void test_map_bracket_simple() {
-        String sql = "SELECT my_map['key'] FROM t";
-        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
-        assertEquals(1, stmtList.size());
+        assertEquals("SELECT my_map['key'] FROM t", rt("SELECT my_map['key'] FROM t"));
     }
 
     @Test
     public void test_array_bracket_with_int() {
-        String sql = "SELECT arr[1] FROM t";
-        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
-        assertEquals(1, stmtList.size());
+        assertEquals("SELECT arr[1] FROM t", rt("SELECT arr[1] FROM t"));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/starrocks/issues/Issue6365.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/starrocks/issues/Issue6365.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.bvt.sql.starrocks.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * StarRocks map/array bracket index access: my_map[key].
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6365">Issue #6365</a>
+ */
+public class Issue6365 {
+    @Test
+    public void test_map_bracket_in_select_and_where() {
+        String sql = "SELECT * FROM (SELECT exp_tags[111] FROM tablea WHERE exp_tags[111] = 22222) t";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_map_bracket_simple() {
+        String sql = "SELECT my_map['key'] FROM t";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
+        assertEquals(1, stmtList.size());
+    }
+
+    @Test
+    public void test_array_bracket_with_int() {
+        String sql = "SELECT arr[1] FROM t";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, DbType.starrocks);
+        assertEquals(1, stmtList.size());
+    }
+}

--- a/core/src/test/resources/bvt/parser/athena/0.txt
+++ b/core/src/test/resources/bvt/parser/athena/0.txt
@@ -25,7 +25,7 @@ FROM 'dag_datalake_klikpajak'.'ebilling' e
 SELECT case when contains(u.roles[company_id_cross], 'report_reader') then 1 else 0 end is_report_reader from t1
 --------------------
 SELECT CASE
-		WHEN contains(ARRAY[company_id_cross], 'report_reader') THEN 1
+		WHEN contains(u.roles[company_id_cross], 'report_reader') THEN 1
 		ELSE 0
 	END AS is_report_reader
 FROM t1

--- a/core/src/test/resources/bvt/parser/postgresql/17.txt
+++ b/core/src/test/resources/bvt/parser/postgresql/17.txt
@@ -369,8 +369,8 @@ CREATE TABLE "public"."city" (
 ) WITH (OIDS=FALSE);
 --------------------
 CREATE TABLE "public"."city" (
-	"id" varchar(6) NOT NULL,
-	"name" varchar(32) NOT NULL
+	"id" varchar(6) COLLATE "default" NOT NULL,
+	"name" varchar(32) COLLATE "default" NOT NULL
 )
 WITH (
 	OIDS = false

--- a/core/src/test/resources/bvt/parser/sqlserver/0.txt
+++ b/core/src/test/resources/bvt/parser/sqlserver/0.txt
@@ -299,7 +299,7 @@ FROM Person.Person p
 	JOIN Person.PersonPhone pph ON p.BusinessEntityID = pph.BusinessEntityID
 WHERE LastName LIKE 'G%'
 ORDER BY LastName, FirstName
-FOR XML , TYPE, XMLSCHEMA, ELEMENTS XSINIL
+FOR XML AUTO, TYPE, XMLSCHEMA, ELEMENTS XSINIL
 ------------------------------------------------------------------------------------------------------------------------
 SELECT First_Name + ' ' + Last Name FROM Employees ORDER BY First_Name OFFSET 10 ROWS
 --------------------


### PR DESCRIPTION
## 概述

批量修复 SQL 解析器中**可解析类 bug**，覆盖 PostgreSQL/openGauss、Oracle、MySQL、SQL Server、BigQuery、Presto、StarRocks 等方言。每个修复均配套复现测试，按 issue 单独提交，便于审阅与回溯。

其中 #6408、#6631 为**会静默改变 SQL 语义**的高危正确性 bug（影响所有方言）。

## 修复清单（18 个解析 bug）

| 方言 | 修复 |
|---|---|
| 通用 | `(5+3)/2` 编程构建丢括号致语义变 `5+3/2`（#6408）；`col['k']` 下标被误判为 `ARRAY['k']` 丢基表达式（#6631） |
| Oracle | `INTERVAL ... TO HOUR/MINUTE` 误判为 MONTH（#6405）；`SELECT INTO a,b` 多余括号（#6435）；`USING INDEX "schema"."idx"`（#6458） |
| PostgreSQL/openGauss | 字符类型 COLLATE 丢失（#6573）；`ALTER COLUMN ... SET DATA TYPE`（#6467）；CTE `[NOT] MATERIALIZED`（#6560）；UNION 派生表列别名（#6572）；`CONNECT BY ... START WITH`（#6637）；`VARIADIC` 函数参数（#6393）；`VARCHAR2/DOUBLE` 列类型（#6540）；`DELETE ... RETURNING` 列清单（#6511） |
| MySQL | 反引号关键字列名 `` `clustered` ``（#6428）；JSON `value MEMBER OF (json_array)`（#6534） |
| SQL Server | `FOR XML` 重复输出且丢 TYPE（#6564）；`EXEC ... WITH RECOMPILE`（#6487） |
| BigQuery | `UNNEST(...) WITH OFFSET`（无别名）（#6547） |

## 回归测试确认（3 个近期已修复，补测试锁定行为）

达梦 `IDENTITY` 列（#6583）、Presto `try_cast`（#6280）、StarRocks `map[k]` 下标（#6365）。

## 测试

- 每个修复均新增 `IssueXXXX` 复现测试。
- 改动通用 parser/visitor 的项均跑全量 `bvt.sql.**`（2613 用例全绿）。
- 反向回归对比：`com.alibaba.druid.sql.**` 包在本分支与 master 的失败方法集**完全一致**，本 PR **零回归**。
- 两处 golden（`sqlserver/0.txt`、`postgresql/17.txt`、`athena/0.txt`）因输出修正而同步更新。

## 关联 issue

Fixes #6540, fixes #6511, fixes #6408, fixes #6405, fixes #6435, fixes #6564, fixes #6631, fixes #6573, fixes #6467, fixes #6560, fixes #6572, fixes #6637, fixes #6393, fixes #6428, fixes #6534, fixes #6487, fixes #6547, fixes #6458, fixes #6583, fixes #6280, fixes #6365

## 备注

- **#6413**（PG `LIKE ? ESCAPE '\'`）暂未纳入：正确修法需让 PG 普通字符串反斜杠按 `standard_conforming_strings` 作字面量，但会改变现有 escape-string 语义、破坏依赖该行为的现有用户与测试数据，需单独决策（开关 / 切默认 / 维持现状）。
- 排查中发现一处与本 PR 无关的 master 既有问题：`PGUpsertTest` 失败，PG `INSERT ... ON CONFLICT (id) DO UPDATE SET ...` 输出丢失整个 ON CONFLICT 子句，建议另行排查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
