### PR TITLE
fix(core): allow optional WITH/BY in CREATE SEQUENCE

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -4753,12 +4753,12 @@ public class SQLStatementParser extends SQLParser {
         for (; ; ) {
             if (lexer.token() == Token.START || lexer.identifierEquals(Constants.START)) {
                 lexer.nextToken();
-                accept(Token.WITH);
+                lexer.nextIf(Token.WITH);
                 stmt.setStartWith(this.exprParser.expr());
                 continue;
             } else if (lexer.identifierEquals(Constants.INCREMENT)) {
                 lexer.nextToken();
-                accept(Token.BY);
+                lexer.nextIf(Token.BY);
                 stmt.setIncrementBy(this.exprParser.expr());
                 continue;
             } else if (lexer.token() == Token.CACHE || lexer.identifierEquals(Constants.CACHE)) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresCreateSequenceOptionalWithByTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresCreateSequenceOptionalWithByTest.java
@@ -1,0 +1,49 @@
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #4313: PostgreSQL (and other dialects) allow {@code START n}
+ * and {@code INCREMENT n} without the optional {@code WITH}/{@code BY} prepositions,
+ * e.g. {@code CREATE SEQUENCE seq_abc START 1 INCREMENT 1}.
+ */
+public class PostgresCreateSequenceOptionalWithByTest {
+    @Test
+    public void createSequenceWithoutWithAndBy() {
+        String sql = "CREATE SEQUENCE seq_abc START 1 INCREMENT 1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void createSequenceWithoutWithOnly() {
+        String sql = "CREATE SEQUENCE seq_abc START WITH 1 INCREMENT 1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmtListSize(stmts, sql));
+    }
+
+    @Test
+    public void createSequenceWithoutByOnly() {
+        String sql = "CREATE SEQUENCE seq_abc START 1 INCREMENT BY 1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmtListSize(stmts, sql));
+    }
+
+    @Test
+    public void createSequenceWithBothStillWorks() {
+        // Regression guard: the fully-spelled form must keep working.
+        String sql = "CREATE SEQUENCE seq_abc START WITH 1 INCREMENT BY 1";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmtListSize(stmts, sql));
+    }
+
+    private static int stmtListSize(List<SQLStatement> stmts, String sql) {
+        return stmts.size();
+    }
+}


### PR DESCRIPTION
## What

`CREATE SEQUENCE` now accepts the optional `WITH`/`BY` prepositions being omitted, e.g. `CREATE SEQUENCE seq START 1 INCREMENT 1` (PostgreSQL syntax).

## Why

`START [WITH] n` and `INCREMENT [BY] n` have optional prepositions in PostgreSQL/MySQL/Oracle. The parser forced `accept(WITH)` / `accept(BY)`, so the shorter form raised:

```
CREATE SEQUENCE seq_abc START 1 INCREMENT 1
  → ParserException: syntax error ... expect WITH, actual null, pos 31 ... token LITERAL_INT
```

This form is commonly emitted by JPA sequence generators (the issue's case).

## Root cause

`SQLStatementParser.parseCreateSequence()` called `accept(Token.WITH)` after `START` and `accept(Token.BY)` after `INCREMENT`, instead of treating them as optional.

## How

Replace both `accept(...)` with `lexer.nextIf(...)`, which consumes the preposition when present and otherwise leaves the expression to parse directly.

## Testing

- New test `PostgresCreateSequenceOptionalWithByTest` (4 cases), three fail before the fix, all pass after:
  - `createSequenceWithoutWithAndBy` — the issue's SQL.
  - `createSequenceWithoutWithOnly` / `createSequenceWithoutByOnly` — one preposition omitted.
  - `createSequenceWithBothStillWorks` — regression guard for the fully-spelled form.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `*CreateSequence*`, `*SequenceTest*` → `Tests run: 10, Failures: 0`.

## Verification of the original issue

Before:
```
CREATE SEQUENCE seq_abc START 1 INCREMENT 1  →  expect WITH, actual null
```

After:
```
CREATE SEQUENCE seq_abc START 1 INCREMENT 1  →  parses successfully
```

Fixes #4313
