### PR TITLE
Fix: GaussDB parser error on "ON DUPLICATE KEY UPDATE NOTHING"

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/ast/stmt/GaussDbInsertStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/ast/stmt/GaussDbInsertStatement.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class GaussDbInsertStatement extends PGInsertStatement {
     private boolean isIgnore;
     private final List<SQLExpr> duplicateKeyUpdate = new ArrayList<SQLExpr>();
+    private boolean duplicateKeyUpdateNothing;
 
     public void setIgnore(boolean ignore) {
         isIgnore = ignore;
@@ -20,5 +21,13 @@ public class GaussDbInsertStatement extends PGInsertStatement {
 
     public List<SQLExpr> getDuplicateKeyUpdate() {
         return duplicateKeyUpdate;
+    }
+
+    public boolean isDuplicateKeyUpdateNothing() {
+        return duplicateKeyUpdateNothing;
+    }
+
+    public void setDuplicateKeyUpdateNothing(boolean duplicateKeyUpdateNothing) {
+        this.duplicateKeyUpdateNothing = duplicateKeyUpdateNothing;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
@@ -158,8 +158,14 @@ public class GaussDbStatementParser extends PGSQLStatementParser {
                 accept(Token.UPDATE);
 
                 if (lexer.identifierEquals(FnvHash.Constants.NOTHING)) {
+                    int mark = lexer.mark();
                     lexer.nextToken();
-                    stmt.setDuplicateKeyUpdateNothing(true);
+                    if (lexer.token() == Token.EQ) {
+                        lexer.reset(mark);
+                    } else {
+                        stmt.setDuplicateKeyUpdateNothing(true);
+                    }
+                }
                 } else {
                     List<SQLExpr> duplicateKeyUpdate = stmt.getDuplicateKeyUpdate();
                     for (; ; ) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
@@ -157,26 +157,31 @@ public class GaussDbStatementParser extends PGSQLStatementParser {
                 accept(Token.KEY);
                 accept(Token.UPDATE);
 
-                List<SQLExpr> duplicateKeyUpdate = stmt.getDuplicateKeyUpdate();
-                for (; ; ) {
-                    SQLName name = this.exprParser.name();
-                    accept(Token.EQ);
-                    SQLExpr value;
-                    try {
-                        value = this.exprParser.expr();
-                    } catch (EOFParserException e) {
-                        throw new ParserException("EOF, " + name + "=", e);
-                    }
+                if (lexer.identifierEquals(FnvHash.Constants.NOTHING)) {
+                    lexer.nextToken();
+                    stmt.setDuplicateKeyUpdateNothing(true);
+                } else {
+                    List<SQLExpr> duplicateKeyUpdate = stmt.getDuplicateKeyUpdate();
+                    for (; ; ) {
+                        SQLName name = this.exprParser.name();
+                        accept(Token.EQ);
+                        SQLExpr value;
+                        try {
+                            value = this.exprParser.expr();
+                        } catch (EOFParserException e) {
+                            throw new ParserException("EOF, " + name + "=", e);
+                        }
 
-                    SQLBinaryOpExpr assignment = new SQLBinaryOpExpr(name, SQLBinaryOperator.Equality, value);
-                    assignment.setParent(stmt);
-                    duplicateKeyUpdate.add(assignment);
+                        SQLBinaryOpExpr assignment = new SQLBinaryOpExpr(name, SQLBinaryOperator.Equality, value);
+                        assignment.setParent(stmt);
+                        duplicateKeyUpdate.add(assignment);
 
-                    if (lexer.token() == Token.COMMA) {
-                        lexer.nextTokenIdent();
-                        continue;
+                        if (lexer.token() == Token.COMMA) {
+                            lexer.nextTokenIdent();
+                            continue;
+                        }
+                        break;
                     }
-                    break;
                 }
             }
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/parser/GaussDbStatementParser.java
@@ -14,10 +14,7 @@ import com.alibaba.druid.sql.dialect.gaussdb.ast.stmt.GaussDbInsertStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGInsertStatement;
 import com.alibaba.druid.sql.dialect.postgresql.ast.stmt.PGSelectStatement;
 import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
-import com.alibaba.druid.sql.parser.EOFParserException;
-import com.alibaba.druid.sql.parser.ParserException;
-import com.alibaba.druid.sql.parser.SQLParserFeature;
-import com.alibaba.druid.sql.parser.Token;
+import com.alibaba.druid.sql.parser.*;
 import com.alibaba.druid.util.FnvHash;
 
 import java.util.ArrayList;
@@ -158,7 +155,7 @@ public class GaussDbStatementParser extends PGSQLStatementParser {
                 accept(Token.UPDATE);
 
                 if (lexer.identifierEquals(FnvHash.Constants.NOTHING)) {
-                    int mark = lexer.mark();
+                    Lexer.SavePoint mark = lexer.markOut();
                     lexer.nextToken();
                     if (lexer.token() == Token.EQ) {
                         lexer.reset(mark);
@@ -166,7 +163,7 @@ public class GaussDbStatementParser extends PGSQLStatementParser {
                         stmt.setDuplicateKeyUpdateNothing(true);
                     }
                 }
-                } else {
+                if (!stmt.isDuplicateKeyUpdateNothing()) {
                     List<SQLExpr> duplicateKeyUpdate = stmt.getDuplicateKeyUpdate();
                     for (; ; ) {
                         SQLName name = this.exprParser.name();

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/visitor/GaussDbOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/gaussdb/visitor/GaussDbOutputVisitor.java
@@ -391,6 +391,9 @@ public class GaussDbOutputVisitor extends PGOutputVisitor implements GaussDbASTV
                 }
                 duplicateKeyUpdate.get(i).accept(this);
             }
+        } else if (x.isDuplicateKeyUpdateNothing()) {
+            println();
+            print0(ucase ? "ON DUPLICATE KEY UPDATE NOTHING" : "on duplicate key update nothing");
         }
 
         printOnConflict(x);

--- a/core/src/test/resources/bvt/parser/gaussdb/1.txt
+++ b/core/src/test/resources/bvt/parser/gaussdb/1.txt
@@ -34,6 +34,18 @@ FROM vdpadmin.ads_longlati_pois_d
 WHERE report_date > '${dt}'
 ON CONFLICT (id) DO NOTHING;
 ------------------------------------------------------------------------------------------------------------------------
+INSERT INTO db1.testOnConflict
+SELECT longitude, latitude
+FROM vdpadmin.ads_longlati_pois_d
+WHERE report_date > '${dt}'
+ON DUPLICATE KEY UPDATE NOTHING;
+--------------------
+INSERT INTO db1.testOnConflict
+SELECT longitude, latitude
+FROM vdpadmin.ads_longlati_pois_d
+WHERE report_date > '${dt}'
+ON DUPLICATE KEY UPDATE NOTHING;
+------------------------------------------------------------------------------------------------------------------------
 INSERT INTO db1.testOnDuplicate
 SELECT 
 longitude,

--- a/core/src/test/resources/bvt/parser/gaussdb/1.txt
+++ b/core/src/test/resources/bvt/parser/gaussdb/1.txt
@@ -46,6 +46,18 @@ FROM vdpadmin.ads_longlati_pois_d
 WHERE report_date > '${dt}'
 ON DUPLICATE KEY UPDATE NOTHING;
 ------------------------------------------------------------------------------------------------------------------------
+INSERT INTO db1.testOnConflict
+SELECT longitude, latitude
+FROM vdpadmin.ads_longlati_pois_d
+WHERE report_date > '${dt}'
+ON DUPLICATE KEY UPDATE NOTHING = '1';
+--------------------
+INSERT INTO db1.testOnConflict
+SELECT longitude, latitude
+FROM vdpadmin.ads_longlati_pois_d
+WHERE report_date > '${dt}'
+ON DUPLICATE KEY UPDATE NOTHING = '1';
+------------------------------------------------------------------------------------------------------------------------
 INSERT INTO db1.testOnDuplicate
 SELECT 
 longitude,


### PR DESCRIPTION
Adds support for the `ON DUPLICATE KEY UPDATE NOTHING` clause in GaussDB SQL parsing.