### PR TITLE
fix: PostgreSQL ALTER COLUMN TYPE ... USING + ADD 引号列名 (#6064)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableAlterColumn.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLAlterTableAlterColumn.java
@@ -33,14 +33,28 @@ public class SQLAlterTableAlterColumn extends SQLObjectImpl implements SQLAlterT
     private SQLName after;
     private SQLDataType dataType;
     private boolean toFirst;
+    // PostgreSQL: ALTER COLUMN col TYPE <type> USING <expr>
+    private SQLExpr using;
 
     @Override
     protected void accept0(SQLASTVisitor visitor) {
         if (visitor.visit(this)) {
             acceptChild(visitor, column);
             acceptChild(visitor, setDefault);
+            acceptChild(visitor, using);
         }
         visitor.endVisit(this);
+    }
+
+    public SQLExpr getUsing() {
+        return using;
+    }
+
+    public void setUsing(SQLExpr using) {
+        if (using != null) {
+            using.setParent(this);
+        }
+        this.using = using;
     }
 
     public SQLColumnDefinition getColumn() {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSQLStatementParser.java
@@ -995,6 +995,15 @@ public class PGSQLStatementParser extends SQLStatementParser {
                 }
             }
         }
+
+        // PostgreSQL: ALTER COLUMN col [SET DATA] TYPE <type> USING <expr>.
+        // parseColumn may already have consumed "TYPE <type>" into the column definition, so this
+        // check is outside the block above (issue #6064).
+        if (lexer.token() == Token.USING || lexer.identifierEquals("USING")) {
+            lexer.nextToken();
+            alterColumn.setUsing(this.exprParser.expr());
+        }
+
         return alterColumn;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3016,7 +3016,9 @@ public class SQLStatementParser extends SQLParser {
 
     protected void alterTableAddRest(SQLAlterTableStatement stmt) {
         acceptIdentifier("ADD");
-        if (lexer.token == Token.IDENTIFIER) {
+        // ADD [COLUMN] <name> <type> ... where the name may be a quoted identifier such as
+        // "version" (a LITERAL_ALIAS), not just a bare IDENTIFIER (issue #6064)
+        if (lexer.token == Token.IDENTIFIER || lexer.token == Token.LITERAL_ALIAS) {
             SQLAlterTableAddColumn item = parseAlterTableAddColumn();
             stmt.addItem(item);
             return;

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -6019,6 +6019,11 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             dataType.accept(this);
         }
 
+        if (x.getUsing() != null) { // postgresql: ALTER COLUMN col TYPE <type> USING <expr>
+            print0(ucase ? " USING " : " using ");
+            x.getUsing().accept(this);
+        }
+
         final SQLName after = x.getAfter();
         if (after != null) {
             print0(ucase ? " AFTER " : " after ");

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6064.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6064.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL ALTER TABLE ... ALTER COLUMN ... TYPE ... USING ..., and ADD a column named "version".
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6064">Issue #6064</a>
+ */
+public class Issue6064 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_alter_column_type_using() {
+        String out = rt("ALTER TABLE table_test ALTER COLUMN num TYPE int8 USING num::int8");
+        assertTrue(out.contains("TYPE int8"), out);
+        assertTrue(out.contains("USING num::int8"), out);
+    }
+
+    @Test
+    public void test_add_column_named_version() {
+        String out = rt("ALTER TABLE table_test ADD \"version\" int8 DEFAULT 1 NOT NULL");
+        assertTrue(out.contains("\"version\""), out);
+    }
+}


### PR DESCRIPTION
## 概述

修复 PostgreSQL `ALTER TABLE` 的两个解析 bug（issue #6064 报告）。

- **`ALTER COLUMN col TYPE <type> USING <expr>`** 在 `USING` 处报 "not supported"。`parseColumn` 会把 `TYPE <type>` 吃进列定义，故把 `USING` 子句的处理放到该判断块外、无条件进行，存到新增的 `SQLAlterTableAlterColumn.using` 字段并在输出渲染。
- **`ADD "version" int8 ...`**（引号列名 `"version"`，LITERAL_ALIAS）报 TODO，因为 `alterTableAddRest` 只接受裸 `IDENTIFIER`；扩展为同时接受 `LITERAL_ALIAS`。

## 测试
新增 `Issue6064`（两个子用例）。全量 `bvt.sql.**` 2632 用例全绿，零回归。

Fixes #6064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
