### PR TITLE
fix(dm): enable DATE 'literal' parsing for Dameng dialect

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/dm/parser/DmLexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/dm/parser/DmLexer.java
@@ -3,10 +3,14 @@ package com.alibaba.druid.sql.dialect.dm.parser;
 import com.alibaba.druid.DbType;
 import com.alibaba.druid.sql.parser.*;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.alibaba.druid.sql.parser.CharTypes.isIdentifierChar;
+import static com.alibaba.druid.sql.parser.DialectFeature.ParserFeature.SQLDateExpr;
+import static com.alibaba.druid.sql.parser.DialectFeature.ParserFeature.SQLTimestampExpr;
 import static com.alibaba.druid.sql.parser.Token.LITERAL_CHARS;
 
 /**
@@ -17,6 +21,14 @@ import static com.alibaba.druid.sql.parser.Token.LITERAL_CHARS;
  * Chinese relational database that supports both Oracle and MySQL syntax extensions.</p>
  */
 public class DmLexer extends Lexer {
+    // DM is Oracle-compatible: it supports the DATE 'literal' syntax (and not the
+    // TIMESTAMP 'literal' shortcut the base lexer enables by default). Mirror the
+    // Oracle lexer's SQLDateExpr/SQLTimestampExpr configuration. See issue #6220.
+    static final DialectFeature DM_FEATURE = new DialectFeature(
+            Arrays.asList(SQLDateExpr),
+            Collections.singletonList(SQLTimestampExpr)
+    );
+
     static final Keywords DM_KEYWORDS;
     static {
         Map<String, Token> map = new HashMap<>();
@@ -91,6 +103,11 @@ public class DmLexer extends Lexer {
         for (SQLParserFeature feature : features) {
             config(feature, true);
         }
+    }
+
+    @Override
+    protected void initDialectFeature() {
+        this.dialectFeature = DM_FEATURE;
     }
 
     @Override

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6220.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/dm/issues/Issue6220.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.dm.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLParseAssertUtil;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for issue #6220: DM (Dameng) is Oracle-compatible and supports the
+ * {@code DATE 'literal'} syntax, but its lexer did not enable the SQLDateExpr feature,
+ * so {@code DATE '2022-02-02'} raised {@code ParserException: not supported ... token LITERAL_CHARS}.
+ */
+public class Issue6220 {
+    private final DbType dbType = DbType.dm;
+
+    @Test
+    public void updateWithDateLiteral() {
+        String sql = "UPDATE TEST_TABLE SET SQLDATE = DATE'2022-02-02' WHERE TEST_ID = 1";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
+        assertEquals(1, stmtList.size());
+        SQLParseAssertUtil.assertParseSql(sql, dbType);
+    }
+
+    @Test
+    public void dateLiteralRoundTrips() {
+        String sql = "SELECT * FROM t WHERE d = DATE'2022-02-02'";
+        List<SQLStatement> stmtList = SQLUtils.parseStatements(sql, dbType);
+        String result = SQLUtils.toSQLString(stmtList.get(0), dbType);
+        assertTrue(result.contains("DATE '2022-02-02'"), "DATE literal must round-trip, got: " + result);
+    }
+}


### PR DESCRIPTION
## What

The DM (Dameng) dialect now parses the `DATE 'literal'` syntax, e.g. `SET col = DATE'2022-02-02'`, instead of raising `ParserException: not supported ... token LITERAL_CHARS`.

## Why

DM is an Oracle-compatible database and supports Oracle's `DATE 'literal'` syntax. druid gates this syntax behind the `SQLDateExpr` dialect feature; the base `Lexer` only enables `SQLTimestampExpr` by default, and `DmLexer` did not override `initDialectFeature()`. So `DATE '2022-02-02'` was tokenized as the `DATE` keyword followed by a bare char literal, which the expression parser rejected:

```
ParserException: not supported. pos 48, line 1, column 37, token LITERAL_CHARS 2022-02-02
```

## Root cause

`DmLexer` inherited the default `DialectFeature`, which enables `SQLTimestampExpr` but not `SQLDateExpr`.

## How

Give `DmLexer` its own `DM_FEATURE` that enables `SQLDateExpr` (and disables the default `SQLTimestampExpr`), mirroring exactly what `OracleLexer.ORACLE_FEATURE` already does — DM is Oracle-compatible. Override `initDialectFeature()` to install it.

## Testing

- New test `Issue6220` (2 cases), both fail before the fix with `not supported ... token LITERAL_CHARS`, both pass after:
  - `updateWithDateLiteral` — the issue's exact SQL.
  - `dateLiteralRoundTrips` — asserts the literal round-trips through `toSQLString`.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: all DM tests (`DM_*Test`, `Issue6*`) → `Tests run: 202, Failures: 0`.

## Verification of the original issue

Before the fix:
```
SQLUtils.parseStatements("UPDATE TEST_TABLE SET SQLDATE = DATE'2022-02-02' WHERE TEST_ID = 1", dm)
  → ParserException: not supported ... token LITERAL_CHARS 2022-02-02
```

After the fix:
```
SQLUtils.parseStatements("UPDATE TEST_TABLE SET SQLDATE = DATE'2022-02-02' WHERE TEST_ID = 1", dm)
  → parses; round-trips to "UPDATE TEST_TABLE\nSET SQLDATE = DATE '2022-02-02'\nWHERE TEST_ID = 1"
```

Fixes #6220
