### PR TITLE
fix(clickhouse): parse two-argument function-style CAST(x, 'Type')

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/clickhouse/parser/CKExprParser.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLStructDataType;
 import com.alibaba.druid.sql.ast.expr.SQLArrayExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
 import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.statement.SQLColumnDefinition;
@@ -71,6 +72,57 @@ public class CKExprParser extends SQLExprParser {
         this.aggregateFunctions = AGGREGATE_FUNCTIONS;
         this.aggregateFunctionHashCodes = AGGREGATE_FUNCTIONS_CODES;
         this.nestedDataType = NESTED_DATA_TYPE;
+    }
+
+    @Override
+    protected SQLExpr parseCast() {
+        // ClickHouse supports the function-style two-argument CAST(x, 'TypeName') in addition
+        // to the SQL-standard CAST(x AS type). Detect the comma form after the first expr
+        // and treat the quoted type name as the target data type. See issue #4421.
+        String castStr = lexer.stringVal();
+        lexer.nextToken();
+        if (lexer.token() != Token.LPAREN) {
+            return new SQLIdentifierExpr(castStr);
+        }
+        lexer.nextToken();
+        SQLExpr expr = this.expr();
+        if (lexer.token() == Token.COMMA) {
+            lexer.nextToken();
+            SQLCharExpr typeLiteral = (SQLCharExpr) this.primary();
+            accept(Token.RPAREN);
+
+            SQLCastExpr cast = new SQLCastExpr();
+            cast.setExpr(expr);
+            // The quoted argument is a ClickHouse type name, e.g. 'String', 'Int64'.
+            cast.setDataType(parseDataTypeFromName(typeLiteral.getText()));
+            return cast;
+        }
+        // Standard form: CAST(x AS type)
+        accept(Token.AS);
+        SQLDataType dataType = parseDataType(false);
+        if (dataType instanceof SQLArrayDataType) {
+            SQLArrayDataType arrayDataType = (SQLArrayDataType) dataType;
+            if (arrayDataType.getDbType() == null) {
+                arrayDataType.setDbType(dbType);
+            }
+            arrayDataType.setUsedForCast(true);
+        }
+        SQLCastExpr cast = new SQLCastExpr();
+        cast.setExpr(expr);
+        cast.setDataType(dataType);
+        cast = parseCastFormat(cast);
+        accept(Token.RPAREN);
+        return cast;
+    }
+
+    private SQLDataType parseDataTypeFromName(String typeName) {
+        // Parse a ClickHouse type name (e.g. "String", "Nullable(Int64)") by feeding it
+        // through the regular data-type parser on a throwaway lexer.
+        Lexer typeLexer = new Lexer(typeName);
+        typeLexer.nextToken();
+        SQLDataType dataType = new SQLExprParser(typeLexer).parseDataType(false);
+        dataType.setDbType(dbType);
+        return dataType;
     }
 
     protected SQLExpr parseAliasExpr(String alias) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/CKCastTwoArgTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/clickhouse/CKCastTwoArgTest.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.bvt.sql.clickhouse;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #4421: ClickHouse's function-style two-argument CAST,
+ * e.g. {@code CAST(x, 'String')}, failed to parse (only {@code CAST(x AS type)} was accepted).
+ */
+public class CKCastTwoArgTest {
+    @Test
+    public void castTwoArgWithStringType() {
+        String sql = "SELECT CAST(data_day, 'String') AS dt";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void castTwoArgWithNumericType() {
+        String sql = "SELECT CAST(value, 'Int64') AS v FROM t";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void castAsFormStillWorks() {
+        // Regression guard: the CAST(x AS type) form must keep working.
+        String sql = "SELECT CAST(data_day AS String) AS dt";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, DbType.clickhouse);
+        assertEquals(1, stmts.size());
+    }
+}


### PR DESCRIPTION
## What

ClickHouse's function-style two-argument `CAST(x, 'TypeName')` now parses, instead of failing with `expect AS, actual ,`.

## Why

ClickHouse supports both `CAST(x AS type)` and `CAST(x, 'TypeName')`. druid only parsed the AS form, so:

```
SELECT CAST(data_day, 'String') AS dt
  → ParserException: syntax error, expect AS, actual , pos 17276 ... token ,
```

## Root cause

The base `SQLExprParser.parseCast()` only accepts `CAST(expr AS type)`. `CKExprParser` did not override it.

## How

Override `parseCast()` in `CKExprParser`: after parsing the first expression, if the next token is `,`, consume it and parse the quoted type name; the type string (e.g. `'String'`, `'Int64'`, `'Nullable(Int64)'`) is fed through the regular data-type parser to produce the target `SQLDataType`. Otherwise fall through to the standard `CAST(expr AS type)` handling.

Round-trip emits the `CAST(x AS type)` form, which ClickHouse also accepts.

## Testing

- New test `CKCastTwoArgTest` (3 cases), two fail before the fix, all pass after:
  - `castTwoArgWithStringType` — the issue's SQL.
  - `castTwoArgWithNumericType` — `CAST(value, 'Int64')`.
  - `castAsFormStillWorks` — regression guard for `CAST(x AS type)`.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `CK_*` → `Tests run: 9, Failures: 0`.

## Verification of the original issue

Before:
```
SELECT CAST(data_day, 'String') AS dt  →  expect AS, actual ,
```

After:
```
→ parses successfully
```

Fixes #4421
