### PR TITLE
fix(ast): align SQLObject.setSource parameter names with impl and callers

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/SQLObject.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/SQLObject.java
@@ -29,7 +29,7 @@ public interface SQLObject {
         return 0;
     }
 
-    default void setSource(int column, int line) {
+    default void setSource(int line, int column) {
     }
 
     void accept(SQLASTVisitor visitor);

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/SQLObjectSetSourceTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/SQLObjectSetSourceTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.druid.bvt.sql;
+
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Locks in the parameter order of {@code SQLObject.setSource(int line, int column)}.
+ * See issue #6311: the interface declaration previously named the parameters in the swapped
+ * order (column, line), while the implementation and every caller used (line, column).
+ * Behavior was unaffected (parameter names are not part of the bytecode), but the misleading
+ * signature could invite wrong-position calls. This test pins the live semantics so a future
+ * swap is caught.
+ */
+public class SQLObjectSetSourceTest {
+    @Test
+    public void setSource_lineFirstColumnSecond() {
+        SQLCharExpr expr = new SQLCharExpr("x");
+        // Call positionally, the way every caller in the parser does: line first, then column.
+        expr.setSource(2, 5);
+        assertEquals(2, expr.getSourceLine(), "first setSource argument must be the line");
+        assertEquals(5, expr.getSourceColumn(), "second setSource argument must be the column");
+    }
+}


### PR DESCRIPTION
## What

The `SQLObject.setSource` interface declaration now names its parameters `(int line, int column)`, matching the implementation in `SQLObjectImpl` and the argument order used by every caller.

## Why

The interface declared the parameters in the swapped order:

```java
// SQLObject.java (before)
default void setSource(int column, int line) { }
```

but the implementation and all 20+ callers use `(line, column)`:

```java
// SQLObjectImpl.java
public void setSource(int line, int column) {
    this.sourceLine = line;
    this.sourceColumn = column;
}

// callers, e.g. Lexer.java, SQLExprParser.java, OdpsExprParser.java
expr.setSource(line, column);
expr.setSource(sourceLine, sourceColumn);
```

The runtime behavior was correct — parameter names are not part of the bytecode, so positional calls were unaffected — but the misleading signature contradicted the implementation and every caller, inviting future positional mistakes (especially for anyone relying on IDE parameter hints or Javadoc).

## Root cause

`SQLObject.java:32` had the parameter names in the opposite order from `SQLObjectImpl.java:302` and all callers.

## How

Rename the interface parameters to `(int line, int column)`. No type/order change, no behavioral change, no caller change.

## Testing

- New test `SQLObjectSetSourceTest.setSource_lineFirstColumnSecond` pins the semantics: `setSource(2, 5)` yields `getSourceLine() == 2` and `getSourceColumn() == 5`, so a future swap is caught.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `SourceLocationTest` → `Tests run: 1, Failures: 0`.

Fixes #6311
