### PR TITLE
Implement equals()/hashCode() in SQLJSONValueExpr per the Object contract

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
@@ -2,18 +2,27 @@ package com.alibaba.druid.sql.ast;
 
 import com.alibaba.druid.sql.visitor.SQLASTVisitor;
 
+import java.util.Objects;
+
 public class SQLJSONValueExpr extends SQLExprImpl {
     private SQLExpr json;
     private SQLExpr path;
 
     @Override
     public boolean equals(Object o) {
-        return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SQLJSONValueExpr that = (SQLJSONValueExpr) o;
+        return Objects.equals(json, that.json) && Objects.equals(path, that.path);
     }
 
     @Override
     public int hashCode() {
-        return 0;
+        return Objects.hash(json, path);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
@@ -8,6 +8,28 @@ public class SQLJSONValueExpr extends SQLExprImpl {
     private SQLExpr json;
     private SQLExpr path;
 
+    public SQLExpr getJson() {
+        return json;
+    }
+
+    public void setJson(SQLExpr json) {
+        if (json != null) {
+            json.setParent(this);
+        }
+        this.json = json;
+    }
+
+    public SQLExpr getPath() {
+        return path;
+    }
+
+    public void setPath(SQLExpr path) {
+        if (path != null) {
+            path.setParent(this);
+        }
+        this.path = path;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLJSONValueExpr.java
@@ -44,7 +44,11 @@ public class SQLJSONValueExpr extends SQLExprImpl {
 
     @Override
     public int hashCode() {
-        return Objects.hash(json, path);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((json == null) ? 0 : json.hashCode());
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        return result;
     }
 
     @Override

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/ast/SQLJSONValueExprTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/ast/SQLJSONValueExprTest.java
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.druid.sql.ast;
+package com.alibaba.druid.bvt.sql.ast;
 
+import com.alibaba.druid.sql.ast.SQLJSONValueExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,5 +44,47 @@ public class SQLJSONValueExprTest {
         int h1 = expr.hashCode();
         int h2 = expr.hashCode();
         assertEquals(h1, h2, "hashCode must be consistent across calls");
+    }
+
+    @Test
+    public void test_equals_with_populated_fields() {
+        SQLJSONValueExpr a = new SQLJSONValueExpr();
+        a.setJson(new SQLIdentifierExpr("col1"));
+        a.setPath(new SQLCharExpr("$.key"));
+
+        SQLJSONValueExpr b = new SQLJSONValueExpr();
+        b.setJson(new SQLIdentifierExpr("col1"));
+        b.setPath(new SQLCharExpr("$.key"));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void test_not_equals_different_path() {
+        // Same json, different path: must not be equal (guards against equals ignoring path)
+        SQLJSONValueExpr a = new SQLJSONValueExpr();
+        a.setJson(new SQLIdentifierExpr("col1"));
+        a.setPath(new SQLCharExpr("$.key1"));
+
+        SQLJSONValueExpr b = new SQLJSONValueExpr();
+        b.setJson(new SQLIdentifierExpr("col1"));
+        b.setPath(new SQLCharExpr("$.key2"));
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void test_not_equals_different_json() {
+        // Same path, different json: must not be equal (guards against equals ignoring json)
+        SQLJSONValueExpr a = new SQLJSONValueExpr();
+        a.setJson(new SQLIdentifierExpr("col1"));
+        a.setPath(new SQLCharExpr("$.key"));
+
+        SQLJSONValueExpr b = new SQLJSONValueExpr();
+        b.setJson(new SQLIdentifierExpr("col2"));
+        b.setPath(new SQLCharExpr("$.key"));
+
+        assertNotEquals(a, b);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/ast/SQLJSONValueExprTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/ast/SQLJSONValueExprTest.java
@@ -87,4 +87,12 @@ public class SQLJSONValueExprTest {
 
         assertNotEquals(a, b);
     }
+
+    @Test
+    public void test_not_equals_different_class() {
+        // Per the Object.equals contract: comparison against an unrelated type must return false,
+        // not throw. Exercises the getClass() guard so removing it is caught as a regression.
+        SQLJSONValueExpr expr = new SQLJSONValueExpr();
+        assertNotEquals(expr, new SQLIdentifierExpr("col1"));
+    }
 }

--- a/core/src/test/java/com/alibaba/druid/sql/ast/SQLJSONValueExprTest.java
+++ b/core/src/test/java/com/alibaba/druid/sql/ast/SQLJSONValueExprTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.druid.sql.ast;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SQLJSONValueExprTest {
+    @Test
+    public void test_equals_reflexivity() {
+        // Per the Java Object.equals contract: x.equals(x) must be true (reflexivity)
+        SQLJSONValueExpr expr = new SQLJSONValueExpr();
+        assertTrue(expr.equals(expr), "An object must be equal to itself (reflexivity)");
+    }
+
+    @Test
+    public void test_equals_null() {
+        // Per the Java Object.equals contract: x.equals(null) must be false
+        SQLJSONValueExpr expr = new SQLJSONValueExpr();
+        assertFalse(expr.equals(null), "x.equals(null) must be false");
+    }
+
+    @Test
+    public void test_hashCode_consistency() {
+        // Per the Java Object contract: multiple calls to hashCode must return the same value
+        SQLJSONValueExpr expr = new SQLJSONValueExpr();
+        int h1 = expr.hashCode();
+        int h2 = expr.hashCode();
+        assertEquals(h1, h2, "hashCode must be consistent across calls");
+    }
+}


### PR DESCRIPTION
`SQLJSONValueExpr.equals(Object)` unconditionally returned `false`, so even `x.equals(x)` was `false` — a violation of the `Object.equals` reflexivity contract — and `hashCode()` always returned `0`.

This implements both based on the `json` and `path` fields (via `Objects.equals` / `Objects.hash`), following the same pattern the other SQL AST nodes use. Adds a regression test covering reflexivity, the null case, and `hashCode` consistency.
