### PR TITLE
fix(odps): preserve range-clustered bucket count

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/odps/parser/OdpsCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/odps/parser/OdpsCreateTableParser.java
@@ -18,7 +18,6 @@ package com.alibaba.druid.sql.dialect.odps.parser;
 import com.alibaba.druid.sql.ast.ClusteringType;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
-import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
 import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.hive.ast.HiveInputOutputFormat;
 import com.alibaba.druid.sql.dialect.odps.ast.OdpsCreateTableStatement;
@@ -376,8 +375,7 @@ public class OdpsCreateTableParser extends SQLCreateTableParser {
                 lexer.nextToken();
 
                 if (lexer.token() == Token.LITERAL_INT) {
-                    stmt.setIntoBuckets(
-                            new SQLIntegerExpr(lexer.integerValue().intValue()));
+                    stmt.setBuckets(lexer.integerValue().intValue());
                     lexer.nextToken();
                     acceptIdentifier("BUCKETS");
                 } else {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsCreateTableTest4.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/OdpsCreateTableTest4.java
@@ -17,6 +17,7 @@ package com.alibaba.druid.bvt.sql.odps;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
 import com.alibaba.druid.util.JdbcConstants;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,20 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class OdpsCreateTableTest4 {
+    @Test
+    public void test_range_clustered_buckets() {
+        String sql = "CREATE TABLE t (id BIGINT) RANGE CLUSTERED BY (id) INTO 1024 BUCKETS;";
+        List<SQLStatement> statementList = SQLUtils.parseStatements(sql, JdbcConstants.ODPS);
+        SQLCreateTableStatement stmt = (SQLCreateTableStatement) statementList.get(0);
+
+        assertEquals(1024, stmt.getBuckets());
+        assertEquals("CREATE TABLE t (\n" +
+                "\tid BIGINT\n" +
+                ")\n" +
+                "RANGE CLUSTERED BY (id)\n" +
+                "INTO 1024 BUCKETS;", SQLUtils.toOdpsString(stmt));
+    }
+
     @Test
     public void test_select() throws Exception {
         // 1095288847322


### PR DESCRIPTION
## Summary

- preserve the bucket count for ODPS `RANGE CLUSTERED BY ... INTO n BUCKETS`
- add a BVT regression test for both the AST value and SQL round trip

## Root cause

`OdpsCreateTableParser` stored the range-clustered bucket count in `intoBuckets`, while the public `getBuckets()` API and `OdpsOutputVisitor` read `buckets`. This field mismatch made `getBuckets()` return `0` and silently removed the `INTO n BUCKETS` clause when serializing the parsed AST.

The parser now uses `setBuckets()`, matching the existing hash-clustered path and the output visitor.

## Reproduction

```sql
CREATE TABLE t (id BIGINT) RANGE CLUSTERED BY (id) INTO 1024 BUCKETS;
```

Before this change:

- `getBuckets()` returned `0`
- `SQLUtils.toOdpsString()` omitted `INTO 1024 BUCKETS`

After this change, the AST reports `1024` and the clause survives the SQL round trip.

## Testing

- `mvn -pl core "-Dtest=com.alibaba.druid.bvt.sql.odps.OdpsCreateTableTest4" test`
- `mvn -pl core "-Dtest=com/alibaba/druid/bvt/sql/odps/*" test` (225 tests)
- `mvn -pl core test` (4,357 tests, 0 failures, 0 errors, 1 skipped)
