### PR TITLE
fix(mysql): null-check hex decode in utf8/utf32/gbk/big5 charset decoders

### DIFF
--- a/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
+++ b/core/src/main/java/com/alibaba/druid/util/MySqlUtils.java
@@ -1957,6 +1957,11 @@ public class MySqlUtils {
 
     public static String utf32(String hex) {
         byte[] bytes = HexBin.decode(hex);
+        if (bytes == null) {
+            // Odd-length (or otherwise invalid) hex decodes to null; mirror utf16's handling
+            // instead of NPE-ing on bytes.length / new String(bytes, ...). See issue #4280.
+            return null;
+        }
         if (bytes.length == 2) {
             return new String(bytes, UTF16);
         }
@@ -1980,16 +1985,25 @@ public class MySqlUtils {
 
     public static String utf8(String hex) {
         byte[] bytes = HexBin.decode(hex);
+        if (bytes == null) {
+            return null;
+        }
         return new String(bytes, UTF8);
     }
 
     public static String gbk(String hex) {
         byte[] bytes = HexBin.decode(hex);
+        if (bytes == null) {
+            return null;
+        }
         return new String(bytes, GBK);
     }
 
     public static String big5(String hex) {
         byte[] bytes = HexBin.decode(hex);
+        if (bytes == null) {
+            return null;
+        }
         return new String(bytes, BIG5);
     }
 }

--- a/core/src/test/java/com/alibaba/druid/util/MySqlUtilsHexDecodeTest.java
+++ b/core/src/test/java/com/alibaba/druid/util/MySqlUtilsHexDecodeTest.java
@@ -1,0 +1,52 @@
+package com.alibaba.druid.util;
+
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression for issue #4280: {@link MySqlUtils}' charset decoders ({@code utf8}, {@code utf32},
+ * {@code gbk}, {@code big5}) called {@link HexBin#decode(String)} and used the result without a
+ * null check. Odd-length hex strings make {@code HexBin.decode} return {@code null}, so the
+ * subsequent {@code new String(bytes, ...)} (and {@code bytes.length} in {@code utf32}) threw
+ * {@link NullPointerException}. {@code utf16} already handled this and serves as the template.
+ */
+public class MySqlUtilsHexDecodeTest {
+    @Test
+    public void utf8_oddLengthHex_returnsNull() {
+        assertNull(MySqlUtils.utf8("ABC"));
+    }
+
+    @Test
+    public void utf32_oddLengthHex_returnsNull() {
+        assertNull(MySqlUtils.utf32("ABC"));
+    }
+
+    @Test
+    public void gbk_oddLengthHex_returnsNull() {
+        assertNull(MySqlUtils.gbk("ABC"));
+    }
+
+    @Test
+    public void big5_oddLengthHex_returnsNull() {
+        assertNull(MySqlUtils.big5("ABC"));
+    }
+
+    @Test
+    public void evenLengthHex_stillDecodes() {
+        // Regression guard: a valid even-length utf8 hex string must still decode.
+        // D0B0D0B2D0B2 = "авв" (already covered by MySqlSelectTest_mtr at the SQL level).
+        assertEquals("авв", MySqlUtils.utf8("D0B0D0B2D0B2"));
+    }
+
+    @Test
+    public void parseSelectWithOddLengthHexUtf8_doesNotThrow() {
+        // Reproduces the exact NPE from the issue: odd-length hex in a _utf8 X'...' literal
+        // previously aborted parsing with NPE inside MySqlUtils.utf8. After the fix parsing
+        // completes and the literal degrades to a null-backed char expr instead of throwing.
+        MySqlStatementParser parser = new MySqlStatementParser("select _utf8 X'ABC'");
+        // The key assertion is that no NullPointerException is thrown during parsing.
+        assertNotNull(parser.parseStatement());
+    }
+}


### PR DESCRIPTION
## What

`MySqlUtils.utf8`, `utf32`, `gbk`, and `big5` now return `null` instead of throwing `NullPointerException` when given an odd-length (or otherwise invalid) hex string.

## Why

`HexBin.decode(hex)` returns `null` when the hex string has odd length (`HexBin.java:87-89`). `utf16` already guarded against this, but `utf8`/`utf32`/`gbk`/`big5` used the decoded bytes unconditionally:

- `utf8`/`gbk`/`big5`: `new String(bytes, ...)` → `new String(null, ...)` → NPE.
- `utf32`: additionally `bytes.length` → NPE before even reaching the `new String`.

These methods are reached from `MySqlExprParser.primary()` for literals like `_utf8 X'ABC'` (lines 741/787/811/835, plus the char-expr paths 1055/1133/1158/1208), so an odd-length hex literal aborted SQL parsing with an NPE instead of degrading gracefully:

```
java.lang.NullPointerException
    at java.lang.String.<init>(String.java:515)
    at com.alibaba.druid.util.MySqlUtils.utf8(MySqlUtils.java:1979)
    at ...MySqlExprParser.primary(MySqlExprParser.java:307)
    at ...SQLExprParser.multiplicative(SQLExprParser.java:225)
    ...
```

## Root cause

`MySqlUtils.java:1958` (`utf32`), `1981` (`utf8`), `1986` (`gbk`), `1991` (`big5`) did not null-check the result of `HexBin.decode`, unlike the sibling `utf16` method which was already correct.

## How

Mirror `utf16`: after `HexBin.decode(hex)`, return `null` if the bytes are `null`. This makes all four charset decoders degrade identically for invalid hex, and requires no change to any caller (the resulting `SQLCharExpr` carries a null text, matching how `utf16` already behaves today).

## Testing

- New test `MySqlUtilsHexDecodeTest` (6 cases), five fail before the fix with NPE (`Cannot read the array length because "bytes" is null`), all pass after:
  - `utf8_oddLengthHex_returnsNull`, `utf32_oddLengthHex_returnsNull`, `gbk_oddLengthHex_returnsNull`, `big5_oddLengthHex_returnsNull` — each decoder on `"ABC"`.
  - `evenLengthHex_stillDecodes` — regression guard: `"D0B0D0B2D0B2"` → `"авв"`.
  - `parseSelectWithOddLengthHexUtf8_doesNotThrow` — the issue's SQL-level scenario: `select _utf8 X'ABC'` parses instead of NPE-ing.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `MySqlSelectTest_mtr, MySqlUtilsTest, MySqlUtils_1_builtin_dataTypes` → `Tests run: 10, Failures: 0`.

## Verification of the original issue

Before the fix:
```
select _utf8 X'ABC'  →  NullPointerException at MySqlUtils.utf8
```

After the fix:
```
select _utf8 X'ABC'  →  parses; the literal degrades to a null-backed char expr
```

Fixes #4280
