### PR TITLE
fix: PostgreSQL CREATE TEMPORARY/TEMP TABLE 解析报错 (#6669)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGCreateTableParser.java
@@ -30,6 +30,18 @@ public class PGCreateTableParser extends SQLCreateTableParser {
         super(exprParser);
     }
 
+    @Override
+    protected void createTableBefore(SQLCreateTableStatement createTable) {
+        super.createTableBefore(createTable);
+        // PostgreSQL 允许省略 GLOBAL/LOCAL 前缀：CREATE TEMPORARY/TEMP TABLE ...
+        // 该形式在标准 SQL 之外，仅限 PostgreSQL（及 PG 系方言）；置于 PG 解析器而非基类，
+        // 以免 Oracle 等要求 GLOBAL TEMPORARY 的方言误接受裸 TEMP 形式。
+        if (lexer.nextIfIdentifier("TEMPORARY") || lexer.nextIfIdentifier("TEMP")
+                || lexer.nextIf(Token.TEMPORARY) || lexer.nextIf(Token.TEMP)) {
+            createTable.config(SQLCreateTableStatement.Feature.Temporary);
+        }
+    }
+
     protected void parseCreateTableRest(SQLCreateTableStatement stmt) {
         // For partition of/by for PG
         for (int i = 0; i < 2; i++) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/postgresql/parser/PGCreateTableParser.java
@@ -30,6 +30,18 @@ public class PGCreateTableParser extends SQLCreateTableParser {
         super(exprParser);
     }
 
+    @Override
+    protected void createTableBefore(SQLCreateTableStatement createTable) {
+        super.createTableBefore(createTable);
+        // PostgreSQL 允许省略 GLOBAL/LOCAL 前缀：CREATE TEMPORARY/TEMP TABLE ...
+        // 该形式在标准 SQL 之外，仅限 PostgreSQL（及 PG 系方言）；置于 PG 解析器而非基类，
+        // 以免 Oracle 等要求 GLOBAL TEMPORARY 的方言误接受裸 TEMP 形式。
+        // TEMPORARY/TEMP 在 PG 系 lexer 中恒为 IDENTIFIER（未注册为 keyword），故只按标识符匹配。
+        if (lexer.nextIfIdentifier("TEMPORARY") || lexer.nextIfIdentifier("TEMP")) {
+            createTable.config(SQLCreateTableStatement.Feature.Temporary);
+        }
+    }
+
     protected void parseCreateTableRest(SQLCreateTableStatement stmt) {
         // For partition of/by for PG
         for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6669.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6669.java
@@ -1,0 +1,65 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL {@code CREATE TEMPORARY TABLE} / {@code CREATE TEMP TABLE}（无 GLOBAL 前缀）的解析测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6669">issue #6669</a>
+ */
+public class Issue6669 {
+    private static List<SQLStatement> parsePg(String sql) {
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.postgresql);
+        return parser.parseStatementList();
+    }
+
+    private static void assertTemporary(String sql) {
+        List<SQLStatement> stmts = parsePg(sql);
+        assertEquals(1, stmts.size(), () -> "应解析为 1 条语句: " + sql);
+        assertTrue(((SQLCreateTableStatement) stmts.get(0)).isTemporary(), () -> "应识别为 temporary: " + sql);
+    }
+
+    @Test
+    public void createTemporaryTable_noPrefix() {
+        // issue #6669：GLOBAL/LOCAL 前缀省略的 TEMPORARY 表
+        String sql = "CREATE TEMPORARY TABLE tbl (id INT)";
+        assertTemporary(sql);
+        String out = SQLUtils.toSQLString(parsePg(sql).get(0), DbType.postgresql);
+        assertTrue(out.contains("TEMPORARY TABLE"), () -> "输出应含 TEMPORARY TABLE: " + out);
+    }
+
+    @Test
+    public void createTempTable_pgShorthand() {
+        // PG 的 TEMP 简写
+        assertTemporary("CREATE TEMP TABLE t (a INT)");
+    }
+
+    @Test
+    public void createGlobalTemporaryTable_unchanged() {
+        // 既有 GLOBAL TEMPORARY 形式不受影响（回归保护）
+        assertTemporary("CREATE GLOBAL TEMPORARY TABLE t (a INT)");
+    }
+
+    @Test
+    public void bareTemp_rejectedByOracle() {
+        // Oracle 要求 GLOBAL/LOCAL TEMPORARY，不接受裸 TEMP 形式。
+        // TEMPORARY/TEMP 处理置于 PGCreateTableParser 而非基类，确保 Oracle 等方言不受影响。
+        String sql = "CREATE TEMP TABLE t (id NUMBER)";
+        SQLStatementParser oracleParser = SQLParserUtils.createSQLStatementParser(sql, DbType.oracle);
+        assertThrows(ParserException.class, oracleParser::parseStatementList,
+                "Oracle 应拒绝裸 CREATE TEMP TABLE");
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
PostgreSQL 无法解析省略 `GLOBAL`/`LOCAL` 前缀的 `CREATE TEMPORARY TABLE` / `CREATE TEMP TABLE`，抛出：

```
ParserException: syntax error ... token IDENTIFIER TEMPORARY
```

issue：#6669

### 根因（Root cause）
`CREATE` 的路由在 `SQLStatementParser.parseCreate()` 中：`accept(CREATE)` 之后先由 `createOptionSkip()` 识别前缀（`GLOBAL`、`TEMPORARY`、`TEMP`）用于决定是否走建表分支，随后 `reset(mark)` 回滚，再由 `createTableBefore()` 真正解析前缀并置位 feature。

`SQLCreateTableParser#createTableBefore` 只处理 `GLOBAL TEMPORARY` / `LOCAL TEMPORARY`，没有处理 PG 可省略前缀的裸 `TEMPORARY`/`TEMP`（PG 语法：`CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE ...`）。于是裸 `CREATE TEMPORARY TABLE` 在 `createTableBefore` 中不被消费，其后期待 `TABLE` 却遇到 `TEMPORARY` 即报错。

`TEMPORARY`/`TEMP` 在 PG 系 lexer 中恒为 `IDENTIFIER`（未注册为 keyword），`nextIfIdentifier` 即可匹配；GaussDB/Redshift/BigQuery 解析器已有相同的 `nextIfIdentifier("TEMPORARY")` 写法。

### 修复（Fix）
在 `PGCreateTableParser` 中 override `createTableBefore()`：先 `super`（仍由基类处理 `GLOBAL`/`LOCAL TEMPORARY`），再识别裸 `TEMPORARY`/`TEMP` 并置位 `Feature.Temporary`。仅按标识符匹配，因为 PG 系 lexer 中 `TEMPORARY`/`TEMP` 恒为 `IDENTIFIER`，不会出现 `Token.TEMPORARY`/`Token.TEMP` 形态。

处理置于 PG 解析器而非基类，以免 Oracle 等要求 `GLOBAL TEMPORARY` 的方言误接受裸 `TEMP` 形式。既有 `GLOBAL TEMPORARY` 解析路径不变。

### 测试（Testing）
新增 `Issue6669` 回归测试（4 个用例）：裸 `TEMPORARY`、PG `TEMP` 简写、`GLOBAL TEMPORARY`（回归保护，确认既有路径不受影响）、以及 Oracle 拒绝裸 `CREATE TEMP TABLE`（确认方言隔离）。修复前前两个抛 `ParserException`，修复后全部通过。

本地验证：
- `./mvnw -pl core test -Dtest=Issue6669` -> 4/4 通过，checkstyle 通过。
- 跨方言建表回归：`DDLParserTest`、`Issue5430`（Hive TEMPORARY）等全绿。

### 复现（Reproduce）
```java
List<SQLStatement> stmts = SQLUtils.parseStatements(
        "CREATE TEMPORARY TABLE tbl (id INT)", DbType.postgresql);
// 修复前：ParserException: token IDENTIFIER TEMPORARY
// 修复后：((SQLCreateTableStatement) stmts.get(0)).isTemporary() == true
```

### 说明（Note）
实证发现 master 上 `CREATE LOCAL TEMPORARY TABLE` 在 PostgreSQL 仍解析失败（`GLOBAL TEMPORARY` 正常）。原因是 `createOptionSkip()` 识别 `GLOBAL`/`TEMPORARY`/`TEMP` 却不识别 `LOCAL`，且 `LOCAL` 在 `parseCreate()` 的 switch 中也没有对应分支，于是在 dispatch 层即报错、到不了 `createTableBefore`。这属于另一个独立的既有问题，不在 #6669 报告范围内，本 PR 未纳入，提请维护者留意。

Fixes #6669
