### PR TITLE
test: 为 10 个已修复的 SQL 解析 issue 补回归测试

### DIFF
--- a/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue6491.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue6491.java
@@ -23,6 +23,8 @@ public class Issue6491 {
                 + "LEFT JOIN default.my_table5_trace_id AS b ON a.trace_id = b.trace_id";
         List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
         assertEquals(1, stmts.size());
-        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.clickhouse).contains("ARRAY JOIN"));
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.clickhouse);
+        assertTrue(out.contains("ARRAY JOIN"), out);
+        assertTrue(out.contains("FROM (default.my_table5"), "parenthesized table source must be kept:\n" + out);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue6491.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue6491.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.clickhouse.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ClickHouse ARRAY JOIN inside a parenthesized table source joined with another table.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6491">Issue #6491</a>
+ */
+public class Issue6491 {
+    @Test
+    public void test_array_join_in_parenthesized_table_source() {
+        String sql = "SELECT trace_id, b.trace_name "
+                + "FROM (default.my_table5 a ARRAY JOIN event_type AS event_type1, device_id AS device_id1) "
+                + "LEFT JOIN default.my_table5_trace_id AS b ON a.trace_id = b.trace_id";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.clickhouse).contains("ARRAY JOIN"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6552.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6552.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.bvt.sql.dm.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * DM (Dameng) LISTAGG over a derived table with DISTINCT.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6552">Issue #6552</a>
+ */
+public class Issue6552 {
+    @Test
+    public void test_listagg_over_derived_table() {
+        String sql = "SELECT project_id, LISTAGG(seq, ',') as ids FROM ("
+                + "SELECT DISTINCT t1.project_id, t2.seq FROM a t1 LEFT JOIN b t2 ON t1.id = t2.id) "
+                + "GROUP BY project_id";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.dm);
+        assertEquals(1, stmts.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6552.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6552.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * DM (Dameng) LISTAGG over a derived table with DISTINCT.
@@ -22,5 +23,8 @@ public class Issue6552 {
                 + "GROUP BY project_id";
         List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.dm);
         assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.dm);
+        assertTrue(out.contains("LISTAGG"), "LISTAGG must be preserved:\n" + out);
+        assertTrue(out.contains("DISTINCT"), "DISTINCT in derived table must be preserved:\n" + out);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6648.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6648.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.bvt.sql.dm.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DM (Dameng) LISTAGG(...) WITHIN GROUP (ORDER BY ...) aggregate parsing.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6648">Issue #6648</a>
+ */
+public class Issue6648 {
+    @Test
+    public void test_listagg_within_group() {
+        String sql = "SELECT field_1, listagg(field_4, ':') WITHIN GROUP (ORDER BY field_0 desc) result "
+                + "FROM t GROUP BY field_1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.dm);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.dm).contains("WITHIN GROUP (ORDER BY field_0 DESC)"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6499.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6499.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DELETE a FROM users FORCE INDEX(a1) WHERE ... must keep its WHERE clause.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6499">Issue #6499</a>
+ */
+public class Issue6499 {
+    @Test
+    public void test_delete_with_force_index_keeps_where() {
+        String sql = "delete a from users force index(a1) where id < 10";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("WHERE id < 10"));
+    }
+
+    @Test
+    public void test_delete_with_alias_force_index_keeps_where() {
+        String sql = "delete a from users a force index(a1) where id < 10";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("WHERE id < 10"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oceanbase/issues/Issue6546.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oceanbase/issues/Issue6546.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.bvt.sql.oceanbase.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UPDATE ... LIMIT must parse (OceanBase / MySQL-compatible).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6546">Issue #6546</a>
+ */
+public class Issue6546 {
+    @Test
+    public void test_update_with_limit() {
+        String sql = "update t set id = last_insert_id(id + 1) limit 1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oceanbase);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.oceanbase).contains("LIMIT 1"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6387.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6387.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle max((subquery)) must keep the inner parentheses around the scalar subquery; otherwise it
+ * renders as max(subquery) and fails with ORA-00936.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6387">Issue #6387</a>
+ */
+public class Issue6387 {
+    @Test
+    public void test_aggregate_over_parenthesized_subquery() {
+        String sql = "select max((SELECT a.name FROM tcur a WHERE a.no = d.no)) vc_name from t d";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("max((") && out.contains("))"), "inner parentheses must be kept:\n" + out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6522.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6522.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Oracle table alias must not get an AS keyword (Oracle does not allow AS for table aliases).
@@ -23,5 +24,6 @@ public class Issue6522 {
         assertEquals(1, stmts.size());
         String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
         assertFalse(out.contains("AB01 AS a"), "Oracle table alias must not use AS:\n" + out);
+        assertTrue(out.contains("AB01 a"), "table alias should be preserved without AS:\n" + out);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6522.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6522.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Oracle table alias must not get an AS keyword (Oracle does not allow AS for table aliases).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6522">Issue #6522</a>
+ */
+public class Issue6522 {
+    @Test
+    public void test_table_alias_without_as() {
+        String sql = "select * from AB01 a where a.AAB999 = '430521463000'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertFalse(out.contains("AB01 AS a"), "Oracle table alias must not use AS:\n" + out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6385.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6385.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.PagerUtils;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The parentheses around a function expression that is then subscripted, e.g. (array_agg(name))[1],
+ * must be preserved (otherwise the [1] subscript binds wrong and execution fails).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6385">Issue #6385</a>
+ */
+public class Issue6385 {
+    @Test
+    public void test_subscript_on_parenthesized_function_kept() {
+        String sql = "SELECT (array_agg(name))[1] FROM fruits GROUP BY id";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).contains("(array_agg(name))[1]"));
+    }
+
+    @Test
+    public void test_pager_count_keeps_parentheses() {
+        String count = PagerUtils.count("SELECT (array_agg(name))[1] FROM fruits group by id", DbType.postgresql);
+        assertTrue(count.contains("(array_agg(name))[1]"), count);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6498.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6498.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * PostgreSQL INSERT ... WITH cte ... SELECT must parse as a single statement, not be split in two.
@@ -20,5 +21,8 @@ public class Issue6498 {
         String sql = "INSERT INTO category (\"name\") WITH t1 AS (SELECT 'aaaa' c) SELECT c FROM t1 WHERE 1 = 0";
         List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
         assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql);
+        assertTrue(out.contains("WITH t1 AS"), "CTE should be preserved:\n" + out);
+        assertTrue(out.contains("INSERT INTO category"), "INSERT target should be preserved:\n" + out);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6498.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6498.java
@@ -1,0 +1,24 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL INSERT ... WITH cte ... SELECT must parse as a single statement, not be split in two.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6498">Issue #6498</a>
+ */
+public class Issue6498 {
+    @Test
+    public void test_insert_with_cte_select_is_one_statement() {
+        String sql = "INSERT INTO category (\"name\") WITH t1 AS (SELECT 'aaaa' c) SELECT c FROM t1 WHERE 1 = 0";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6437.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue6437.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SQL Server COLLATE in a join/where predicate, e.g. a.x = b.y COLLATE Chinese_PRC_CI_AI_WS.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6437">Issue #6437</a>
+ */
+public class Issue6437 {
+    @Test
+    public void test_collate_in_join_predicate() {
+        String sql = "select * from a join b on a.REPORTLINE = b.REPORT_ITEM_ID COLLATE Chinese_PRC_CI_AI_WS "
+                + "WHERE a.referencedate = ?";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.sqlserver);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.sqlserver).contains("COLLATE Chinese_PRC_CI_AI_WS"));
+    }
+}


### PR DESCRIPTION
## 概述

以下 10 个 issue 被报告为 SQL 解析 bug，但**已被近期重构顺带修复**。本 PR 补上复现/回归测试，锁定行为并关闭这些 issue。每个测试均已通过。

| Issue | 验证点 |
|---|---|
| #6498 | PG `INSERT ... WITH cte ... SELECT` 解析为单条语句（不再被拆成两条） |
| #6385 | PG 被下标访问的函数表达式 `(array_agg(name))[1]` 外层括号保留 |
| #6499 | MySQL `DELETE a FROM ... FORCE INDEX(...) WHERE ...` 保留 WHERE |
| #6387 | Oracle `max((subquery))` 保留内层括号（否则 ORA-00936） |
| #6522 | Oracle 表别名不加 `AS` |
| #6648 / #6552 | 达梦 `LISTAGG(...) WITHIN GROUP (...)` |
| #6546 | `UPDATE ... LIMIT`（OceanBase） |
| #6491 | ClickHouse 括号表源内 `ARRAY JOIN` |
| #6437 | SQL Server 谓词中的 `COLLATE` |

## 关联 issue

Fixes #6498, fixes #6385, fixes #6499, fixes #6387, fixes #6522, fixes #6648, fixes #6552, fixes #6546, fixes #6491, fixes #6437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
