### PR TITLE
fix: Doris INSERT OVERWRITE TABLE t PARTITION(*) 解析报错 (#6350)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -3878,11 +3878,17 @@ public class SQLStatementParser extends SQLParser {
             accept(Token.LPAREN);
             for (; ; ) {
                 SQLAssignItem ptExpr = new SQLAssignItem();
-                ptExpr.setTarget(this.exprParser.name());
-                if (lexer.token == Token.EQ || lexer.token == Token.EQEQ) {
-                    lexer.nextTokenValue();
-                    SQLExpr ptValue = this.exprParser.expr();
-                    ptExpr.setValue(ptValue);
+                if (lexer.token == Token.STAR) {
+                    // PARTITION(*) 表示全分区，通配符统一用 SQLAllColumnExpr 建模
+                    ptExpr.setTarget(new SQLAllColumnExpr());
+                    lexer.nextToken();
+                } else {
+                    ptExpr.setTarget(this.exprParser.name());
+                    if (lexer.token == Token.EQ || lexer.token == Token.EQEQ) {
+                        lexer.nextTokenValue();
+                        SQLExpr ptValue = this.exprParser.expr();
+                        ptExpr.setValue(ptValue);
+                    }
                 }
                 insertStatement.addPartition(ptExpr);
                 if (!(lexer.token == (Token.COMMA))) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/doris/issues/Issue6350.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/doris/issues/Issue6350.java
@@ -1,0 +1,40 @@
+package com.alibaba.druid.bvt.sql.doris.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLAllColumnExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Doris {@code INSERT OVERWRITE TABLE ... PARTITION(*)} 解析测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6350">issue #6350</a>
+ */
+public class Issue6350 {
+    @Test
+    public void insertOverwritePartitionStar() {
+        String sql = "INSERT OVERWRITE TABLE t PARTITION(*) SELECT * FROM t";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.doris);
+        List<SQLStatement> stmts = parser.parseStatementList();
+        assertEquals(1, stmts.size());
+
+        SQLInsertStatement insert = (SQLInsertStatement) stmts.get(0);
+        assertEquals(1, insert.getPartitions().size());
+
+        // AST 级断言：PARTITION(*) 的 target 应为通配符节点 SQLAllColumnExpr，
+        // 而非依赖 round-trip 输出里是否含 "*"（SELECT * 也会满足后者，无法区分）。
+        SQLAssignItem partition = insert.getPartitions().get(0);
+        assertInstanceOf(SQLAllColumnExpr.class, partition.getTarget(),
+                () -> "PARTITION(*) target 应为 SQLAllColumnExpr，实际为: "
+                        + partition.getTarget().getClass().getSimpleName());
+    }
+}

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/doris/issues/Issue6350.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/doris/issues/Issue6350.java
@@ -1,0 +1,45 @@
+package com.alibaba.druid.bvt.sql.doris.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLAllColumnExpr;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Doris {@code INSERT OVERWRITE TABLE ... PARTITION(*)} 解析测试。
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6350">issue #6350</a>
+ */
+public class Issue6350 {
+    @Test
+    public void insertOverwritePartitionStar() {
+        String sql = "INSERT OVERWRITE TABLE t PARTITION(*) SELECT * FROM t";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.doris);
+        List<SQLStatement> stmts = parser.parseStatementList();
+        assertEquals(1, stmts.size());
+
+        SQLInsertStatement insert = (SQLInsertStatement) stmts.get(0);
+        assertEquals(1, insert.getPartitions().size());
+
+        // AST 级断言：PARTITION(*) 的 target 应为通配符节点 SQLAllColumnExpr，
+        // 而非依赖输出里是否含 "*"（SELECT * 也会满足后者，无法区分）。
+        SQLAssignItem partition = insert.getPartitions().get(0);
+        assertInstanceOf(SQLAllColumnExpr.class, partition.getTarget(),
+                () -> "PARTITION(*) target 应为 SQLAllColumnExpr，实际为: "
+                        + partition.getTarget().getClass().getSimpleName());
+
+        // 输出级断言：锁定 round-trip 精确渲染，防止 visitor 层回归。
+        assertEquals("INSERT OVERWRITE TABLE t PARTITION (*)\nSELECT *\nFROM t",
+                SQLUtils.toSQLString(insert, DbType.doris));
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
Doris/StarRocks 的全分区覆盖写入语法 `INSERT OVERWRITE TABLE t PARTITION(*) SELECT ...` 解析失败：

```
ParserException: illegal name, pos 36, token *
```

issue：#6350

### 根因（Root cause）
基类 `SQLStatementParser.parseInsert0`（`SQLStatementParser.java:3876` 起）的 PARTITION 循环对每个分区目标无条件调用 `this.exprParser.name()`，而 `name()` 拒绝 `*`。Doris/StarRocks 不覆盖该分区循环，直接走基类，故 `PARTITION(*)` 报错。

### 修复（Fix）
分区循环里对 `Token.STAR` 特判：`ptExpr.setTarget(new SQLAllColumnExpr())` 并前进，跳过 `name()`；其余 `PARTITION(col=val)` 路径完全不变。仅影响此前直接报错的 `PARTITION(*)` 场景。

`*` 建模为 `SQLAllColumnExpr`（按 review 建议调整）：它是代码库规范的通配符节点（`SELECT *` 同节点，库内 20+ 处以 `instanceof SQLAllColumnExpr` 识别通配符），而非字面量 `SQLIdentifierExpr("*")`，使通过 instanceof 识别通配符的 AST 消费者（列解析、SQL 改写工具）能正确识别。

### 测试（Testing）
新增 `Issue6350`，双重断言：
- AST 级：`PARTITION(*)` 的 target 为 `SQLAllColumnExpr`（不用 `out.contains("*")`，它会被同语句的 `SELECT *` 满足、无法区分）；
- 输出级：round-trip 精确渲染为 `INSERT OVERWRITE TABLE t PARTITION (*)` + 换行的 `SELECT * FROM t`，防止 visitor 层回归。

本地验证：
- `./mvnw -pl core test -Dtest=Issue6350,DorisResourceTest,MySqlInsertTest_43` -> 3/3 通过，0 checkstyle 违规。
- 修复前该 SQL 抛 `ParserException: illegal name, token *`（已在父提交实测复现），修复后解析为 1 条 INSERT（1 个分区，target 为通配符）。

### 复现（Reproduce）
```java
List<SQLStatement> stmts = SQLUtils.parseStatements(
        "INSERT OVERWRITE TABLE t PARTITION(*) SELECT * FROM t", DbType.doris);
// 修复前：ParserException: illegal name, token *
// 修复后：1 条 INSERT，含 1 个分区（target 为 SQLAllColumnExpr）
```

Fixes #6350
