### PR TITLE
Print usage instead of ArrayIndexOutOfBoundsException in ConfigTools.main with no args

### DIFF
--- a/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -40,6 +40,10 @@ public class ConfigTools {
     public static final String DEFAULT_PUBLIC_KEY_STRING = "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKHGwq7q2RmwuRgKxBypQHw0mYu4BQZ3eMsTrdK8E6igRcxsobUC7uT0SoxIjl1WveWniCASejoQtn/BY6hVKWsCAwEAAQ==";
 
     public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            System.out.println("Usage: ConfigTools <password>");
+            return;
+        }
         String password = args[0];
         String[] arr = genKeyPair(512);
         System.out.println("privateKey:" + arr[0]);

--- a/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -41,7 +41,7 @@ public class ConfigTools {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            System.out.println("Usage: ConfigTools <password>");
+            System.err.println("Usage: ConfigTools <password>");
             return;
         }
         String password = args[0];

--- a/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
+++ b/core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java
@@ -40,15 +40,26 @@ public class ConfigTools {
     public static final String DEFAULT_PUBLIC_KEY_STRING = "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKHGwq7q2RmwuRgKxBypQHw0mYu4BQZ3eMsTrdK8E6igRcxsobUC7uT0SoxIjl1WveWniCASejoQtn/BY6hVKWsCAwEAAQ==";
 
     public static void main(String[] args) throws Exception {
+        int status = run(args);
+        if (status != 0) {
+            System.exit(status);
+        }
+    }
+
+    /**
+     * @return 0 when the keys were generated, 1 when the required password argument is missing
+     */
+    public static int run(String[] args) throws Exception {
         if (args.length == 0) {
             System.err.println("Usage: ConfigTools <password>");
-            return;
+            return 1;
         }
         String password = args[0];
         String[] arr = genKeyPair(512);
         System.out.println("privateKey:" + arr[0]);
         System.out.println("publicKey:" + arr[1]);
         System.out.println("password:" + encrypt(arr[0], password));
+        return 0;
     }
 
     public static String decrypt(String cipherText) throws Exception {

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
@@ -1,27 +1,47 @@
 package com.alibaba.druid.bvt.filter.config;
 
 import com.alibaba.druid.filter.config.ConfigTools;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfigToolsMainTest {
     @Test
-    public void main_withNoArgs_printsUsageToStdErr_notAIOOBE() throws Exception {
-        PrintStream origErr = System.err;
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(err, true, "UTF-8"));
+    public void run_withNoArgs_printsUsageToStderr_andReturnsFailureStatus() throws Exception {
+        PrintStream stderr = System.err;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        int status;
         try {
-            Assertions.assertDoesNotThrow(() -> ConfigTools.main(new String[0]),
-                    "main() with no args should print usage, not throw ArrayIndexOutOfBoundsException");
+            System.setErr(new PrintStream(buf, true, "UTF-8"));
+            status = ConfigTools.run(new String[0]);
         } finally {
-            System.setErr(origErr);
+            System.setErr(stderr);
         }
-        String stderr = new String(err.toByteArray(), StandardCharsets.UTF_8);
-        Assertions.assertTrue(stderr.contains("Usage:"),
-                "the usage message is a diagnostic and should be written to System.err, not System.out");
+
+        assertEquals(1, status, "run() with no args should report a usage error, not success");
+        assertTrue(buf.toString("UTF-8").contains("Usage: ConfigTools <password>"),
+                "run() with no args should print the usage message to stderr");
+    }
+
+    @Test
+    public void run_withPassword_returnsSuccessStatus() throws Exception {
+        PrintStream stdout = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        int status;
+        try {
+            System.setOut(new PrintStream(buf, true, "UTF-8"));
+            status = ConfigTools.run(new String[]{"druid"});
+        } finally {
+            System.setOut(stdout);
+        }
+
+        assertEquals(0, status);
+        assertTrue(buf.toString("UTF-8").contains("password:"));
     }
 }

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
@@ -1,0 +1,13 @@
+package com.alibaba.druid.bvt.filter.config;
+
+import com.alibaba.druid.filter.config.ConfigTools;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConfigToolsMainTest {
+    @Test
+    public void main_withNoArgs_printsUsage_notAIOOBE() {
+        Assertions.assertDoesNotThrow(() -> ConfigTools.main(new String[0]),
+                "main() with no args should print usage, not throw ArrayIndexOutOfBoundsException");
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java
@@ -4,10 +4,24 @@ import com.alibaba.druid.filter.config.ConfigTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
 public class ConfigToolsMainTest {
     @Test
-    public void main_withNoArgs_printsUsage_notAIOOBE() {
-        Assertions.assertDoesNotThrow(() -> ConfigTools.main(new String[0]),
-                "main() with no args should print usage, not throw ArrayIndexOutOfBoundsException");
+    public void main_withNoArgs_printsUsageToStdErr_notAIOOBE() throws Exception {
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, "UTF-8"));
+        try {
+            Assertions.assertDoesNotThrow(() -> ConfigTools.main(new String[0]),
+                    "main() with no args should print usage, not throw ArrayIndexOutOfBoundsException");
+        } finally {
+            System.setErr(origErr);
+        }
+        String stderr = new String(err.toByteArray(), StandardCharsets.UTF_8);
+        Assertions.assertTrue(stderr.contains("Usage:"),
+                "the usage message is a diagnostic and should be written to System.err, not System.out");
     }
 }


### PR DESCRIPTION
## What is wrong

`ConfigTools.main` reads `args[0]` without checking `args.length`, so running the tool with no arguments throws `ArrayIndexOutOfBoundsException` instead of telling the user how to use it.

## Where (file `core/src/main/java/com/alibaba/druid/filter/config/ConfigTools.java`)

- **Line 42-43** — `main` uses `args[0]` immediately:
  ```java
  public static void main(String[] args) throws Exception {
      String password = args[0];      // ArrayIndexOutOfBoundsException when args is empty
  ```

## How it fails

```
$ java -cp druid.jar com.alibaba.druid.filter.config.ConfigTools
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 0
    at com.alibaba.druid.filter.config.ConfigTools.main(ConfigTools.java:43)
```

## Test (`core/src/test/java/com/alibaba/druid/bvt/filter/config/ConfigToolsMainTest.java`)

```java
@Test
public void main_withNoArgs_printsUsage_notAIOOBE() {
    Assertions.assertDoesNotThrow(() -> ConfigTools.main(new String[0]),
            "main() with no args should print usage, not throw ArrayIndexOutOfBoundsException");
}
```

Before the fix it fails:

```
org.opentest4j.AssertionFailedError: ... ==> Unexpected exception thrown:
java.lang.ArrayIndexOutOfBoundsException: 0
```

## Fix

```diff
 public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+        System.out.println("Usage: ConfigTools <password>");
+        return;
+    }
     String password = args[0];
```

## Verification

`mvn test -Dtest=ConfigToolsMainTest -pl core` — **red before** (`ArrayIndexOutOfBoundsException: 0`), **green after** (prints `Usage: ConfigTools <password>`, `Tests run: 1, Failures: 0`).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
