### PR TITLE
fix: PostgreSQL GROUP BY ROLLUP(a), b 解析报错 (#6662)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/odps/parser/OdpsLexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/odps/parser/OdpsLexer.java
@@ -46,7 +46,6 @@ public class OdpsLexer extends HiveLexer {
                     JoinAt,
                     UserDefinedJoin,
                     TwoConsecutiveUnion,
-                    RewriteGroupByCubeRollupToFunction,
                     PrimaryTwoConsecutiveSet,
                     ParseAllIdentifier,
                     PrimaryRestCommaAfterLparen,

--- a/core/src/main/java/com/alibaba/druid/sql/parser/DialectFeature.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/DialectFeature.java
@@ -161,7 +161,6 @@ public class DialectFeature {
         TwoConsecutiveUnion(1L << 11),
         QueryTable(1L << 12),
         GroupByAll(1L << 13),
-        RewriteGroupByCubeRollupToFunction(1L << 14),
         GroupByPostDesc(1L << 15),
         GroupByItemOrder(1L << 16),
         SQLDateExpr(1L << 17),

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -968,18 +968,12 @@ public class SQLSelectParser extends SQLParser {
                 accept(Token.RPAREN);
                 groupBy.setParen(true);
 
-                if (lexer.token == Token.COMMA && dialectFeatureEnabled(RewriteGroupByCubeRollupToFunction)) {
+                // 支持 GROUP BY ROLLUP(a), b / CUBE(a), b 这类分组函数后跟更多分组项的形式。
+                // ODPS 通过 RewriteGroupByCubeRollupToFunction 特性开启；标准 SQL（如 PostgreSQL）默认支持。
+                // 两种情形共用 rewriteCubeRollupToFunction 完成一致的函数式重写，避免重复逻辑漂移。
+                if (lexer.token == Token.COMMA) {
                     lexer.nextToken();
-                    SQLMethodInvokeExpr func = new SQLMethodInvokeExpr(groupBy.isWithCube() ? "CUBE" : "ROLLUP");
-                    func.getArguments().addAll(groupBy.getItems());
-                    groupBy.getItems().clear();
-                    groupBy.setWithCube(false);
-                    groupBy.setWithRollUp(false);
-                    for (SQLExpr arg : func.getArguments()) {
-                        arg.setParent(func);
-                    }
-                    groupBy.addItem(func);
-                    this.exprParser.exprList(groupBy.getItems(), groupBy);
+                    rewriteCubeRollupToFunction(groupBy);
                 }
             }
 
@@ -1045,6 +1039,28 @@ public class SQLSelectParser extends SQLParser {
 
             queryBlock.setGroupBy(groupBy);
         }
+    }
+
+    /**
+     * 将已解析的 ROLLUP/CUBE 分组项重写为函数式分组项（SQLMethodInvokeExpr），
+     * 并继续解析其后逗号分隔的更多分组项。
+     * 例如 GROUP BY ROLLUP(a), b 中，ROLLUP(a) 先以 withRollUp 标志解析，
+     * 此处将其重组为 ROLLUP(a) 函数调用，再续解析 ", b"。
+     */
+    private void rewriteCubeRollupToFunction(SQLSelectGroupByClause groupBy) {
+        SQLMethodInvokeExpr func = new SQLMethodInvokeExpr(groupBy.isWithCube() ? "CUBE" : "ROLLUP");
+        func.getArguments().addAll(groupBy.getItems());
+        for (SQLExpr arg : func.getArguments()) {
+            arg.setParent(func);
+        }
+        groupBy.getItems().clear();
+        groupBy.setWithCube(false);
+        groupBy.setWithRollUp(false);
+        // withRollUp/withCube 已清零，paren 标志不再有意义，统一置 false 以保证
+        // 不同方言解析同一 SQL 得到结构一致的 AST（equals/hashCode 不分叉）。
+        groupBy.setParen(false);
+        groupBy.addItem(func);
+        this.exprParser.exprList(groupBy.getItems(), groupBy);
     }
 
     protected void parseOrderByWith(SQLSelectGroupByClause groupBy, SQLSelectQueryBlock queryBlock) {

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLSelectParser.java
@@ -968,9 +968,9 @@ public class SQLSelectParser extends SQLParser {
                 accept(Token.RPAREN);
                 groupBy.setParen(true);
 
-                // 支持 GROUP BY ROLLUP(a), b / CUBE(a), b 这类分组函数后跟更多分组项的形式。
-                // ODPS 通过 RewriteGroupByCubeRollupToFunction 特性开启；标准 SQL（如 PostgreSQL）默认支持。
-                // 两种情形共用 rewriteCubeRollupToFunction 完成一致的函数式重写，避免重复逻辑漂移。
+                // 支持 GROUP BY ROLLUP(a), b / CUBE(a), b 这类分组函数后跟更多分组项的形式：
+                // wrap 形式（withRollUp/withCube + paren）无法承载 ROLLUP/CUBE 之外的额外分组项，
+                // 故统一重写为函数式分组项（SQLMethodInvokeExpr），所有方言一致处理。
                 if (lexer.token == Token.COMMA) {
                     lexer.nextToken();
                     rewriteCubeRollupToFunction(groupBy);

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/odps/issues/Issue6662.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/odps/issues/Issue6662.java
@@ -1,0 +1,85 @@
+package com.alibaba.druid.bvt.sql.odps.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ODPS 侧 {@code GROUP BY ROLLUP(...)} / {@code CUBE(...)} 后跟更多分组项的回归测试。
+ *
+ * <p>该能力原由 ODPS 专属特性 {@code RewriteGroupByCubeRollupToFunction} 开启，现已上移到基础
+ * {@code SQLSelectParser#parseGroupBy} 对所有方言统一处理（见 issue #6662）。本测试锁定 ODPS 在
+ * 尾随逗号场景下的函数式重写结果（withRollUp/withCube/paren 清零），防止该归一化回退。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6662">issue #6662</a>
+ */
+public class Issue6662 {
+    private static SQLSelectGroupByClause groupByOf(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.odps);
+        assertEquals(1, stmts.size());
+        return ((SQLSelectQueryBlock) ((SQLSelectStatement) stmts.get(0)).getSelect().getQuery()).getGroupBy();
+    }
+
+    @Test
+    public void odps_rollup_followed_by_column_rewritten_to_function_form() {
+        SQLSelectGroupByClause groupBy = groupByOf("SELECT count(*) FROM t GROUP BY ROLLUP(a), b");
+
+        assertEquals(2, groupBy.getItems().size());
+        SQLMethodInvokeExpr rollup = assertInstanceOf(SQLMethodInvokeExpr.class, groupBy.getItems().get(0));
+        assertEquals("ROLLUP", rollup.getMethodName());
+
+        // 重写为函数式分组项后，withRollUp/withCube/paren 必须清零，保证与标准 SQL 方言 AST 一致
+        assertFalse(groupBy.isWithRollUp(), "withRollUp 应清零");
+        assertFalse(groupBy.isParen(), "paren 应清零");
+    }
+
+    @Test
+    public void odps_rollup_followed_by_column_round_trips() {
+        String sql = "SELECT count(*) FROM t GROUP BY ROLLUP(a), b";
+        String out = SQLUtils.toSQLString(SQLUtils.parseStatements(sql, DbType.odps).get(0), DbType.odps);
+        assertTrue(out.contains("ROLLUP"), () -> "输出应保留 ROLLUP: " + out);
+        assertTrue(out.contains("b"), () -> "输出应保留尾部列 b: " + out);
+    }
+
+    @Test
+    public void odps_cube_followed_by_column_rewritten_to_function_form() {
+        SQLSelectGroupByClause groupBy = groupByOf("SELECT count(*) FROM t GROUP BY CUBE(a), b");
+
+        assertEquals(2, groupBy.getItems().size());
+        SQLMethodInvokeExpr cube = assertInstanceOf(SQLMethodInvokeExpr.class, groupBy.getItems().get(0));
+        assertEquals("CUBE", cube.getMethodName());
+        assertFalse(groupBy.isWithCube(), "withCube 应清零");
+        assertFalse(groupBy.isParen(), "paren 应清零");
+    }
+
+    @Test
+    public void odps_multiple_grouping_functions_mixed() {
+        SQLSelectGroupByClause groupBy = groupByOf("SELECT count(*) FROM t GROUP BY ROLLUP(a), CUBE(b), c");
+
+        assertEquals(3, groupBy.getItems().size());
+        assertEquals("ROLLUP", ((SQLMethodInvokeExpr) groupBy.getItems().get(0)).getMethodName());
+        assertEquals("CUBE", ((SQLMethodInvokeExpr) groupBy.getItems().get(1)).getMethodName());
+    }
+
+    @Test
+    public void odps_plain_rollup_without_trailing_items_keeps_wrap_form() {
+        // GROUP BY ROLLUP(a, b)（无后续分组项）保持 wrap 形式，行为不变
+        SQLSelectGroupByClause groupBy = groupByOf("SELECT count(*) FROM t GROUP BY ROLLUP(a, b)");
+
+        assertEquals(2, groupBy.getItems().size());
+        assertTrue(groupBy.isWithRollUp(), "无尾随项时保持 withRollUp");
+        assertTrue(groupBy.isParen(), "无尾随项时保持 paren");
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6662.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6662.java
@@ -1,0 +1,128 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL {@code GROUP BY ROLLUP(...)} 后跟更多分组项（如 {@code GROUP BY ROLLUP(a), b}）的解析测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6662">issue #6662</a>
+ */
+public class Issue6662 {
+    private static List<SQLStatement> parsePg(String sql) {
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        return parser.parseStatementList();
+    }
+
+    @Test
+    public void rollup_followed_by_column_parses() {
+        String sql = "SELECT count(*) FROM t GROUP BY ROLLUP(x), y";
+        List<SQLStatement> stmts = parsePg(sql);
+        assertEquals(1, stmts.size());
+
+        SQLSelectGroupByClause groupBy = groupByOf(stmts.get(0));
+        assertEquals(2, groupBy.getItems().size());
+
+        SQLMethodInvokeExpr rollup = assertInstanceOf(SQLMethodInvokeExpr.class, groupBy.getItems().get(0));
+        assertEquals("ROLLUP", rollup.getMethodName());
+        assertEquals(1, rollup.getArguments().size());
+
+        // ROLLUP 建模为函数式分组项，withRollUp/paren 为 false
+        assertTrue(!groupBy.isWithRollUp() && !groupBy.isParen(),
+                "ROLLUP 应建模为函数式分组项");
+
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql);
+        assertTrue(out.contains("ROLLUP"), () -> "输出应保留 ROLLUP: " + out);
+        assertTrue(out.contains("y"), () -> "输出应保留尾部列 y: " + out);
+    }
+
+    @Test
+    public void issue_minimal_repro_parses() {
+        String sql = "SELECT dis_dept_code, COUNT(*)\n"
+                + "FROM dwd_inp_fact_discharge_reg\n"
+                + "GROUP BY rollup(dis_dept_code), dis_date";
+        List<SQLStatement> stmts = parsePg(sql);
+        assertEquals(1, stmts.size());
+
+        SQLSelectGroupByClause groupBy = groupByOf(stmts.get(0));
+        assertEquals(2, groupBy.getItems().size());
+        assertEquals("ROLLUP",
+                ((SQLMethodInvokeExpr) groupBy.getItems().get(0)).getMethodName());
+    }
+
+    @Test
+    public void plain_rollup_without_trailing_items_unchanged() {
+        // GROUP BY ROLLUP(a, b)（无后续分组项）解析为 withRollUp/paren 包装形式，含 a、b 两项
+        String sql = "SELECT count(*) FROM t GROUP BY ROLLUP(a, b)";
+        List<SQLStatement> stmts = parsePg(sql);
+        assertEquals(1, stmts.size());
+        SQLSelectGroupByClause groupBy = groupByOf(stmts.get(0));
+        assertEquals(2, groupBy.getItems().size());
+        assertTrue(groupBy.isWithRollUp(), "withRollUp 为 true");
+        assertTrue(groupBy.isParen(), "paren 为 true");
+    }
+
+    @Test
+    public void multiple_grouping_functions_mixed() {
+        String sql = "SELECT count(*) FROM t GROUP BY ROLLUP(a), CUBE(b), c";
+        List<SQLStatement> stmts = parsePg(sql);
+        SQLSelectGroupByClause groupBy = groupByOf(stmts.get(0));
+        assertEquals(3, groupBy.getItems().size());
+        assertEquals("ROLLUP", ((SQLMethodInvokeExpr) groupBy.getItems().get(0)).getMethodName());
+        assertEquals("CUBE", ((SQLMethodInvokeExpr) groupBy.getItems().get(1)).getMethodName());
+    }
+
+    @Test
+    public void cube_followed_by_column_parses() {
+        // CUBE 作为首个分组函数后跟逗号：覆盖 isWithCube() ? "CUBE" : "ROLLUP" 的 CUBE 分支
+        String sql = "SELECT count(*) FROM t GROUP BY CUBE(a), b";
+        List<SQLStatement> stmts = parsePg(sql);
+        assertEquals(1, stmts.size());
+
+        SQLSelectGroupByClause groupBy = groupByOf(stmts.get(0));
+        assertEquals(2, groupBy.getItems().size());
+
+        SQLMethodInvokeExpr cube = assertInstanceOf(SQLMethodInvokeExpr.class, groupBy.getItems().get(0));
+        assertEquals("CUBE", cube.getMethodName());
+        assertEquals(1, cube.getArguments().size());
+
+        // CUBE 建模为函数式分组项后，withCube/paren 应清零，与 ROLLUP 路径保持一致
+        assertTrue(!groupBy.isWithCube() && !groupBy.isParen(),
+                "CUBE 应建模为函数式分组项");
+
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.postgresql);
+        assertTrue(out.contains("CUBE"), () -> "输出应保留 CUBE: " + out);
+        assertTrue(out.contains("b"), () -> "输出应保留尾部列 b: " + out);
+    }
+
+    @Test
+    public void missing_comma_between_items_still_rejected() {
+        // 分组项之间缺少逗号的畸形 SQL 应报 ParserException
+        String sql = "SELECT count(*) FROM t GROUP BY ROLLUP(a) b";
+        assertThrows(ParserException.class, () -> parsePg(sql));
+    }
+
+    private static SQLSelectGroupByClause groupByOf(SQLStatement stmt) {
+        SQLSelectQueryBlock queryBlock = (SQLSelectQueryBlock)
+                ((SQLSelectStatement) stmt).getSelect().getQuery();
+        SQLSelectGroupByClause groupBy = queryBlock.getGroupBy();
+        assertTrue(groupBy != null, "应存在 GROUP BY 子句");
+        return groupBy;
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
PostgreSQL（及其他标准 SQL 方言）无法解析 `GROUP BY ROLLUP(a), b` 这类"分组函数后跟更多分组项"的语法，抛出：

```
com.alibaba.druid.sql.parser.ParserException: not supported. pos ..., token ,
```

issue：#6662

### 根因（Root cause）
`SQLSelectParser#parseGroupBy` 把 `ROLLUP`/`CUBE` 当作"包装"形式消费（设 `withRollUp`/`paren` 并吃掉 `ROLLUP(`）。`accept(RPAREN)` 之后，只有 ODPS 方言（启用了 `RewriteGroupByCubeRollupToFunction`）会消费尾部的 `, b`；其余方言（如 PostgreSQL）不会，导致剩余 `, b` 无人消费，上游解析器遇到 `,` 即报错。

### 修复（Fix）
当 `ROLLUP(...)`/`CUBE(...)` 包装形式之后还有逗号时：把已收集的项重组为函数式分组项（`SQLMethodInvokeExpr("ROLLUP"/"CUBE")`），重置 `withRollUp`/`withCube`/`paren`，然后继续解析剩余逗号分隔的分组项。

- `GROUP BY ROLLUP(a), b` → 分组项 `[ROLLUP(a), b]`，输出可正确 round-trip。
- `GROUP BY ROLLUP(a), CUBE(b), c` → `[ROLLUP(a), CUBE(b), c]`。
- `GROUP BY ROLLUP(a, b)`（无后续项）→ 行为不变，仍是 `withRollUp`/`paren` 包装形式。

按 review 建议（5822971c）提取共享 helper 后进一步收敛：删除了原先仅 ODPS 生效的 `ParserFeature.RewriteGroupByCubeRollupToFunction` 门控分支，重写逻辑统一到单一 `rewriteCubeRollupToFunction` 私有方法，所有方言共用，消除了两份近似副本的漂移风险。

**兼容性说明（f402d4c）**：随门控一起删除了 `DialectFeature.ParserFeature.RewriteGroupByCubeRollupToFunction` 枚举常量（及 `OdpsLexer` 中的注册）。这是对外 source/binary 不兼容的 API 删除：外部代码若直接引用该常量将编译失败。该 flag 在本 PR 后已无任何行为语义（重写对所有方言无条件生效），保留只会误导。若倾向保留兼容，可改为 `@Deprecated` 空实现，我可以在 follow-up 恢复。

### 测试（Testing）
新增两个 `Issue6662` 回归测试类，共 11 个用例：

- PG（6 个）：尾随列、issue 原始 SQL、`GROUP BY CUBE(a), b`（CUBE 初始包装形式，review 建议补）、无尾随项（保持包装形式）、混合分组函数、畸形 SQL 仍报错。
- ODPS（5 个，f402d4c 补）：门控删除后 ODPS 行为不回归，含 `paren` 重置断言。

本地验证：
- `./mvnw -pl core test -Dtest=Issue6662` → 11/11 通过，0 checkstyle 违规。
- 跨方言 GROUP BY 回归（186 个用例，覆盖 `PG*`、`MySqlSelectTest_116_with_cube`、`GroupingSetsTest`、`OdpsGroupingSetsCommaTest`、`OdpsSelectTest17/22/24/25/26`、`OracleGroupingSet(s)Test`、`OracleSelectGroupingTest`、`SnowflakeParserTest`、`HiveSelectTest_41/47`、`DB2SelectTest_26` 等）全绿。
- 其中 `PGAlterTest`、`PGUpsertTest`、`PG_500_connection_Test` 三个失败在干净 master 上同样失败（分别涉及 ALTER OWNER 解析、UPSERT 输出、需真实 PG 连接），与本次改动无关。

### 复现（Reproduce）
```java
List<SQLStatement> stmts = SQLUtils.parseStatements(
    "SELECT count(*) FROM t GROUP BY ROLLUP(a), b", DbType.postgresql);
// 修复前：ParserException: not supported token ,
// 修复后：正常解析，groupBy 含 ROLLUP(a) 与 b 两项
```

Fixes #6662
