### PR TITLE
Fix oceanbase_oracle DbType mask corrupted by int sign extension

### DIFF
--- a/core/src/main/java/com/alibaba/druid/DbType.java
+++ b/core/src/main/java/com/alibaba/druid/DbType.java
@@ -44,7 +44,7 @@ public enum DbType {
     antspark(1 << 30),
 
     spark(1 << 30),
-    oceanbase_oracle(1 << 31),
+    oceanbase_oracle(1L << 31),
     /**
      * Alibaba Cloud PolarDB-Oracle 1.0
      */

--- a/core/src/test/java/com/alibaba/druid/bvt/DbTypeMaskTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/DbTypeMaskTest.java
@@ -1,4 +1,4 @@
-package com.alibaba.druid.test;
+package com.alibaba.druid.bvt;
 
 import com.alibaba.druid.DbType;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/com/alibaba/druid/test/DbTypeMaskTest.java
+++ b/core/src/test/java/com/alibaba/druid/test/DbTypeMaskTest.java
@@ -1,0 +1,36 @@
+package com.alibaba.druid.test;
+
+import com.alibaba.druid.DbType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DbTypeMaskTest {
+    @Test
+    public void test_oceanbase_oracle_mask_no_sign_extension() {
+        long expectedMask = 1L << 31; // 0x0000000080000000L
+        assertEquals(expectedMask, DbType.oceanbase_oracle.mask,
+                "oceanbase_oracle mask should be a single clean bit at position 31, not sign-extended");
+    }
+
+    @Test
+    public void test_of_oceanbase_oracle_plus_polardb_no_corruption() {
+        long combined = DbType.of(DbType.oceanbase_oracle, DbType.polardb);
+        long expected = (1L << 31) | (1L << 32);
+        assertEquals(expected, combined,
+                "Combining oceanbase_oracle + polardb should not corrupt high bits due to sign extension");
+    }
+
+    @Test
+    public void test_all_masks_are_clean_single_bits() {
+        for (DbType type : DbType.values()) {
+            long mask = type.mask;
+            if (mask == 0) {
+                continue;
+            }
+            boolean isPowerOfTwo = (mask & (mask - 1)) == 0;
+            assertEquals(true, isPowerOfTwo,
+                    "DbType " + type + " mask should be a clean power of two (single bit), but was 0x" + Long.toHexString(mask));
+        }
+    }
+}


### PR DESCRIPTION
### Problem

`DbType.oceanbase_oracle` is declared as:

```java
oceanbase_oracle(1 << 31),
```

`1 << 31` is evaluated in `int`, so it is `Integer.MIN_VALUE` (`0x80000000`). When that `int` is passed to the `DbType(long mask)` constructor it is widened with sign extension to `0xFFFFFFFF80000000L`, setting all of the upper 33 bits instead of just bit 31. Every other value at bit 32 and above already uses the `1L << n` form (`polardb(1L << 32)`, `ali_oracle(1L << 33)`, ...); `oceanbase_oracle` is the only one that shifts an `int`.

### Impact

`DbType.of(...)` OR-combines masks:

```java
value |= type.mask;
```

Because `oceanbase_oracle.mask` has all high bits set, any combination that includes it corrupts the result and produces false positives for mask-based matching against db types at bit 32 and above (polardb, ali_oracle, mock, ...).

### Fix

```diff
-    oceanbase_oracle(1 << 31),
+    oceanbase_oracle(1L << 31),
```

so the mask is the intended single bit `0x0000000080000000L`.

### Test

Adds `DbTypeMaskTest` (core module) covering the raw mask value, an `of(oceanbase_oracle, polardb)` combination, and a general "every non-zero mask is a single bit" invariant. All three assertions fail before the fix and pass after.
