### PR TITLE
Compare filter class names case-sensitively in FilterManager.existsFilter

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/FilterManager.java
+++ b/core/src/main/java/com/alibaba/druid/filter/FilterManager.java
@@ -161,7 +161,7 @@ public class FilterManager {
     private static boolean existsFilter(List<Filter> filterList, String filterClassName) {
         for (Filter filter : filterList) {
             String itemFilterClassName = filter.getClass().getName();
-            if (itemFilterClassName.equalsIgnoreCase(filterClassName)) {
+            if (itemFilterClassName.equals(filterClassName)) {
                 return true;
             }
         }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
@@ -56,4 +56,22 @@ public class FilterManagerTest {
             throw new RuntimeException();
         }
     }
+
+    @org.junit.jupiter.api.Test
+    public void test_existsFilter_caseSensitive() throws Exception {
+        java.util.List<com.alibaba.druid.filter.Filter> filterList = new java.util.ArrayList<>();
+        filterList.add(new CaseTestFilter());
+        String exactName = CaseTestFilter.class.getName();
+        String lowerName = exactName.toLowerCase();
+        java.lang.reflect.Method existsFilter = com.alibaba.druid.filter.FilterManager.class
+                .getDeclaredMethod("existsFilter", java.util.List.class, String.class);
+        existsFilter.setAccessible(true);
+        org.junit.jupiter.api.Assertions.assertTrue((Boolean) existsFilter.invoke(null, filterList, exactName));
+        org.junit.jupiter.api.Assertions.assertFalse((Boolean) existsFilter.invoke(null, filterList, lowerName),
+                "existsFilter should be case-sensitive; class names that differ only in case are different classes");
+    }
+
+    public static class CaseTestFilter extends com.alibaba.druid.filter.FilterAdapter {
+    }
+
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java
@@ -5,8 +5,10 @@ import com.alibaba.druid.filter.FilterAdapter;
 import com.alibaba.druid.filter.FilterManager;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,21 +59,21 @@ public class FilterManagerTest {
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void test_existsFilter_caseSensitive() throws Exception {
-        java.util.List<com.alibaba.druid.filter.Filter> filterList = new java.util.ArrayList<>();
+        List<Filter> filterList = new ArrayList<Filter>();
         filterList.add(new CaseTestFilter());
         String exactName = CaseTestFilter.class.getName();
         String lowerName = exactName.toLowerCase();
-        java.lang.reflect.Method existsFilter = com.alibaba.druid.filter.FilterManager.class
-                .getDeclaredMethod("existsFilter", java.util.List.class, String.class);
+        Method existsFilter = FilterManager.class
+                .getDeclaredMethod("existsFilter", List.class, String.class);
         existsFilter.setAccessible(true);
-        org.junit.jupiter.api.Assertions.assertTrue((Boolean) existsFilter.invoke(null, filterList, exactName));
-        org.junit.jupiter.api.Assertions.assertFalse((Boolean) existsFilter.invoke(null, filterList, lowerName),
+        assertTrue((Boolean) existsFilter.invoke(null, filterList, exactName));
+        assertFalse((Boolean) existsFilter.invoke(null, filterList, lowerName),
                 "existsFilter should be case-sensitive; class names that differ only in case are different classes");
     }
 
-    public static class CaseTestFilter extends com.alibaba.druid.filter.FilterAdapter {
+    public static class CaseTestFilter extends FilterAdapter {
     }
 
 }


### PR DESCRIPTION
## What is wrong

`FilterManager.existsFilter(...)` checks whether a filter class is already registered by comparing fully-qualified class names with `equalsIgnoreCase`. Java class names are **case-sensitive** (`com.foo.MyFilter` and `com.foo.myfilter` are different classes), so two distinct filter classes whose names differ only in case are treated as the same one, and the second is silently skipped instead of being registered.

## Where (file `core/src/main/java/com/alibaba/druid/filter/FilterManager.java`)

- **Line 161** — the private dedup check:
  ```java
  private static boolean existsFilter(List<Filter> filterList, String filterClassName) {
  ```
- **Line 164** — compares class names case-insensitively:
  ```java
  if (itemFilterClassName.equalsIgnoreCase(filterClassName)) {   // class names are case-sensitive
  ```

`existsFilter` gates registration at lines 108 and 143, so a false positive here drops a real filter.

## How it fails

```java
List<Filter> filters = new ArrayList<>();
filters.add(new MyFilter());                       // com.foo.MyFilter
existsFilter(filters, "com.foo.myfilter");         // returns TRUE -> a different class is treated as present
```

## Test (`core/src/test/java/com/alibaba/druid/bvt/filter/FilterManagerTest.java`)

```java
@Test
public void test_existsFilter_caseSensitive() throws Exception {
    List<Filter> filterList = new ArrayList<>();
    filterList.add(new CaseTestFilter());
    String exactName = CaseTestFilter.class.getName();
    String lowerName = exactName.toLowerCase();
    Method existsFilter = FilterManager.class.getDeclaredMethod("existsFilter", List.class, String.class);
    existsFilter.setAccessible(true);
    assertTrue((Boolean) existsFilter.invoke(null, filterList, exactName));   // exact match
    assertFalse((Boolean) existsFilter.invoke(null, filterList, lowerName),   // different class, different name
            "existsFilter should be case-sensitive; class names that differ only in case are different classes");
}
```

Before the fix it fails:

```
org.opentest4j.AssertionFailedError: existsFilter should be case-sensitive; class names that differ
only in case are different classes ==> expected: <false> but was: <true>
```

## Fix

```diff
- if (itemFilterClassName.equalsIgnoreCase(filterClassName)) {
+ if (itemFilterClassName.equals(filterClassName)) {
```

## Verification

`mvn test -Dtest=FilterManagerTest#test_existsFilter_caseSensitive -pl core` — **red before** (`expected: <false> but was: <true>`), **green after** (`Tests run: 1, Failures: 0`).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
