### PR TITLE
fix: MySQL ADD COLUMN IF NOT EXISTS (#6067) + 5 个已修复 issue 的回归测试

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLColumnDefinition.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLColumnDefinition.java
@@ -603,6 +603,7 @@ public class SQLColumnDefinition extends SQLObjectImpl implements SQLTableElemen
 
         x.stored = stored;
         x.virtual = virtual;
+        x.ifNotExists = ifNotExists;
 
         if (identity != null) {
             x.setIdentity(identity.clone());

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
@@ -1735,6 +1735,14 @@ public class MySqlExprParser extends SQLExprParser {
         SQLColumnDefinition column = new SQLColumnDefinition();
         column.setDbType(dbType);
 
+        // MySQL/MariaDB: ALTER TABLE ... ADD COLUMN IF NOT EXISTS col ... (issue #6067)
+        if (lexer.token() == Token.IF) {
+            lexer.nextToken();
+            accept(Token.NOT);
+            accept(Token.EXISTS);
+            column.setIfNotExists(true);
+        }
+
         SQLName name = name();
         column.setName(name);
         column.setDataType(

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlExprParser.java
@@ -1735,14 +1735,6 @@ public class MySqlExprParser extends SQLExprParser {
         SQLColumnDefinition column = new SQLColumnDefinition();
         column.setDbType(dbType);
 
-        // MySQL/MariaDB: ALTER TABLE ... ADD COLUMN IF NOT EXISTS col ... (issue #6067)
-        if (lexer.token() == Token.IF) {
-            lexer.nextToken();
-            accept(Token.NOT);
-            accept(Token.EXISTS);
-            column.setIfNotExists(true);
-        }
-
         SQLName name = name();
         column.setName(name);
         column.setDataType(

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -7572,7 +7572,18 @@ public class MySqlStatementParser extends SQLStatementParser {
 
         SQLAlterTableAddColumn item = new SQLAlterTableAddColumn();
         for (; ; ) {
+            // MySQL/MariaDB: ADD COLUMN IF NOT EXISTS col ... (scoped to ADD COLUMN; issue #6067)
+            boolean ifNotExists = false;
+            if (lexer.token() == Token.IF) {
+                lexer.nextToken();
+                accept(Token.NOT);
+                accept(Token.EXISTS);
+                ifNotExists = true;
+            }
             SQLColumnDefinition columnDef = this.exprParser.parseColumn();
+            if (ifNotExists) {
+                columnDef.setIfNotExists(true);
+            }
             item.addColumn(columnDef);
             if (lexer.identifierEquals("AFTER")) {
                 lexer.nextToken();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -260,6 +260,10 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         boolean parameterized = this.parameterized;
         this.parameterized = false;
 
+        if (x.isIfNotExists()) {
+            print0(ucase ? "IF NOT EXISTS " : "if not exists ");
+        }
+
         String columnName = replaceQuota(x.getName().getSimpleName());
         printName0(columnName);
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/starrocks/visitor/StarRocksOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/starrocks/visitor/StarRocksOutputVisitor.java
@@ -251,6 +251,9 @@ public class StarRocksOutputVisitor extends SQLASTOutputVisitor implements StarR
     }
 
     public boolean visit(SQLColumnDefinition x) {
+        if (x.isIfNotExists()) {
+            print0(ucase ? "IF NOT EXISTS " : "if not exists ");
+        }
         String columnName = replaceQuota(x.getName().getSimpleName());
         printName0(columnName);
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6032.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6032.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A back-quoted table name containing the word "check" must parse (the CHECK keyword inside a
+ * quoted identifier is not a constraint).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6032">Issue #6032</a>
+ */
+public class Issue6032 {
+    @Test
+    public void test_backquoted_table_name_with_check() {
+        String sql = "SELECT `email` FROM `hr`.`background-check-info`";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("`background-check-info`"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6067.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6067.java
@@ -1,0 +1,35 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MySQL / MariaDB ALTER TABLE ... ADD COLUMN IF NOT EXISTS.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6067">Issue #6067</a>
+ */
+public class Issue6067 {
+    @Test
+    public void test_add_column_if_not_exists() {
+        String sql = "alter table aaa add column if not exists cc_count int(1) DEFAULT '5'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.mysql);
+        assertTrue(out.contains("ADD COLUMN IF NOT EXISTS cc_count"), out);
+    }
+
+    @Test
+    public void test_add_column_without_if_not_exists_unchanged() {
+        String sql = "alter table aaa add column cc_count int(1) DEFAULT '5'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("ADD COLUMN cc_count"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6067.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6067.java
@@ -3,11 +3,15 @@ package com.alibaba.druid.bvt.sql.mysql.issues;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableAddColumn;
+import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -17,12 +21,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Issue6067 {
     @Test
-    public void test_add_column_if_not_exists() {
+    public void test_add_column_if_not_exists_mysql_and_mariadb() {
         String sql = "alter table aaa add column if not exists cc_count int(1) DEFAULT '5'";
+        for (DbType dbType : new DbType[]{DbType.mysql, DbType.mariadb}) {
+            List<SQLStatement> stmts = SQLUtils.parseStatements(sql, dbType);
+            assertEquals(1, stmts.size());
+
+            SQLAlterTableStatement alter = (SQLAlterTableStatement) stmts.get(0);
+            SQLAlterTableAddColumn add = (SQLAlterTableAddColumn) alter.getItems().get(0);
+            SQLColumnDefinition col = add.getColumns().get(0);
+            assertTrue(col.isIfNotExists(), "AST flag must be set for " + dbType);
+
+            assertTrue(SQLUtils.toSQLString(stmts.get(0), dbType).contains("ADD COLUMN IF NOT EXISTS cc_count"));
+        }
+    }
+
+    @Test
+    public void test_add_multiple_columns_if_not_exists() {
+        String sql = "alter table t add column if not exists a int, add column if not exists b varchar(10)";
         List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
         assertEquals(1, stmts.size());
         String out = SQLUtils.toSQLString(stmts.get(0), DbType.mysql);
-        assertTrue(out.contains("ADD COLUMN IF NOT EXISTS cc_count"), out);
+        assertTrue(out.contains("ADD COLUMN IF NOT EXISTS a"), out);
+        assertTrue(out.contains("ADD COLUMN IF NOT EXISTS b"), out);
     }
 
     @Test
@@ -30,6 +51,16 @@ public class Issue6067 {
         String sql = "alter table aaa add column cc_count int(1) DEFAULT '5'";
         List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
         assertEquals(1, stmts.size());
+        SQLAlterTableStatement alter = (SQLAlterTableStatement) stmts.get(0);
+        SQLColumnDefinition col = ((SQLAlterTableAddColumn) alter.getItems().get(0)).getColumns().get(0);
+        assertEquals(false, col.isIfNotExists());
         assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("ADD COLUMN cc_count"));
+    }
+
+    @Test
+    public void test_if_without_not_exists_is_error() {
+        // IF must be followed by NOT EXISTS; otherwise it is a syntax error
+        assertThrows(Exception.class,
+                () -> SQLUtils.parseStatements("alter table t add column if foo int", DbType.mysql));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6088.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6088.java
@@ -1,0 +1,33 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle LISTAGG(...) WITHIN GROUP (...) OVER (PARTITION BY ...) must round-trip with balanced
+ * parentheses (the reported symptom was a missing right parenthesis).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6088">Issue #6088</a>
+ */
+public class Issue6088 {
+    @Test
+    public void test_listagg_within_group_over() {
+        String sql = "select listagg(nvl(a.orderid,0)*100,',') within group(order by t.time) "
+                + "over(partition by t.create_time) as ids from a";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("WITHIN GROUP (ORDER BY t.time)"), out);
+        assertTrue(out.contains("OVER (PARTITION BY t.create_time)"), out);
+        long open = out.chars().filter(c -> c == '(').count();
+        long close = out.chars().filter(c -> c == ')').count();
+        assertEquals(open, close, "parentheses must be balanced:\n" + out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6100.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6100.java
@@ -1,0 +1,27 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL ORDER BY ... DESC NULLS LAST.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6100">Issue #6100</a>
+ */
+public class Issue6100 {
+    @Test
+    public void test_order_by_nulls_last() {
+        String sql = "select * from t ORDER BY case_count DESC NULLS LAST, read_count DESC NULLS LAST LIMIT 5 OFFSET 0";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql);
+        assertTrue(out.contains("DESC NULLS LAST"), out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6133.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6133.java
@@ -1,0 +1,34 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.visitor.ParameterizedOutputVisitorUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL CURRENT_DATE - INTERVAL '1 day' must parse and parameterize without error.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6133">Issue #6133</a>
+ */
+public class Issue6133 {
+    @Test
+    public void test_current_date_minus_interval() {
+        String sql = "select TO_CHAR(CURRENT_DATE - INTERVAL '1 day', 'YYYYMMDD') from t";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).contains("CURRENT_DATE"));
+    }
+
+    @Test
+    public void test_parameterize_does_not_throw() {
+        String sql = "select TO_CHAR(CURRENT_DATE - INTERVAL '1 day', 'YYYYMMDD') from t";
+        String template = ParameterizedOutputVisitorUtils.parameterize(sql, DbType.postgresql);
+        assertTrue(template != null && template.length() > 0);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6146.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6146.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL pagination OFFSET ... ROWS FETCH FIRST ... ROWS ONLY (Hibernate 6 style) must parse
+ * (the reported symptom was an error at the FIRST token).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6146">Issue #6146</a>
+ */
+public class Issue6146 {
+    @Test
+    public void test_offset_fetch_first_rows_only() {
+        String sql = "select id from t order by id offset ? rows fetch first ? rows only";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).toUpperCase();
+        assertTrue(out.contains("FETCH FIRST ? ROWS ONLY"), out);
+    }
+}


### PR DESCRIPTION
## 概述

继续排查更早的开放 issue。本 PR 含 **1 个解析 bug 修复** + **5 个已被近期重构修复的 issue 的回归测试**（补测试以关闭）。

### 修复
- **#6067** MySQL/MariaDB `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`：`MySqlExprParser.parseColumn` 未处理 `IF NOT EXISTS` 前缀（通用 parser 有），在 IF 处报错。复用已有的 `SQLColumnDefinition.ifNotExists` 字段解析并在 MySQL 输出渲染。

### 回归测试（已修复，补测试关闭）
| Issue | 验证点 |
|---|---|
| #6032 | MySQL 反引号表名含 `check`（`\`background-check-info\``） |
| #6100 | PG `ORDER BY ... DESC NULLS LAST` |
| #6133 | PG `CURRENT_DATE - INTERVAL '1 day'` 解析 + parameterize |
| #6088 | Oracle `LISTAGG(...) WITHIN GROUP (...) OVER (...)` 括号平衡 |
| #6146 | PG `OFFSET ... FETCH FIRST ... ROWS ONLY`（Hibernate 6 分页） |

## 测试
全量 `bvt.sql.**` 2628 用例全绿，零回归。

## 关联 issue

Fixes #6067, fixes #6032, fixes #6100, fixes #6133, fixes #6088, fixes #6146

## 备注（本批暂缓，需后续单独处理）
- **#6064** PG `ALTER COLUMN ... TYPE ... USING expr` 与 `ADD "version"` 引号列名 —— 真 bug，需 PG alter 改动
- **#6072** MySQL `INTERVAL (expr) % n MONTH`（INTERVAL 值含括号+运算+函数）—— 解析较复杂、改动风险高
- **#6057 / #6082** 别名 `*`、双逗号"应报错却宽松解析" —— 需让 parser 更严格，风险较高
- **#6413** PG 反斜杠字符串语义 —— 兼容性权衡，需决策

🤖 Generated with [Claude Code](https://claude.com/claude-code)
