### PR TITLE
fix: PG FOR KEY SHARE / MySQL 空 hex (#5203 #5244) + 8 个已修复 issue 回归测试

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLHexExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/expr/SQLHexExpr.java
@@ -33,8 +33,13 @@ public class SQLHexExpr extends SQLExprImpl implements SQLLiteralExpr, SQLValuab
     }
 
     public void output(StringBuilder buf) {
-        buf.append("0x");
-        buf.append(this.hex);
+        if (this.hex == null || this.hex.isEmpty()) {
+            // 0x must have at least one digit; an empty hex literal is written X'' (issue #5244)
+            buf.append("X''");
+        } else {
+            buf.append("0x");
+            buf.append(this.hex);
+        }
 
         String charset = (String) getAttribute("USING");
         if (charset != null) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/ast/stmt/PGSelectQueryBlock.java
@@ -136,7 +136,7 @@ public class PGSelectQueryBlock extends SQLSelectQueryBlock implements PGSQLObje
 
     public static class ForClause extends PGSQLObjectImpl {
         public static enum Option {
-            UPDATE, SHARE
+            UPDATE, SHARE, KEY_SHARE, NO_KEY_UPDATE
         }
 
         private List<SQLExpr> of = new ArrayList<SQLExpr>(2);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -209,8 +209,19 @@ public class PGSelectParser extends SQLSelectParser {
             } else if (lexer.token() == Token.SHARE) {
                 forClause.setOption(PGSelectQueryBlock.ForClause.Option.SHARE);
                 lexer.nextToken();
+            } else if (lexer.token() == Token.KEY) {
+                // FOR KEY SHARE
+                lexer.nextToken();
+                accept(Token.SHARE);
+                forClause.setOption(PGSelectQueryBlock.ForClause.Option.KEY_SHARE);
+            } else if (lexer.identifierEquals("NO")) {
+                // FOR NO KEY UPDATE
+                lexer.nextToken();
+                accept(Token.KEY);
+                accept(Token.UPDATE);
+                forClause.setOption(PGSelectQueryBlock.ForClause.Option.NO_KEY_UPDATE);
             } else {
-                throw new ParserException("expect 'FIRST' or 'NEXT'. " + lexer.info());
+                throw new ParserException("expect UPDATE, SHARE, KEY SHARE or NO KEY UPDATE. " + lexer.info());
             }
 
             if (lexer.token() == Token.OF) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGSelectParser.java
@@ -225,6 +225,7 @@ public class PGSelectParser extends SQLSelectParser {
             }
 
             if (lexer.token() == Token.OF) {
+                lexer.nextToken();
                 for (; ; ) {
                     SQLExpr expr = this.createExprParser().expr();
                     forClause.getOf().add(expr);

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -77,6 +77,10 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
             print0(ucase ? "UPDATE" : "update");
         } else if (ForClause.Option.SHARE.equals(x.getOption())) {
             print0(ucase ? "SHARE" : "share");
+        } else if (ForClause.Option.KEY_SHARE.equals(x.getOption())) {
+            print0(ucase ? "KEY SHARE" : "key share");
+        } else if (ForClause.Option.NO_KEY_UPDATE.equals(x.getOption())) {
+            print0(ucase ? "NO KEY UPDATE" : "no key update");
         }
 
         if (x.getOf().size() > 0) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/visitor/PGOutputVisitor.java
@@ -84,10 +84,10 @@ public class PGOutputVisitor extends SQLASTOutputVisitor implements PGASTVisitor
         }
 
         if (x.getOf().size() > 0) {
-            print(' ');
+            print0(ucase ? " OF " : " of ");
             for (int i = 0; i < x.getOf().size(); ++i) {
                 if (i != 0) {
-                    println(", ");
+                    print0(", ");
                 }
                 x.getOf().get(i).accept(this);
             }

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -4429,8 +4429,14 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             return false;
         }
 
-        print0("0x");
-        print0(x.getHex());
+        String hex = x.getHex();
+        if (hex == null || hex.isEmpty()) {
+            // 0x must have at least one digit; an empty hex literal is written X'' (issue #5244)
+            print0("X''");
+        } else {
+            print0("0x");
+            print0(hex);
+        }
 
         String charset = (String) x.getAttribute("USING");
         if (charset != null) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue5235.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue5235.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.clickhouse.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ClickHouse array-predicate functions hasAll / hasAny with array literal arguments.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5235">Issue #5235</a>
+ */
+public class Issue5235 {
+    @Test
+    public void test_has_all_has_any() {
+        for (String fn : new String[]{"hasAll", "hasAny"}) {
+            String sql = "SELECT " + fn + "([1,2,3], [1,2]) FROM t";
+            List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+            assertEquals(1, stmts.size());
+            assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.clickhouse).contains(fn + "("));
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5244.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5244.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MySQL empty hex literal X'' must not be rendered as the invalid 0x (0x needs at least one digit).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5244">Issue #5244</a>
+ */
+public class Issue5244 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.mysql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_empty_hex_literal() {
+        String out = rt("INSERT INTO `t` (`id`, `v`) VALUES (NULL, X'')");
+        assertTrue(out.contains("X''"), out);
+        assertFalse(out.contains("0x)") || out.contains("0x "), "must not emit a bare 0x: " + out);
+    }
+
+    @Test
+    public void test_non_empty_hex_literal_unchanged() {
+        assertTrue(rt("INSERT INTO t (v) VALUES (X'41')").contains("0x41"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5244.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5244.java
@@ -3,6 +3,7 @@ package com.alibaba.druid.bvt.sql.mysql.issues;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLHexExpr;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,5 +34,13 @@ public class Issue5244 {
     @Test
     public void test_non_empty_hex_literal_unchanged() {
         assertTrue(rt("INSERT INTO t (v) VALUES (X'41')").contains("0x41"));
+    }
+
+    @Test
+    public void test_empty_hex_tostring_path() {
+        // SQLObjectImpl.toString() goes through SQLHexExpr.output(), not the visitor
+        assertEquals("X''", new SQLHexExpr("").toString());
+        assertEquals("X''", new SQLHexExpr((String) null).toString());
+        assertEquals("0x41", new SQLHexExpr("41").toString());
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5304.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue5304.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * GROUP_CONCAT(expr SEPARATOR '...') with a multi-byte separator.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5304">Issue #5304</a>
+ */
+public class Issue5304 {
+    @Test
+    public void test_group_concat_separator() {
+        String sql = "SELECT GROUP_CONCAT(name SEPARATOR '、') FROM t";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.mysql).contains("SEPARATOR '、'"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5203.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5203.java
@@ -38,4 +38,22 @@ public class Issue5203 {
         assertEquals("SELECT id FROM t FOR UPDATE", rt("SELECT id FROM t FOR UPDATE"));
         assertEquals("SELECT id FROM t FOR SHARE", rt("SELECT id FROM t FOR SHARE"));
     }
+
+    @Test
+    public void test_for_key_share_with_of() {
+        assertEquals("SELECT * FROM t FOR KEY SHARE OF t",
+                rt("SELECT * FROM t FOR KEY SHARE OF t"));
+    }
+
+    @Test
+    public void test_for_no_key_update_with_nowait() {
+        assertEquals("SELECT * FROM t FOR NO KEY UPDATE NOWAIT",
+                rt("SELECT * FROM t FOR NO KEY UPDATE NOWAIT"));
+    }
+
+    @Test
+    public void test_for_key_share_skip_locked() {
+        assertEquals("SELECT * FROM t FOR KEY SHARE SKIP LOCKED",
+                rt("SELECT * FROM t FOR KEY SHARE SKIP LOCKED"));
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5203.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5203.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL row-locking clauses: FOR UPDATE / FOR NO KEY UPDATE / FOR SHARE / FOR KEY SHARE.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5203">Issue #5203</a>
+ */
+public class Issue5203 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_for_key_share() {
+        assertEquals("SELECT id FROM t WHERE id = 1 FOR KEY SHARE",
+                rt("SELECT id FROM t WHERE id = 1 FOR KEY SHARE"));
+    }
+
+    @Test
+    public void test_for_no_key_update() {
+        assertEquals("SELECT id FROM t WHERE id = 1 FOR NO KEY UPDATE",
+                rt("SELECT id FROM t WHERE id = 1 FOR NO KEY UPDATE"));
+    }
+
+    @Test
+    public void test_for_update_and_share_unchanged() {
+        assertEquals("SELECT id FROM t FOR UPDATE", rt("SELECT id FROM t FOR UPDATE"));
+        assertEquals("SELECT id FROM t FOR SHARE", rt("SELECT id FROM t FOR SHARE"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5266.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5266.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL CREATE TABLE with an auto-increment column GENERATED ALWAYS AS IDENTITY.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5266">Issue #5266</a>
+ */
+public class Issue5266 {
+    @Test
+    public void test_generated_always_as_identity() {
+        String sql = "CREATE TABLE t (id integer NOT NULL GENERATED ALWAYS AS IDENTITY, name varchar(10))";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).contains("GENERATED ALWAYS AS IDENTITY"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6633.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6633.java
@@ -1,0 +1,56 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.repository.SchemaRepository;
+import com.alibaba.druid.wall.WallCheckResult;
+import com.alibaba.druid.wall.spi.PGWallProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Visiting a PostgreSQL-specific expression (EXTRACT, ::cast, ...) with a non-PG visitor used to
+ * throw ClassCastException (SQLEvalVisitorImpl / SchemaResolveVisitor cannot be cast to PGASTVisitor),
+ * e.g. during WallFilter eval or schema resolve. PGExprImpl now checks instanceof before casting.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6633">Issue #6633</a>
+ * @see <a href="https://github.com/alibaba/druid/issues/6158">Issue #6158</a>
+ * @see <a href="https://github.com/alibaba/druid/issues/5201">Issue #5201</a>
+ */
+public class Issue6633 {
+    private static final String[] SQLS = {
+            "select * from a where extract(epoch from current_date)::bigint > 1",
+            "select EXTRACT(EPOCH FROM COALESCE(a, now())) - EXTRACT(EPOCH FROM b) as s from t",
+    };
+
+    @Test
+    public void test_resolve_does_not_throw_cce() {
+        for (String sql : SQLS) {
+            SchemaRepository repo = new SchemaRepository(DbType.postgresql);
+            List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+            for (SQLStatement stmt : stmts) {
+                repo.resolve(stmt);
+            }
+        }
+    }
+
+    @Test
+    public void test_wall_eval_does_not_throw_cce() {
+        PGWallProvider provider = new PGWallProvider();
+        for (String sql : SQLS) {
+            WallCheckResult result = provider.check(sql);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    public void test_select_after_extract_cast_parses() {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(SQLS[0], DbType.postgresql);
+        assertEquals(1, stmts.size());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/spark/issues/Issue5269.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/spark/issues/Issue5269.java
@@ -1,0 +1,26 @@
+package com.alibaba.druid.bvt.sql.spark.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Spark SQL file-format table reference, e.g. FROM parquet.`oss://bucket/path`.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5269">Issue #5269</a>
+ */
+public class Issue5269 {
+    @Test
+    public void test_format_path_table_source() {
+        String sql = "select sum(show_cnt) from parquet.`oss://bucket/path` limit 1000";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.spark);
+        assertEquals(1, stmts.size());
+        assertTrue(SQLUtils.toSQLString(stmts.get(0), DbType.spark).contains("parquet.`oss://bucket/path`"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue5211.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/sqlserver/issues/Issue5211.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.bvt.sql.sqlserver.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SQL Server OUTER APPLY / CROSS APPLY.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/5211">Issue #5211</a>
+ */
+public class Issue5211 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.sqlserver);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.sqlserver).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_outer_apply() {
+        assertTrue(rt("select t1.name from tableA as t1 outer apply (select * from tableB t2 where t2.id = 1) where t1.name = ?")
+                .contains("OUTER APPLY"));
+    }
+
+    @Test
+    public void test_cross_apply() {
+        assertTrue(rt("select t1.name from tableA t1 cross apply (select * from tableB t2 where t2.id = 1) t")
+                .contains("CROSS APPLY"));
+    }
+}


### PR DESCRIPTION
## 概述

继续清理更早的解析 issue：**2 个解析 bug 修复** + **8 个已被近期重构修复的 issue 的回归测试**（其中一个 CCE 测试覆盖 3 个 issue）。

### 修复
- **#5203** PostgreSQL 行锁子句 `FOR KEY SHARE` 与 `FOR NO KEY UPDATE`（此前仅支持 `FOR UPDATE`/`FOR SHARE`，遇 KEY/NO 报错）。
- **#5244** MySQL 空 hex 字面量 `X''` 被输出成无效的 `0x`（`0x` 至少需一位）；空时输出 `X''`，非空保持 `0x<digits>`。

### 回归测试（已修复，补测试关闭）
| Issue | 验证点 |
|---|---|
| #6633 / #6158 / #5201 | 用非 PG visitor（wall eval / schema resolve）访问 PG 专用表达式不再抛 `ClassCastException` |
| #5211 | SQL Server `OUTER APPLY` / `CROSS APPLY` |
| #5235 | ClickHouse `hasAll` / `hasAny` 数组谓词 |
| #5266 | PG `GENERATED ALWAYS AS IDENTITY` 自增列 |
| #5269 | Spark `parquet.\`oss://path\`` 文件表引用 |
| #5304 | `GROUP_CONCAT(... SEPARATOR '...')` |

## 测试
全量 `bvt.sql.**` 2646 用例全绿，零回归。

## 关联 issue

Fixes #5203, fixes #5244, fixes #6633, fixes #6158, fixes #5201, fixes #5211, fixes #5235, fixes #5266, fixes #5269, fixes #5304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
