### PR TITLE
Decode with UTF-8 in ConfigTools.decrypt to match encrypt

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,25 @@
 						<include>**/bvt/**/*.java</include>
 					</includes>
 				</configuration>
+				<executions>
+					<!-- Run the charset round-trip test under a non-UTF-8 default charset so it
+					     actually fails if decrypt() stops decoding as UTF-8 (it passes trivially
+					     when the JVM default is already UTF-8). -->
+					<execution>
+						<id>charset-tests</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/bvt/filter/config/ConfigToolsCharsetTest.java</include>
+							</includes>
+							<argLine>-Dfile.encoding=ISO-8859-1</argLine>
+							<reportsDirectory>${project.build.directory}/surefire-reports-charset</reportsDirectory>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>

--- a/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -143,7 +143,7 @@ public class ConfigTools {
         byte[] cipherBytes = Base64.base64ToByteArray(cipherText);
         byte[] plainBytes = cipher.doFinal(cipherBytes);
 
-        return new String(plainBytes);
+        return new String(plainBytes, "UTF-8");
     }
 
     public static String encrypt(String plainText) throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsCharsetTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsCharsetTest.java
@@ -1,0 +1,19 @@
+package com.alibaba.druid.bvt.filter.config;
+
+import com.alibaba.druid.filter.config.ConfigTools;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConfigToolsCharsetTest {
+    // A password with multibyte (non-ASCII) characters. encrypt() encodes with UTF-8,
+    // so decrypt() must also decode with UTF-8, independent of the JVM default charset.
+    @Test
+    public void test_decrypt_roundtrips_multibyte_regardless_of_default_charset() throws Exception {
+        String password = "密码P@sséü";   // 密码P@sséü
+        String cipher = ConfigTools.encrypt(password);
+        String plain = ConfigTools.decrypt(cipher);
+        assertEquals(password, plain,
+                "decrypt must round-trip a UTF-8-encoded password even when the JVM default charset is not UTF-8");
+    }
+}


### PR DESCRIPTION
## What is wrong

`ConfigTools` **encrypts** passwords with **UTF-8** but **decrypts** with the **JVM default charset**. On any JVM whose default charset is not UTF-8 (Windows GBK, or a container started with `-Dfile.encoding=ISO-8859-1`), decrypting a password that contains non-ASCII characters returns garbage.

## Where (file `core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java`)

- **Line 179** (`encrypt`) encodes with UTF-8:
  ```java
  byte[] encryptedBytes = cipher.doFinal(plainText.getBytes("UTF-8"));
  ```
- **Line 146** (`decrypt`) decodes with the platform default charset (no charset argument):
  ```java
  return new String(plainBytes);      // uses Charset.defaultCharset()
  ```

The two sides disagree on charset, so the round trip is only correct when the default happens to be UTF-8.

## How it fails

Encrypt then decrypt a password with multibyte characters on a non-UTF-8 JVM:

```java
String pw = "密码P@sséü";
ConfigTools.decrypt(ConfigTools.encrypt(pw));   // does not equal pw
```

The bytes were written as UTF-8, but `decrypt` reads them back as (for example) ISO-8859-1.

## Test (`core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsCharsetTest.java`)

```java
@Test
public void test_decrypt_roundtrips_multibyte_regardless_of_default_charset() throws Exception {
    String password = "密码P@sséü";
    String cipher = ConfigTools.encrypt(password);
    String plain  = ConfigTools.decrypt(cipher);
    assertEquals(password, plain,
        "decrypt must round-trip a UTF-8-encoded password even when the JVM default charset is not UTF-8");
}
```

Run with the default charset forced to a non-UTF-8 value (the condition under which the bug appears):

```
mvn test -Dtest=ConfigToolsCharsetTest -pl core -DargLine="-Dfile.encoding=ISO-8859-1"
```

Before the fix it fails:

```
org.opentest4j.AssertionFailedError: decrypt must round-trip a UTF-8-encoded password even when the JVM
default charset is not UTF-8 ==> expected: <密码P@sséü> but was: <å¯ç P@ssÃ©Ã¼>
```

## Fix

```diff
- return new String(plainBytes);
+ return new String(plainBytes, "UTF-8");
```

Decode with UTF-8 so `decrypt` matches `encrypt`.

## Verification

`mvn test -Dtest=ConfigToolsCharsetTest -pl core -DargLine="-Dfile.encoding=ISO-8859-1"` — **red before** (expected `密码P@sséü`, got `å¯ç P@ssÃ©Ã¼`), **green after** (`Tests run: 1, Failures: 0, BUILD SUCCESS`). On a default-UTF-8 JVM the round trip already works, which is why the test forces the non-UTF-8 condition.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
