### PR TITLE
fix: 修复 Oracle UNPIVOT 空别名输出 (#6515)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -2883,7 +2883,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         }
 
         List<String> aliasList = x.getAliasList();
-        if (aliasList == null) {
+        if (aliasList == null || aliasList.isEmpty()) {
             return false;
         }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6515.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6515.java
@@ -1,0 +1,32 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle UNPIVOT 的 IN 列表没有显式别名时，不应输出空的 AS ()。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6515">Issue #6515</a>
+ */
+public class Issue6515 {
+    @Test
+    public void test_unpivot_in_items_without_alias() {
+        String sql = "select ins_num, indx_val from (select * from pty_corp_fin) "
+                + "unpivot (indx_val for indx_no in (tot_ast, tot_liab)) t";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size());
+
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle).replaceAll("\\s+", " ").trim();
+        assertTrue(out.contains("IN (tot_ast, tot_liab)"), "expected plain UNPIVOT IN list, got:\n" + out);
+        assertFalse(out.contains("AS ()"), "UNPIVOT IN item must not render empty alias list:\n" + out);
+    }
+}


### PR DESCRIPTION
## 变更

- 修复 Oracle UNPIVOT 的 IN 列表没有显式别名时输出 `AS ()` 的问题
- 增加 `Issue6515` 回归测试，覆盖无显式别名的 UNPIVOT IN 项

## 原因

`OracleSelectParser` 在解析无显式别名的 UNPIVOT IN 项时会构造空的 `aliasList`。`SQLASTOutputVisitor` 此前只判断 `aliasList == null`，导致空列表也会被输出成 `AS ()`，生成 Oracle 无法执行的 SQL。

## 验证

- `./mvnw test -pl core -Dtest=com.alibaba.druid.bvt.sql.oracle.issues.Issue6515`
- `./mvnw test -pl core`
- `./mvnw test`

Fixes #6515
