### PR TITLE
fix: MySQL ALTER TABLE 多个 ALTER INDEX VISIBLE/INVISIBLE 子句解析报错 (#6036)

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -6210,7 +6210,8 @@ public class MySqlStatementParser extends SQLStatementParser {
                         alterIndex.getIndexDefinition().getOptions().setInvisible(lexer.identifierEquals("INVISIBLE"));
                         lexer.nextToken();
                         stmt.addItem(alterIndex);
-                        break;
+                        // 该子句已成功解析,需返回 true 让外层 alterTableAfterName 的逗号循环继续解析后续子句
+                        return true;
                     }
 
                     MySqlAlterTableAlterFullTextIndex alterIndex = new MySqlAlterTableAlterFullTextIndex();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6036.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/issues/Issue6036.java
@@ -1,0 +1,57 @@
+package com.alibaba.druid.bvt.sql.mysql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 验证 ALTER TABLE 多个 ALTER INDEX ... VISIBLE/INVISIBLE 子句用逗号分隔时可正确解析
+ *
+ * @see <a href="https://github.com/alibaba/druid/issues/6036">Issue来源</a>
+ */
+public class Issue6036 {
+    @Test
+    public void test_alter_index_multiple_clauses() {
+        String sql = "ALTER TABLE t1 ALTER INDEX idx_1 INVISIBLE, ALTER INDEX idx_2 INVISIBLE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.mysql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+
+        assertEquals(1, statementList.size());
+        // 两个 ALTER INDEX 子句都应被解析为独立的 table item
+        String result = statementList.get(0).toString();
+        System.out.println("解析结果===" + result);
+        assertEquals(2, ((com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement) statementList.get(0))
+                .getItems().size());
+        assertEquals("ALTER TABLE t1\n\tALTER INDEX idx_1  INVISIBLE,\n\tALTER INDEX idx_2  INVISIBLE", result);
+    }
+
+    @Test
+    public void test_alter_index_mixed_clauses() {
+        // 第一个 INVISIBLE、第二个 VISIBLE,确认两条子句都被解析且可见性标识正确
+        String sql = "ALTER TABLE t1 ALTER INDEX idx_1 INVISIBLE, ALTER INDEX idx_2 VISIBLE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.mysql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+
+        assertEquals(1, statementList.size());
+        String result = statementList.get(0).toString();
+        System.out.println("解析结果===" + result);
+        assertEquals("ALTER TABLE t1\n\tALTER INDEX idx_1  INVISIBLE,\n\tALTER INDEX idx_2  VISIBLE", result);
+    }
+
+    @Test
+    public void test_single_clause_still_works() {
+        // 单条子句的解析行为不能因修复而回退
+        String sql = "ALTER TABLE t1 ALTER INDEX idx_1 INVISIBLE";
+        SQLStatementParser parser = SQLParserUtils.createSQLStatementParser(sql, DbType.mysql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+
+        assertEquals(1, statementList.size());
+        assertEquals("ALTER TABLE t1\n\tALTER INDEX idx_1  INVISIBLE", statementList.get(0).toString());
+    }
+}


### PR DESCRIPTION
## 问题\n`ALTER TABLE t1 ALTER INDEX idx_1 INVISIBLE, ALTER INDEX idx_2 INVISIBLE` 解析失败。issue #6036\n\n## 根因\n`MySqlStatementParser` 的 VISIBLE/INVISIBLE 分支用 `break` 跳出，未返回 true，导致外层 `alterTableAfterName` 的逗号循环不继续解析后续 `ALTER INDEX` 子句。\n\n## 修复\n该分支改为 `return true`，让逗号循环继续。仅 1 行。\n\n## 测试\n新增 `Issue6036`（3 用例，含多子句、单子句、round-trip），修复前 fail、修复后 pass。0 checkstyle；MySQL BVT 与 alter table index 相关测试全绿。