### PR TITLE
fix(oracle): parse hints placed after FROM in DELETE statement

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -2454,6 +2454,10 @@ public class OracleStatementParser extends SQLStatementParser {
 
             if (lexer.token() == (Token.FROM)) {
                 lexer.nextToken();
+                // Oracle allows optimizer hints between FROM and the table, e.g.
+                // `DELETE FROM /*+index(t pk)*/ t`. The pre-FROM hint parse above only
+                // covers `DELETE /*+hint*/ FROM ...`, so consume hints again here.
+                parseHints(deleteStatement.getHints());
             }
 
             if (lexer.identifierEquals("ONLY")) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleDeleteFromHintTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleDeleteFromHintTest.java
@@ -1,0 +1,57 @@
+package com.alibaba.druid.bvt.sql.oracle;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLHint;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleDeleteStatement;
+import com.alibaba.druid.sql.dialect.oracle.parser.OracleStatementParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OracleDeleteFromHintTest {
+    @Test
+    public void deleteFromHint() {
+        // Hint placed after FROM, mirroring the report in issue #5200.
+        String sql = "DELETE FROM /*+index(T PK_OM_WF_RECEPTION_WAITING)*/ OM_WF_RECEPTION_WAITING T WHERE REGION = 200 AND ORDERLINEID = ? AND STATUS = ?";
+
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmtList.size());
+
+        OracleDeleteStatement stmt = (OracleDeleteStatement) stmtList.get(0);
+        List<SQLHint> hints = stmt.getHints();
+        assertEquals(1, hints.size(), "hint after FROM must be captured");
+        assertTrue(hints.get(0).toString().contains("index(T PK_OM_WF_RECEPTION_WAITING)"),
+                "captured hint text must match");
+
+        // Re-serialize: the output visitor renders hints at the canonical position
+        // right after DELETE, regardless of where they appeared in the source SQL.
+        String formatted = SQLUtils.formatOracle(sql);
+        assertEquals("DELETE /*+index(T PK_OM_WF_RECEPTION_WAITING)*/ FROM OM_WF_RECEPTION_WAITING T"
+                + "\nWHERE REGION = 200\n\tAND ORDERLINEID = ?\n\tAND STATUS = ?", formatted);
+    }
+
+    @Test
+    public void deleteHintBeforeFromStillWorks() {
+        // Regression guard: the pre-existing `DELETE /*+hint*/ FROM t` path must keep working.
+        String sql = "DELETE /*+index(a MTN_SMS_LOG_PK)*/ FROM MTN_SMS_LOG a WHERE id = 1";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        OracleDeleteStatement stmt = (OracleDeleteStatement) parser.parseStatement();
+
+        List<SQLHint> hints = stmt.getHints();
+        assertEquals(1, hints.size());
+        assertTrue(hints.get(0).toString().contains("index(a MTN_SMS_LOG_PK)"));
+    }
+
+    @Test
+    public void parseStatementDirectly() {
+        // Mirrors the exact reproduction path from the issue report.
+        String sql = "DELETE FROM  /*+index(T PK_OM_WF_RECEPTION_WAITING)*/ OM_WF_RECEPTION_WAITING T WHERE REGION = 200";
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        SQLStatement stmt = parser.parseStatement();
+        assertNotNull(stmt);
+    }
+}


### PR DESCRIPTION
## What

`OracleStatementParser.parseDeleteStatement()` now also consumes optimizer hints placed between `FROM` and the table name, so `DELETE FROM /*+index(...)*/ t` parses instead of throwing `ParserException: illegal name, ... token HINT`.

## Why

Oracle allows hints in both positions — `DELETE /*+hint*/ FROM t` and `DELETE FROM /*+hint*/ t`. The parser only handled the first form: `parseHints()` was called right after `DELETE` (before `FROM`), but not after `FROM` was consumed. When a hint appeared after `FROM`, the leftover `HINT` token reached `exprParser.name()`, which has no `HINT` case, raising the exception reported in #5200.

## Root cause

`OracleStatementParser.java:2453` called `parseHints(deleteStatement.getHints())` only once, before the `FROM` keyword. After consuming `FROM` (line 2456) the next token could be a `HINT`, which then fell through to `name()` and failed.

## How

Call `parseHints(deleteStatement.getHints())` again right after consuming `FROM`. Hints accumulate into the same list the pre-FORM path already populates, matching how `SELECT`/`UPDATE` handle hints.

## Testing

- New test `OracleDeleteFromHintTest` (3 cases):
  - `deleteFromHint` — the issue's exact SQL: fails before the fix with `token HINT`, passes after; also asserts the hint is captured on the AST and round-trips through the output visitor.
  - `deleteHintBeforeFromStillWorks` — regression guard for the existing `DELETE /*+hint*/ FROM t` path.
  - `parseStatementDirectly` — the literal reproduction path from the issue report.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `OracleHintTest`, `OracleDeleteTest*` → `Tests run: 10, Failures: 0`.

## Verification of the original issue

Before the fix:
```
com.alibaba.druid.sql.parser.ParserException: illegal name, pos 53, line 1, column 14, token HINT
	at com.alibaba.druid.sql.parser.SQLExprParser.name(SQLExprParser.java:2338)
	at ...OracleStatementParser.parseDeleteStatement(OracleStatementParser.java:2308)
```

After the fix, `DELETE FROM /*+index(T PK_OM_WF_RECEPTION_WAITING)*/ OM_WF_RECEPTION_WAITING T WHERE ...` parses, the hint is attached to the `OracleDeleteStatement`, and the statement serializes back to canonical Oracle form.

Fixes #5200
