### PR TITLE
fix: Oracle AT LOCAL 小写渲染误输出 alter session set (#6533)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1095,7 +1095,7 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
 
         if (timeZone instanceof SQLIdentifierExpr) {
             if (((SQLIdentifierExpr) timeZone).getName().equalsIgnoreCase("LOCAL")) {
-                print0(ucase ? " AT LOCAL" : "alter session set ");
+                print0(ucase ? " AT LOCAL" : " at local");
                 return false;
             }
         }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/visitor/OracleOutputVisitor.java
@@ -1089,24 +1089,6 @@ public class OracleOutputVisitor extends SQLASTOutputVisitor implements OracleAS
     }
 
     @Override
-    public boolean visit(OracleDatetimeExpr x) {
-        x.getExpr().accept(this);
-        SQLExpr timeZone = x.getTimeZone();
-
-        if (timeZone instanceof SQLIdentifierExpr) {
-            if (((SQLIdentifierExpr) timeZone).getName().equalsIgnoreCase("LOCAL")) {
-                print0(ucase ? " AT LOCAL" : "alter session set ");
-                return false;
-            }
-        }
-
-        print0(ucase ? " AT TIME ZONE " : " at time zone ");
-        timeZone.accept(this);
-
-        return false;
-    }
-
-    @Override
     public boolean visit(OracleSysdateExpr x) {
         print0(ucase ? "SYSDATE" : "sysdate");
         if (x.getOption() != null) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6533.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6533.java
@@ -1,0 +1,47 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleDatetimeExpr;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleOutputVisitor;
+import com.alibaba.druid.sql.visitor.VisitorFeature;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle {@code AT LOCAL}（{@link OracleDatetimeExpr}）在小写渲染（ucase=false）下的输出测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6533">issue #6533</a>
+ */
+public class Issue6533 {
+    private static OracleDatetimeExpr atLocal() {
+        // 直接构造 AT LOCAL 节点，聚焦输出 visitor 的渲染行为
+        SQLExpr base = new SQLIdentifierExpr("d");
+        return new OracleDatetimeExpr(base, new SQLIdentifierExpr("LOCAL"));
+    }
+
+    @Test
+    public void atLocal_lowercaseRender() {
+        StringBuilder sb = new StringBuilder();
+        OracleOutputVisitor visitor = new OracleOutputVisitor(sb);
+        visitor.config(VisitorFeature.OutputUCase, false);
+        atLocal().accept(visitor);
+
+        String out = sb.toString();
+        assertTrue(out.contains(" at local"), () -> "小写渲染应输出 ' at local'，实际: " + out);
+        assertFalse(out.contains("alter session set"), () -> "小写渲染被错误串污染: " + out);
+    }
+
+    @Test
+    public void atLocal_uppercaseRender() {
+        StringBuilder sb = new StringBuilder();
+        OracleOutputVisitor visitor = new OracleOutputVisitor(sb);
+        visitor.config(VisitorFeature.OutputUCase, true);
+        atLocal().accept(visitor);
+
+        String out = sb.toString();
+        assertTrue(out.contains(" AT LOCAL"), () -> "大写渲染应输出 ' AT LOCAL'，实际: " + out);
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6533.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6533.java
@@ -1,0 +1,53 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trip test for Oracle {@code AT LOCAL} rendering.
+ *
+ * <p>Regression for issue #6533: lowercase rendering ({@code ucase=false}) of {@code AT LOCAL}
+ * emitted {@code "alter session set "} (a stray copy from {@code visit(OracleAlterSessionStatement)})
+ * instead of {@code " at local"}, corrupting the generated SQL.
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6533">issue #6533</a>
+ */
+public class Issue6533 {
+    private static List<SQLStatement> parse(String sql) {
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.oracle);
+        assertEquals(1, stmts.size(), () -> "expected exactly one statement for: " + sql);
+        return stmts;
+    }
+
+    // The parentheses are required: a bare "d AT LOCAL" as a select item hits an unrelated
+    // select-item parser quirk; "(d AT LOCAL)" parses cleanly into an OracleDatetimeExpr.
+    private static final String SQL = "SELECT (d AT LOCAL) FROM DUAL";
+
+    @Test
+    public void atLocal_lowercaseRender() {
+        // Exercises the full parse -> AST -> output path, not a hand-built node.
+        List<SQLStatement> stmts = parse(SQL);
+        String out = SQLUtils.toSQLString(stmts, DbType.oracle, new SQLUtils.FormatOption(false));
+
+        // " at local" can only be emitted by visit(OracleDatetimeExpr), so its presence
+        // proves the parser produced an OracleDatetimeExpr and the lowercase branch is correct.
+        assertTrue(out.contains(" at local"), () -> "lowercase render should contain ' at local', got: " + out);
+        assertFalse(out.contains("alter session set"), () -> "lowercase render polluted by 'alter session set': " + out);
+    }
+
+    @Test
+    public void atLocal_uppercaseRender() {
+        List<SQLStatement> stmts = parse(SQL);
+        String out = SQLUtils.toSQLString(stmts, DbType.oracle);
+
+        assertTrue(out.contains(" AT LOCAL"), () -> "uppercase render should contain ' AT LOCAL', got: " + out);
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
`OracleOutputVisitor` 在小写渲染（`ucase=false`）下输出 `AT LOCAL` 时，错误地输出 `alter session set `，导致生成的 SQL 损坏（例如 `"dalter session set "`）。

issue：#6533

### 根因（Root cause）
`OracleOutputVisitor#visit(OracleDatetimeExpr)` 是一份与父类 `SQLASTOutputVisitor#visit(OracleDatetimeExpr)` **逐字重复**的 override（仅小写分支不同）。其小写输出 `"alter session set "` 是从紧邻的 `visit(OracleAlterSessionStatement)` 复制粘贴而来。

关键点：提交 [`c6c4d1dbe`](https://github.com/alibaba/druid/commit/c6c4d1dbe)（*fix lowercase phrases in SQLASTOutputVisitor*）**已经把父类这行从 `"alter session set "` 修成了 `" at local"`**，但这次修复对 Oracle 输出**根本没生效**——因为本 override 遮蔽（shadow）了父类，实际渲染走的是 override 这份。这正是 #6533 至今仍存在的真正原因。

### 修复（Fix）
**删除这份冗余的 override**，让（早已正确的）父类 `SQLASTOutputVisitor#visit(OracleDatetimeExpr)` 直接接管 `OracleDatetimeExpr` 的渲染：

- bug 修复：小写分支走父类的 `" at local"`；
- 根除“override 与父类重复 -> 父类修复被遮蔽 -> override 漂移”这一结构性隐患（本次 bug 正是因此躲过了 `c6c4d1dbe` 的一次修复）。

`AT TIME ZONE` 分支同理由父类处理，行为不变。

### 测试（Testing）
新增 `Issue6533` 回归测试（round-trip：`parseStatements -> toSQLString`，覆盖小写/大写两种渲染）：

- 小写：`SELECT (d AT LOCAL) FROM DUAL` -> 输出含 ` at local`、不含 `alter session set`；
- 大写：输出含 ` AT LOCAL`。

本地验证：

- `./mvnw -pl core test -Dtest=Issue6533` -> 2/2 通过；
- 临时塞回 buggy override -> 小写用例失败（输出 `select dalter session set from DUAL`），证明测试有效；
- Oracle 输出回归：`EqualTest_OracleTimestampExpr`、`OracleASTVisitorAdapterTest`、`OracleOutputVisitorTest_*` 及全 Oracle 测试包（155 个）全部通过；
- checkstyle（`druid-checks.xml`）：0 violations。

> 说明：测试 SQL 用 `(d AT LOCAL)` 带括号，是因为裸 `d AT LOCAL` 作为 select item 会撞上一个无关的 select-item 解析限制；`(d AT LOCAL)` 能干净解析为 `OracleDatetimeExpr`。

Fixes #6533
