### PR TITLE
fix: Oracle SEGMENT 作为列别名解析失败 (#6324)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLParser.java
@@ -566,6 +566,7 @@ public class SQLParser {
                 case LEAVE:
                 case ENABLE:
                 case DISABLE:
+                case SEGMENT:
                 case REPLACE:
                     alias = lexer.stringVal();
                     lexer.nextToken();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6324.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/issues/Issue6324.java
@@ -1,0 +1,45 @@
+package com.alibaba.druid.bvt.sql.oracle.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Oracle 将 SEGMENT 用作列别名的解析测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6324">issue #6324</a>
+ */
+public class Issue6324 {
+    @Test
+    public void segmentAsColumnAlias() {
+        String sql = "SELECT bill_segment segment FROM t_billsas";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.oracle);
+        List<SQLStatement> stmts = parser.parseStatementList();
+        assertEquals(1, stmts.size());
+
+        SQLSelectQueryBlock queryBlock = (SQLSelectQueryBlock) ((SQLSelectStatement) stmts.get(0)).getSelect().getQuery();
+        assertEquals("segment", queryBlock.getSelectList().get(0).getAlias());
+
+        String out = SQLUtils.toSQLString(stmts.get(0), DbType.oracle);
+        assertTrue(out.contains("AS segment"), () -> "round-trip 应保留别名 segment: " + out);
+    }
+
+    @Test
+    public void segmentInStorageClauseUnaffected() {
+        // SEGMENT 作为 storage 子句关键字（非别名）的解析路径不受影响
+        String sql = "CREATE TABLE t_billsas (id NUMBER) SEGMENT CREATION IMMEDIATE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.oracle);
+        List<SQLStatement> stmts = parser.parseStatementList();
+        assertEquals(1, stmts.size());
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
Oracle 无法把 `SEGMENT` 用作列别名，例如 `SELECT bill_segment segment FROM t_billsas` 抛出：

```
ParserException: TODO ... token SEGMENT
```

issue：#6324（用户确认该 SQL 在 Oracle/DBeaver/Navicat 可正常执行）

### 根因（Root cause）
`OracleLexer` 把 `"SEGMENT"` 映射为 `Token.SEGMENT`（关键字），因此列别名 `segment` 走到 `SQLParser.as()` 的别名关键字白名单，但白名单里没有 `SEGMENT`——别名未被消费，解析失败。`as()` 早已为 `REPLACE/COMMENT/TABLESPACE/PRIMARY/...` 等大量关键字开了同样的口子。

### 修复（Fix）
在 `SQLParser.as()` 的别名关键字列表里加一个 `case SEGMENT:`，沿用既有写法（一行）。`Token.SEGMENT` 仅由 `OracleLexer` 产生，因此只影响 Oracle；其他方言把 `segment` 当普通 IDENTIFIER，本就接受。

### 范围（Scope）
`SEGMENT` 并非孤例。Oracle storage 族关键字 `STORAGE / PCTFREE / INITRANS / MAXTRANS / NEXT / CACHE / MINEXTENTS` 等存在于兄弟方法 `alias()` 的别名白名单、却缺失于 `as()` -> 走隐式列别名路径时未被消费 -> 同样抛 `ParserException: TODO token <KW>`。本 PR 按 issue #6324 的范围仅修 `SEGMENT`；若希望一并覆盖其余关键字，可在后续 PR 处理。

### 测试（Testing）
新增 `Issue6324`：
- `segmentAsColumnAlias`：`SELECT bill_segment segment FROM t_billsas` 解析成功，别名=`segment`，round-trip 保留别名。修复前抛 `ParserException`。
- `segmentInStorageClauseUnaffected`：`CREATE TABLE t (...) SEGMENT CREATION IMMEDIATE` 仍正常解析（保护：storage 子句的 SEGMENT 关键字路径不受影响）。

本地验证：
- `./mvnw -pl core test -Dtest=Issue6324` → 2/2 通过，0 checkstyle 违规。
- Oracle 回归：`OracleSelectTest*`、`OracleSelectGroupingTest`、`Issue6533`/`Issue6669`/`Issue6662` 等全绿。

### 复现（Reproduce）
```java
List<SQLStatement> stmts = SQLUtils.parseStatements(
        "SELECT bill_segment segment FROM t_billsas", DbType.oracle);
// 修复前：ParserException: TODO token SEGMENT
// 修复后：别名 segment 正常识别
```

Fixes #6324
