### PR TITLE
fix(pg): parse trailing ARRAY column type

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLExprParser.java
@@ -4703,6 +4703,24 @@ public class SQLExprParser extends SQLParser {
             }
         }
 
+        // PostgreSQL allows a trailing ARRAY on a column type, e.g. `integer ARRAY`
+        // or `integer ARRAY[4]`. MySQL spells its own multi-value index/CAST form
+        // (... AS CHAR(50) ARRAY) and resolves it elsewhere, so only apply this for
+        // postgresql. See #3480.
+        if (dbType == DbType.postgresql
+                && (lexer.identifierEquals(FnvHash.Constants.ARRAY) || lexer.token() == Token.ARRAY)) {
+            lexer.nextToken();
+            SQLArrayDataType arrayType = new SQLArrayDataType(dataType, dbType);
+            if (lexer.token() == Token.LBRACKET) {
+                lexer.nextToken();
+                if (lexer.token() != Token.RBRACKET) {
+                    this.exprList(arrayType.getArguments(), arrayType, true);
+                }
+                accept(Token.RBRACKET);
+            }
+            return arrayType;
+        }
+
         return dataType;
     }
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresTrailingArrayTypeTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/PostgresTrailingArrayTypeTest.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.postgresql;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #3480: PostgreSQL's trailing array column type
+ * ({@code <type> ARRAY} / {@code <type> ARRAY[n]}) failed to parse.
+ */
+public class PostgresTrailingArrayTypeTest {
+    @Test
+    public void columnWithBareTrailingArray() {
+        String sql = "CREATE TABLE tb_menu (id bigserial NOT NULL, reference_ids integer ARRAY, PRIMARY KEY (id))";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void columnWithSizedTrailingArray() {
+        String sql = "CREATE TABLE t (id int, scores integer ARRAY[4])";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void plainColumnArraySyntaxStillWorks() {
+        // Regression guard: the int[] form must keep working.
+        String sql = "CREATE TABLE t (id int, refs integer[])";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "postgresql");
+        assertEquals(1, stmts.size());
+    }
+}


### PR DESCRIPTION
## What

PostgreSQL trailing array column types — `<type> ARRAY` and `<type> ARRAY[n]` — now parse, instead of failing with `expect RPAREN, actual ARRAY`.

## Why

PostgreSQL accepts two spellings for array columns: the bracket form `integer[]` and the `ARRAY` keyword form. druid only parsed the bracket form, so:

```
CREATE TABLE tb_menu (id bigserial NOT NULL, reference_ids integer ARRAY, PRIMARY KEY (id))
  → ParserException: syntax error ... expect RPAREN, actual ARRAY
```

## Root cause

`SQLExprParser.parseDataTypeRest()` returned the parsed scalar type without checking for a trailing `ARRAY` keyword, so column parsing saw `ARRAY` where it expected `,` or `)`.

## How

In `parseDataTypeRest()`, after the existing type-suffix handling, if the next token is `ARRAY` (identifier or token), consume it and wrap the already-parsed type into a `SQLArrayDataType`. An optional `[n]` sizing is consumed as the array's arguments (matching how the bracket form is handled).

## Testing

- New test `PostgresTrailingArrayTypeTest` (3 cases), two fail before the fix, all pass after:
  - `columnWithBareTrailingArray` — the issue's SQL (`integer ARRAY`).
  - `columnWithSizedTrailingArray` — `integer ARRAY[4]`.
  - `plainColumnArraySyntaxStillWorks` — regression guard: the `integer[]` form still parses.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `*DataTypeTest*`, `*CreateTableTest*` → `Tests run: 75, Failures: 0`.

## Verification of the original issue

Before:
```
... reference_ids integer ARRAY ...  →  expect RPAREN, actual ARRAY
```

After:
```
→ parses successfully
```

Fixes #3480
