### PR TITLE
fix(mysql): support IDENTIFIED WITH in ALTER USER

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterUserStatement.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/ast/statement/MySqlAlterUserStatement.java
@@ -73,6 +73,10 @@ public class MySqlAlterUserStatement extends MySqlStatementImpl implements SQLAl
 
     public static class AuthOption {
         private SQLCharExpr authString;
+        // For IDENTIFIED WITH auth_plugin [BY 'auth_string' | AS 'hash']
+        private SQLExpr authPlugin;
+        private boolean pluginAs;
+        private SQLExpr password;
 
         public SQLCharExpr getAuthString() {
             return authString;
@@ -80,6 +84,30 @@ public class MySqlAlterUserStatement extends MySqlStatementImpl implements SQLAl
 
         public void setAuthString(SQLCharExpr authString) {
             this.authString = authString;
+        }
+
+        public SQLExpr getAuthPlugin() {
+            return authPlugin;
+        }
+
+        public void setAuthPlugin(SQLExpr authPlugin) {
+            this.authPlugin = authPlugin;
+        }
+
+        public boolean isPluginAs() {
+            return pluginAs;
+        }
+
+        public void setPluginAs(boolean pluginAs) {
+            this.pluginAs = pluginAs;
+        }
+
+        public SQLExpr getPassword() {
+            return password;
+        }
+
+        public void setPassword(SQLExpr password) {
+            this.password = password;
         }
     }
 

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/parser/MySqlStatementParser.java
@@ -8166,11 +8166,30 @@ public class MySqlStatementParser extends SQLStatementParser {
             }
             if (lexer.identifierEquals("IDENTIFIED")) {
                 lexer.nextToken();
-                accept(Token.BY);
 
                 MySqlAlterUserStatement.AuthOption authOption = new MySqlAlterUserStatement.AuthOption();
-                SQLCharExpr authString = this.exprParser.charExpr();
-                authOption.setAuthString(authString);
+
+                if (lexer.token() == Token.BY) {
+                    lexer.nextToken();
+                    authOption.setAuthString(this.exprParser.charExpr());
+                } else if (lexer.token() == Token.WITH) {
+                    // IDENTIFIED WITH auth_plugin [BY 'auth_string' | AS 'hash']
+                    lexer.nextToken();
+                    authOption.setAuthPlugin(this.exprParser.charExpr());
+
+                    if (lexer.token() == Token.BY || lexer.token() == Token.AS) {
+                        authOption.setPluginAs(lexer.token() == Token.AS);
+                        lexer.nextToken();
+                        if (authOption.isPluginAs()) {
+                            // The hash is a quoted string literal; drop the surrounding quotes.
+                            String hash = lexer.stringVal();
+                            authOption.setPassword(new SQLCharExpr(trimQuotesBeginAndEnd(hash)));
+                            lexer.nextToken();
+                        } else {
+                            authOption.setPassword(this.exprParser.charExpr());
+                        }
+                    }
+                }
 
                 alterUser.setAuthOption(authOption);
             }

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/mysql/visitor/MySqlOutputVisitor.java
@@ -4054,9 +4054,19 @@ public class MySqlOutputVisitor extends SQLASTOutputVisitor implements MySqlASTV
             alterUser.getUser().accept(this);
 
             if (alterUser.getAuthOption() != null) {
-                print(" IDENTIFIED BY ");
-                SQLCharExpr authString = alterUser.getAuthOption().getAuthString();
-                authString.accept(this);
+                MySqlAlterUserStatement.AuthOption authOption = alterUser.getAuthOption();
+                if (authOption.getAuthPlugin() != null) {
+                    print(" IDENTIFIED WITH ");
+                    authOption.getAuthPlugin().accept(this);
+                    if (authOption.getPassword() != null) {
+                        print0(authOption.isPluginAs() ? (ucase ? " AS " : " as ") : (ucase ? " BY " : " by "));
+                        authOption.getPassword().accept(this);
+                    }
+                } else {
+                    print(" IDENTIFIED BY ");
+                    SQLCharExpr authString = authOption.getAuthString();
+                    authString.accept(this);
+                }
             }
             if (alterUser.getAccountLockOption() != null) {
                 print0(ucase ? " ACCOUNT " : " account ");

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlAlterUserIdentifiedWithTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/mysql/MySqlAlterUserIdentifiedWithTest.java
@@ -1,0 +1,57 @@
+package com.alibaba.druid.bvt.sql.mysql;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlAlterUserStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression for issue #4306: {@code ALTER USER ... IDENTIFIED WITH plugin AS 'hash'}
+ * (and {@code BY 'auth_string'}) failed to parse — only {@code IDENTIFIED BY 'pass'}
+ * was accepted, while {@code CREATE USER} already supported the WITH form.
+ */
+public class MySqlAlterUserIdentifiedWithTest {
+    @Test
+    public void identifiedWithAs() {
+        String sql = "ALTER USER 'root'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*F3A2A51A9B0F2BE2468926B4132313728C250DBF'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "mysql");
+        assertEquals(1, stmts.size());
+
+        MySqlAlterUserStatement stmt = (MySqlAlterUserStatement) stmts.get(0);
+        MySqlAlterUserStatement.AuthOption auth = stmt.getAlterUsers().get(0).getAuthOption();
+        assertNotNull(auth.getAuthPlugin(), "auth plugin must be captured");
+        assertNotNull(auth.getPassword(), "hash must be captured");
+        assertEquals(true, auth.isPluginAs(), "AS form must be flagged");
+
+        String formatted = SQLUtils.toSQLString(stmt, com.alibaba.druid.DbType.mysql);
+        assertEquals("ALTER USER 'root'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*F3A2A51A9B0F2BE2468926B4132313728C250DBF'", formatted);
+    }
+
+    @Test
+    public void identifiedWithBy() {
+        String sql = "ALTER USER 'u'@'%' IDENTIFIED WITH 'plugin' BY 'secret'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "mysql");
+        MySqlAlterUserStatement.AuthOption auth = ((MySqlAlterUserStatement) stmts.get(0))
+                .getAlterUsers().get(0).getAuthOption();
+        assertNotNull(auth.getAuthPlugin());
+        assertNotNull(auth.getPassword());
+        assertEquals(false, auth.isPluginAs());
+    }
+
+    @Test
+    public void identifiedByStillWorks() {
+        // Regression guard: the original IDENTIFIED BY 'pass' form must keep working.
+        String sql = "ALTER USER u IDENTIFIED BY 'secret'";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "mysql");
+        assertEquals(1, stmts.size());
+
+        MySqlAlterUserStatement.AuthOption auth = ((MySqlAlterUserStatement) stmts.get(0))
+                .getAlterUsers().get(0).getAuthOption();
+        assertNotNull(auth.getAuthString());
+    }
+}


### PR DESCRIPTION
## What

MySQL `ALTER USER` now supports the `IDENTIFIED WITH auth_plugin [BY 'auth_string' | AS 'hash']` syntax, instead of failing with `expect BY, actual WITH`.

## Why

`ALTER USER ... IDENTIFIED BY 'pass'` worked, but the WITH form (commonly used to pin an auth plugin and a password hash) did not:

```
ALTER USER 'root'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*F3A2...DBF'
  → ParserException: syntax error ... expect BY, actual WITH
```

The sibling `CREATE USER` parser (`user()`) already fully supports `IDENTIFIED WITH plugin [BY|AS ...]`; `ALTER USER`'s `alterUser()` only `accept(Token.BY)`.

## Root cause

`MySqlStatementParser.alterUser()` (the IDENTIFIED branch) only handled `BY`; it had no branch for `WITH`.

## How

Mirror the `CREATE USER` IDENTIFIED handling:
- `IDENTIFIED BY 'pass'` → unchanged (authString).
- `IDENTIFIED WITH plugin [BY 'secret' | AS 'hash']` → capture plugin + optional password + AS/BY discriminator.

`AuthOption` gains `authPlugin`, `password`, and `pluginAs` fields. The MySQL output visitor renders the WITH form back to canonical syntax.

## Testing

- New test `MySqlAlterUserIdentifiedWithTest` (3 cases):
  - `identifiedWithAs` — the issue's SQL; asserts plugin + hash captured and round-trips.
  - `identifiedWithBy` — `IDENTIFIED WITH plugin BY 'secret'`.
  - `identifiedByStillWorks` — regression guard for the original BY form.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `*AlterUser*` → `Tests run: 3, Failures: 0`.

## Verification of the original issue

Before:
```
ALTER USER 'root'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*F3A2...DBF'
  → ParserException: expect BY, actual WITH
```

After:
```
→ parses; round-trips to the same SQL with WITH ... AS preserved.
```

Fixes #4306
