### PR TITLE
fix(derby): render row-limiting clause as FETCH FIRST instead of LIMIT

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -2772,6 +2772,7 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
         SQLExpr first = limit.getRowCount();
 
         if (DbType.db2 == dbType
+                || DbType.derby == dbType
                 || DbType.oracle == dbType
                 || DbType.sqlserver == dbType
         ) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/derby/DerbyFetchFirstTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/derby/DerbyFetchFirstTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.druid.bvt.sql.derby;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #3612: Derby supports {@code FETCH FIRST n ROWS ONLY} and does NOT
+ * support {@code LIMIT}. {@code SQLUtils.toSQLString(..., derby)} previously rendered the
+ * fetch clause as {@code LIMIT n}, producing invalid Derby SQL.
+ */
+public class DerbyFetchFirstTest {
+    @Test
+    public void fetchFirstRendersAsFetchNotLimit() {
+        String sql = "SELECT * FROM mytest FETCH FIRST 200 ROWS ONLY";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "derby");
+
+        String result = SQLUtils.toSQLString(stmts.get(0), com.alibaba.druid.DbType.derby);
+        assertEquals("SELECT *\nFROM mytest\nFETCH FIRST 200 ROWS ONLY", result);
+    }
+}


### PR DESCRIPTION
## What

`SQLUtils.toSQLString(..., derby)` now renders the row-limiting clause as `FETCH FIRST n ROWS ONLY` (which Derby supports) instead of `LIMIT n` (which Derby does not support).

## Why

Derby uses the SQL standard `FETCH FIRST n ROWS ONLY` syntax and has no `LIMIT` keyword. druid parsed `FETCH FIRST n ROWS ONLY` correctly, but when re-serializing for Derby it emitted `LIMIT n`, producing SQL Derby rejects:

```
Input:  SELECT * FROM mytest FETCH FIRST 200 ROWS ONLY
Output: SELECT * FROM mytest LIMIT 200   ← invalid Derby SQL
```

## Root cause

`SQLASTOutputVisitor.printFetchFirst()` only emitted the `FETCH FIRST ... ROWS ONLY` form for `db2`, `oracle`, and `sqlserver`; every other dialect (including Derby) fell through to `printLimit()`, which writes `LIMIT`.

The `FETCH FIRST ... ROWS ONLY` row-limiting syntax is part of the SQL standard and shared by db2/derby/oracle/sqlserver, so Derby belongs in the same branch.

## How

Add `DbType.derby` to the dbType check in `printFetchFirst()` so Derby renders the fetch clause the same way db2/oracle/sqlserver already do. One line.

## Testing

- New test `DerbyFetchFirstTest#fetchFirstRendersAsFetchNotLimit` — fails before the fix (output `LIMIT 200`), passes after (output `FETCH FIRST 200 ROWS ONLY`).
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `*DB2SelectTest*`, `*FetchFirst*`, `*OracleSelectTest*` → `Tests run: 17, Failures: 0` (the existing db2/oracle FETCH paths are unaffected).

## Verification of the original issue

Before the fix:
```
SQLUtils.toSQLString(stmt, derby) → "SELECT *\nFROM mytest\nLIMIT 200"
```

After the fix:
```
SQLUtils.toSQLString(stmt, derby) → "SELECT *\nFROM mytest\nFETCH FIRST 200 ROWS ONLY"
```

Fixes #3612
