### PR TITLE
fix(h2): register LISTAGG as aggregate for WITHIN GROUP support

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/h2/parser/H2ExprParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/h2/parser/H2ExprParser.java
@@ -29,7 +29,7 @@ public class H2ExprParser extends SQLExprParser {
     private static final long[] AGGREGATE_FUNCTIONS_CODES;
 
     static {
-        String[] strings = {"AVG", "COUNT", "MAX", "MIN", "STDDEV", "SUM", "ROW_NUMBER",
+        String[] strings = {"AVG", "COUNT", "LISTAGG", "MAX", "MIN", "STDDEV", "SUM", "ROW_NUMBER",
                 "ROWNUMBER"};
         AGGREGATE_FUNCTIONS_CODES = FnvHash.fnv1a_64_lower(strings, true);
         AGGREGATE_FUNCTIONS = new String[AGGREGATE_FUNCTIONS_CODES.length];

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/h2/H2ListaggWithinGroupTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/h2/H2ListaggWithinGroupTest.java
@@ -1,0 +1,31 @@
+package com.alibaba.druid.bvt.sql.h2;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #4301: H2 (Oracle-compatibility mode) supports
+ * {@code LISTAGG(...) WITHIN GROUP (ORDER BY ...)}, but the H2 parser did not
+ * treat LISTAGG as an aggregate, so the WITHIN GROUP clause failed to parse.
+ */
+public class H2ListaggWithinGroupTest {
+    @Test
+    public void listaggWithinGroup() {
+        String sql = "SELECT listagg(x, ',') WITHIN GROUP (ORDER BY length(fdn) ASC) FROM t";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "h2");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void listaggWithinGroupRoundTrips() {
+        String sql = "SELECT listagg(x, ',') WITHIN GROUP (ORDER BY fdn) FROM t";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "h2");
+        String result = SQLUtils.toSQLString(stmts.get(0), com.alibaba.druid.DbType.h2);
+        assertEquals("SELECT listagg(x, ',') WITHIN GROUP (ORDER BY fdn)\nFROM t", result);
+    }
+}


### PR DESCRIPTION
## What

H2 now parses `LISTAGG(...) WITHIN GROUP (ORDER BY ...)` (H2's Oracle-compatibility mode), instead of failing with `expect BY, actual (`.

## Why

H2 supports Oracle-compatibility mode including the `LISTAGG` ordered-set aggregate. druid's H2 parser did not register `LISTAGG` as an aggregate function, so it was parsed as a plain method call and the trailing `WITHIN GROUP (ORDER BY ...)` clause broke parsing:

```
SELECT listagg(x, ',') WITHIN GROUP (ORDER BY length(fdn) ASC) FROM t
  → ParserException: syntax error ... expect BY, actual (, pos 37 ... token (
```

The same SQL parses fine on the oracle dialect, whose aggregate-function list already includes `LISTAGG`.

## Root cause

`H2ExprParser`'s `AGGREGATE_FUNCTIONS` array omitted `LISTAGG`, so `isAggregateFunction("LISTAGG")` returned false and the WITHIN GROUP aggregate path (`parseAggregateExpr` → `parseAggregateExprRest`) was never taken.

## How

Add `LISTAGG` to `H2ExprParser.AGGREGATE_FUNCTIONS`, matching the Oracle parser. The base `parseAggregateExprRest` already handles `WITHIN GROUP`.

## Testing

- New test `H2ListaggWithinGroupTest` (2 cases), both fail before the fix, both pass after:
  - `listaggWithinGroup` — the issue's SQL.
  - `listaggWithinGroupRoundTrips` — asserts the statement round-trips.
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `H2_*` → `Tests run: 3, Failures: 0`.

## Verification of the original issue

Before:
```
SELECT listagg(x, ',') WITHIN GROUP (ORDER BY length(fdn) ASC) FROM t  →  expect BY, actual (
```

After:
```
→ parses; round-trips with WITHIN GROUP preserved.
```

Fixes #4301
