### PR TITLE
fix: 4 个更早的多方言解析 bug (#4972 #4987 #4979 #4950) + #4998 回归测试

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKCreateTableParser.java
@@ -99,6 +99,15 @@ public class CKCreateTableParser extends SQLCreateTableParser {
                 ckStmt.setTtl(this.exprParser.expr());
                 ttlSeen = true;
             } else {
+                // a repeated engine clause (e.g. two ORDER BY) would otherwise leak to the caller
+                // and produce a misleading "expect EOF" error; report it clearly instead
+                if (lexer.token() == Token.PARTITION
+                        || lexer.token() == Token.ORDER
+                        || lexer.token() == Token.PRIMARY
+                        || lexer.token() == Token.TTL
+                        || lexer.identifierEquals("SAMPLE")) {
+                    throw new ParserException("duplicate ClickHouse engine clause. " + lexer.info());
+                }
                 break;
             }
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKCreateTableParser.java
@@ -1,12 +1,11 @@
 package com.alibaba.druid.sql.dialect.clickhouse.parser;
 
-import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.SQLOrderBy;
 import com.alibaba.druid.sql.ast.SQLPartitionBy;
 import com.alibaba.druid.sql.ast.SQLPartitionByList;
 import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLPrimaryKey;
+import com.alibaba.druid.sql.ast.statement.SQLPrimaryKeyImpl;
 import com.alibaba.druid.sql.dialect.clickhouse.ast.CKCreateTableStatement;
 import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.SQLCreateTableParser;
@@ -48,6 +47,19 @@ public class CKCreateTableParser extends SQLCreateTableParser {
         return sqlPartitionBy;
     }
 
+    // ClickHouse PRIMARY KEY accepts a bare column list (PRIMARY KEY a, b) as well as PRIMARY KEY (a, b)
+    private SQLPrimaryKey parseCKPrimaryKey() {
+        accept(Token.PRIMARY);
+        accept(Token.KEY);
+        SQLPrimaryKeyImpl pk = new SQLPrimaryKeyImpl();
+        boolean paren = lexer.nextIf(Token.LPAREN);
+        this.exprParser.orderBy(pk.getColumns(), pk);
+        if (paren) {
+            accept(Token.RPAREN);
+        }
+        return pk;
+    }
+
     protected void parseCreateTableRest(SQLCreateTableStatement stmt) {
         CKCreateTableStatement ckStmt = (CKCreateTableStatement) stmt;
         if (lexer.identifierEquals(FnvHash.Constants.ENGINE)) {
@@ -60,31 +72,35 @@ public class CKCreateTableParser extends SQLCreateTableParser {
             );
         }
 
-        if (lexer.token() == Token.PARTITION) {
-            ckStmt.setPartitionBy(parsePartitionBy());
-        }
-
-        if (lexer.token() == Token.ORDER) {
-            SQLOrderBy orderBy = this.exprParser.parseOrderBy();
-            ckStmt.setOrderBy(orderBy);
-        }
-
-        if (lexer.token() == Token.PRIMARY) {
-            SQLPrimaryKey sqlPrimaryKey = this.exprParser.parsePrimaryKey();
-            ckStmt.setPrimaryKey(sqlPrimaryKey);
-        }
-
-        if (lexer.identifierEquals("SAMPLE")) {
-            lexer.nextToken();
-            accept(Token.BY);
-            SQLExpr expr = this.exprParser.expr();
-            ckStmt.setSampleBy(expr);
-        }
-
-        if (lexer.token() == Token.TTL) {
-            lexer.nextToken();
-            SQLExpr expr = this.exprParser.expr();
-            ckStmt.setTtl(expr);
+        // ClickHouse allows PARTITION BY / ORDER BY / PRIMARY KEY / SAMPLE BY / TTL in any order
+        // (e.g. PRIMARY KEY before ORDER BY); loop until no more engine clauses match (issue #4950)
+        boolean partitionSeen = false;
+        boolean orderSeen = false;
+        boolean primarySeen = false;
+        boolean sampleSeen = false;
+        boolean ttlSeen = false;
+        for (; ; ) {
+            if (lexer.token() == Token.PARTITION && !partitionSeen) {
+                ckStmt.setPartitionBy(parsePartitionBy());
+                partitionSeen = true;
+            } else if (lexer.token() == Token.ORDER && !orderSeen) {
+                ckStmt.setOrderBy(this.exprParser.parseOrderBy());
+                orderSeen = true;
+            } else if (lexer.token() == Token.PRIMARY && !primarySeen) {
+                ckStmt.setPrimaryKey(parseCKPrimaryKey());
+                primarySeen = true;
+            } else if (lexer.identifierEquals("SAMPLE") && !sampleSeen) {
+                lexer.nextToken();
+                accept(Token.BY);
+                ckStmt.setSampleBy(this.exprParser.expr());
+                sampleSeen = true;
+            } else if (lexer.token() == Token.TTL && !ttlSeen) {
+                lexer.nextToken();
+                ckStmt.setTtl(this.exprParser.expr());
+                ttlSeen = true;
+            } else {
+                break;
+            }
         }
 
         if (lexer.token() == Token.SETTINGS) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -1136,6 +1136,16 @@ public class MySqlStatementParser extends SQLStatementParser {
 
             if (lexer.token() != EOF && lexer.token() != SEMI) {
                 SQLExpr xid = exprParser.expr();
+                // xid may have up to three comma-separated parts: gtrid[, bqual[, formatID]] (#4979)
+                if (lexer.token() == Token.COMMA) {
+                    SQLListExpr list = new SQLListExpr();
+                    list.addItem(xid);
+                    while (lexer.token() == Token.COMMA) {
+                        lexer.nextToken();
+                        list.addItem(exprParser.expr());
+                    }
+                    xid = list;
+                }
                 stmt.setId(xid);
             }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -1136,11 +1136,15 @@ public class MySqlStatementParser extends SQLStatementParser {
 
             if (lexer.token() != EOF && lexer.token() != SEMI) {
                 SQLExpr xid = exprParser.expr();
-                // xid may have up to three comma-separated parts: gtrid[, bqual[, formatID]] (#4979)
+                // xid has at most three comma-separated parts: gtrid[, bqual[, formatID]] (#4979)
                 if (lexer.token() == Token.COMMA) {
                     SQLListExpr list = new SQLListExpr();
                     list.addItem(xid);
                     while (lexer.token() == Token.COMMA) {
+                        if (list.getItems().size() >= 3) {
+                            throw new ParserException(
+                                    "XA xid has at most 3 parts (gtrid, bqual, formatID). " + lexer.info());
+                        }
                         lexer.nextToken();
                         list.addItem(exprParser.expr());
                     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -5586,7 +5586,12 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
         SQLExpr id = x.getId();
         if (id != null) {
             print(' ');
-            printExpr(id);
+            if (id instanceof SQLListExpr) {
+                // multi-part xid: gtrid, bqual, formatID — comma-separated, no surrounding parens
+                printAndAccept(((SQLListExpr) id).getItems(), ", ");
+            } else {
+                printExpr(id);
+            }
         }
         return false;
     }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1993,6 +1993,11 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
         if (x.isPurgeSnapshotLog()) {
             print0(ucase ? " PURGE SNAPSHOT LOG" : " purge snapshot log");
         }
+        if (x.isDropStorage()) {
+            print0(ucase ? " DROP STORAGE" : " drop storage");
+        } else if (x.isReuseStorage()) {
+            print0(ucase ? " REUSE STORAGE" : " reuse storage");
+        }
         return false;
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -1053,6 +1053,12 @@ public class SQLStatementParser extends SQLParser {
         }
         accept(Token.VIEW);
 
+        // PostgreSQL: REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] name (CONCURRENTLY after VIEW)
+        if (lexer.identifierEquals("CONCURRENTLY")) {
+            lexer.nextToken();
+            stmt.setConcurrently(true);
+        }
+
         stmt.setName(this.exprParser.name());
 
         if (lexer.token() == WITH) {
@@ -3764,14 +3770,14 @@ public class SQLStatementParser extends SQLParser {
 
             if (lexer.token == Token.DROP) {
                 lexer.nextToken();
-                acceptIdentifier("STORAGE");
+                accept(Token.STORAGE);
                 stmt.setDropStorage(true);
                 continue;
             }
 
             if (lexer.identifierEquals("REUSE")) {
                 lexer.nextToken();
-                acceptIdentifier("STORAGE");
+                accept(Token.STORAGE);
                 stmt.setReuseStorage(true);
                 continue;
             }

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -9299,13 +9299,12 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
     @Override
     public boolean visit(SQLRefreshMaterializedViewStatement x) {
-        print0(ucase ? "REFRESH MATERIALIZED" : "refresh materialized");
+        print0(ucase ? "REFRESH MATERIALIZED VIEW " : "refresh materialized view ");
 
+        // PostgreSQL: REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] name
         if (x.isConcurrently()) {
-            print0(ucase ? " CONCURRENTLY" : " concurrently");
+            print0(ucase ? "CONCURRENTLY " : "concurrently ");
         }
-
-        print0(ucase ? " VIEW " : " view ");
 
         x.getName().accept(this);
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue4950.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/issues/Issue4950.java
@@ -1,0 +1,41 @@
+package com.alibaba.druid.bvt.sql.clickhouse.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ClickHouse CREATE TABLE engine clauses (PARTITION BY / ORDER BY / PRIMARY KEY) may appear in any
+ * order, and PRIMARY KEY accepts a bare column (no parentheses).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/4950">Issue #4950</a>
+ */
+public class Issue4950 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.clickhouse).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_primary_key_before_order_by_bare_column() {
+        String out = rt("CREATE TABLE t (api_log_id String, created_date DateTime) "
+                + "ENGINE = ReplacingMergeTree(created_date) PARTITION BY toYYYYMM(created_date) "
+                + "PRIMARY KEY api_log_id ORDER BY (api_log_id, created_date)");
+        assertTrue(out.contains("PRIMARY KEY (api_log_id)"), out);
+        assertTrue(out.contains("ORDER BY (api_log_id, created_date)"), out);
+    }
+
+    @Test
+    public void test_order_by_before_primary_key() {
+        String out = rt("CREATE TABLE t (id String) ENGINE = MergeTree() ORDER BY (id) PRIMARY KEY (id)");
+        assertTrue(out.contains("ORDER BY (id)"), out);
+        assertTrue(out.contains("PRIMARY KEY (id)"), out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue4979.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue4979.java
@@ -1,0 +1,33 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * MySQL XA transaction id with up to three comma-separated parts: gtrid[, bqual[, formatID]].
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/4979">Issue #4979</a>
+ */
+public class Issue4979 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.mysql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.mysql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_xa_start_multi_part_xid() {
+        assertEquals("XA START 0x31, 0x2d, 0x26", rt("XA START 0x31,0x2d,0x26"));
+    }
+
+    @Test
+    public void test_xa_start_single_xid_unchanged() {
+        assertEquals("XA START 0x31", rt("XA START 0x31"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue4979.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue4979.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * MySQL XA transaction id with up to three comma-separated parts: gtrid[, bqual[, formatID]].
@@ -29,5 +30,18 @@ public class Issue4979 {
     @Test
     public void test_xa_start_single_xid_unchanged() {
         assertEquals("XA START 0x31", rt("XA START 0x31"));
+    }
+
+    @Test
+    public void test_xa_other_commands_share_xid_parsing() {
+        // xid parsing is shared across all XA command types
+        assertEquals("XA END 0x31, 0x2d, 0x26", rt("XA END 0x31,0x2d,0x26"));
+        assertEquals("XA COMMIT 0x31, 0x2d, 0x26", rt("XA COMMIT 0x31,0x2d,0x26"));
+    }
+
+    @Test
+    public void test_xa_xid_more_than_three_parts_is_error() {
+        // MySQL allows at most gtrid, bqual, formatID
+        assertThrows(Exception.class, () -> rt("XA START 0x31,0x2d,0x26,0x99"));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue4972.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue4972.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Oracle TRUNCATE TABLE ... DROP STORAGE / REUSE STORAGE.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/4972">Issue #4972</a>
+ */
+public class Issue4972 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.oracle).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_drop_storage() {
+        assertEquals("TRUNCATE TABLE xxx DROP STORAGE", rt("TRUNCATE TABLE xxx DROP STORAGE"));
+    }
+
+    @Test
+    public void test_reuse_storage() {
+        assertEquals("TRUNCATE TABLE xxx REUSE STORAGE", rt("TRUNCATE TABLE xxx REUSE STORAGE"));
+    }
+
+    @Test
+    public void test_plain_truncate_unchanged() {
+        assertEquals("TRUNCATE TABLE xxx", rt("TRUNCATE TABLE xxx"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue4987.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue4987.java
@@ -1,0 +1,35 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL REFRESH MATERIALIZED VIEW [CONCURRENTLY] name [WITH [NO] DATA].
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/4987">Issue #4987</a>
+ */
+public class Issue4987 {
+    private static String rt(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        return SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    public void test_refresh_concurrently_with_data() {
+        assertEquals("REFRESH MATERIALIZED VIEW CONCURRENTLY mv WITH DATA",
+                rt("REFRESH MATERIALIZED VIEW CONCURRENTLY mv WITH DATA"));
+    }
+
+    @Test
+    public void test_refresh_with_no_data() {
+        assertEquals("REFRESH MATERIALIZED VIEW mv WITH NO DATA",
+                rt("REFRESH MATERIALIZED VIEW mv WITH NO DATA"));
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue4998.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue4998.java
@@ -1,0 +1,28 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL ALTER TABLE ... ALTER COLUMN ... TYPE ... USING ... (same family as #6064).
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/4998">Issue #4998</a>
+ */
+public class Issue4998 {
+    @Test
+    public void test_alter_column_type_using() {
+        String sql = "alter table dwd_order alter column ospl_status type BIGINT using ospl_status::BIGINT";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.postgresql);
+        assertEquals(1, stmts.size());
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql).replaceAll("\\s+", " ");
+        assertTrue(out.contains("TYPE BIGINT"), out);
+        assertTrue(out.contains("USING ospl_status::BIGINT"), out);
+    }
+}

--- a/core/src/test/resources/bvt/parser/postgresql/15.txt
+++ b/core/src/test/resources/bvt/parser/postgresql/15.txt
@@ -1,3 +1,3 @@
 refresh materialized concurrently view v1 with no data
 --------------------
-REFRESH MATERIALIZED CONCURRENTLY VIEW v1 WITH NO DATA
+REFRESH MATERIALIZED VIEW CONCURRENTLY v1 WITH NO DATA


### PR DESCRIPTION
## 概述

继续清理更早的解析 issue：**4 个解析 bug 修复** + **1 个已修复 issue 的回归测试**。

### 修复
| Issue | 问题 |
|---|---|
| #4972 | Oracle `TRUNCATE TABLE ... DROP STORAGE / REUSE STORAGE`（STORAGE 是关键字 token，`acceptIdentifier` 失败）；并补输出渲染 |
| #4987 | PG `REFRESH MATERIALIZED VIEW CONCURRENTLY name`（CONCURRENTLY 在 VIEW 之后；此前位置判断错误致视图名被吞）；同步更新 `postgresql/15.txt` golden |
| #4979 | MySQL `XA START` 多段 xid（`gtrid[, bqual[, formatID]]` 逗号连接） |
| #4950 | ClickHouse 建表 engine 子句（PARTITION BY / ORDER BY / PRIMARY KEY / SAMPLE BY / TTL）支持**任意顺序**，且 `PRIMARY KEY` 支持**裸列名**（无括号） |

### 回归测试（已修复，补测试关闭）
- #4998 PG `ALTER COLUMN ... TYPE ... USING ...`（与 #6064 一并已修复）

## 测试
全量 `bvt.sql.**` 2651 用例全绿，零回归。

Fixes #4972, fixes #4987, fixes #4979, fixes #4950, fixes #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)
