### PR TITLE
fix(oracle): allow dot in MyBatis placeholders ${a.b} / #{a.b}

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleLexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleLexer.java
@@ -206,7 +206,11 @@ public class OracleLexer extends Lexer {
             for (; ; ) {
                 ch = charAt(++pos);
 
-                if (!isIdentifierChar(ch) && ch != ':') {
+                // Allow '.' only inside ${...} / #{...} MyBatis placeholders so dotted
+                // parameter names like ${a.b} are preserved. Plain :VAR bind variables
+                // (e.g. Oracle's :NEW."ID") must NOT consume the dot. See #5172.
+                boolean allowDot = mybatisFlag && ch == '.';
+                if (!isIdentifierChar(ch) && ch != ':' && !allowDot) {
                     break;
                 }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleMybatisPlaceholderTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleMybatisPlaceholderTest.java
@@ -1,0 +1,49 @@
+package com.alibaba.druid.bvt.sql.oracle;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #5172: Oracle's lexer did not allow {@code .} inside MyBatis
+ * placeholders, so {@code ${a.b}} raised {@code ParserException: syntax error} while
+ * mysql/postgresql already accepted it.
+ */
+public class OracleMybatisPlaceholderTest {
+    @Test
+    public void mybatisPlaceholderWithDotParses() {
+        String sql = "select * from table_a where b.b1 = ${a.basdf}";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+
+        String formatted = SQLUtils.formatOracle(sql);
+        assertEquals("SELECT *\nFROM table_a\nWHERE b.b1 = ${a.basdf}", formatted);
+    }
+
+    @Test
+    public void mybatisPlaceholderNestedDotParses() {
+        String sql = "select * from t where b = ${a.b.c}";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void hashPlaceholderWithDotParses() {
+        // The same scan path covers #{...} placeholders.
+        String sql = "select * from t where b = #{a.b}";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void simplePlaceholderStillWorks() {
+        // Regression guard: a placeholder without a dot must keep working.
+        String sql = "select * from t where b = ${a}";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+    }
+}


### PR DESCRIPTION
## What

Oracle's lexer now allows `.` inside MyBatis placeholders, so `${a.b}` / `#{a.b.c}` parse instead of raising `ParserException: syntax error`.

## Why

MyBatis parameter names commonly use dots (e.g. `${item.id}`). mysql/postgresql already accept this; the Oracle lexer's `scanVariable()` only allowed identifier characters and `:` inside `${...}`/`#{...}`, so the dot terminated the placeholder early and the leftover content broke parsing:

```
select * from table_a where b.b1 = ${a.basdf}
  → ParserException: syntax errorpos 38, line 1, column 36, token =
  at ...OracleLexer.scanVariable(OracleLexer.java:205)
```

## Root cause

`OracleLexer.scanVariable()` (the placeholder name loop) checked `!isIdentifierChar(ch) && ch != ':'` and broke on `.`. The base `Lexer.scanVariable()` does not have this restriction.

## How

Also accept `.` in that loop, mirroring how the base lexer handles dotted placeholder names. One line in the break condition.

## Testing

- New test `OracleMybatisPlaceholderTest` (4 cases), three fail before the fix with `syntax errorpos ... token =`, all pass after:
  - `mybatisPlaceholderWithDotParses` — the issue's SQL; also asserts round-trip.
  - `mybatisPlaceholderNestedDotParses` — `${a.b.c}`.
  - `hashPlaceholderWithDotParses` — same scan path covers `#{a.b}`.
  - `simplePlaceholderStillWorks` — regression guard: `${a}` (no dot) still works.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `OracleLexerTest`, `OracleParameterTest` → `Tests run: 5, Failures: 0`.

## Verification of the original issue

Before:
```
SQLUtils.parseStatements("select * from table_a where b.b1 = ${a.basdf}", oracle)
  → ParserException: syntax errorpos 38 ... token =
```

After:
```
→ parses; round-trips to "SELECT *\nFROM table_a\nWHERE b.b1 = ${a.basdf}"
```

Fixes #5172
