### PR TITLE
fix(oracle): parse PL/SQL TYPE ... IS RECORD declarations

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleStatementParser.java
@@ -2054,6 +2054,23 @@ public class OracleStatementParser extends SQLStatementParser {
 
                     dataType = new SQLDataTypeImpl("REF CURSOR");
                     dataType.setDbType(dbType);
+                } else if (lexer.identifierEquals("RECORD")) {
+                    // PL/SQL record type: TYPE name IS RECORD (field1 type1, field2 type2, ...).
+                    lexer.nextToken();
+                    accept(Token.LPAREN);
+                    SQLStructDataType structDataType = new SQLStructDataType(dbType);
+                    for (; ; ) {
+                        SQLName fieldName = this.exprParser.name();
+                        SQLDataType fieldType = this.exprParser.parseDataType(false);
+                        structDataType.addField(fieldName, fieldType);
+                        if (lexer.token() == Token.COMMA) {
+                            lexer.nextToken();
+                            continue;
+                        }
+                        break;
+                    }
+                    accept(Token.RPAREN);
+                    dataType = structDataType;
                 } else if (lexer.token() == Token.TABLE) {
                     lexer.nextToken();
                     accept(Token.OF);

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleTypeRecordTest.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/OracleTypeRecordTest.java
@@ -1,0 +1,42 @@
+package com.alibaba.druid.bvt.sql.oracle;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for issue #2755: Oracle PL/SQL {@code TYPE ... IS RECORD (...)}
+ * declarations failed to parse.
+ */
+public class OracleTypeRecordTest {
+    @Test
+    public void typeIsRecord() {
+        String sql = "DECLARE\n"
+                + "  TYPE TR_EQUIP_SPEC_RECORD IS RECORD (ID VARCHAR2(36), NAME VARCHAR2(200));\n"
+                + "  V_SPEC_ROW TR_EQUIP_SPEC_RECORD;\n"
+                + "BEGIN\n"
+                + "  NULL;\n"
+                + "END;";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+    }
+
+    @Test
+    public void typeIsRecordInFullBlock() {
+        // Issue's full block with REF CURSOR + RECORD + variable of the record type.
+        String sql = "DECLARE\n"
+                + "  TYPE T_EQUIP_SPEC IS REF CURSOR;\n"
+                + "  V_EQUIP_SPEC T_EQUIP_SPEC;\n"
+                + "  TYPE TR_EQUIP_SPEC_RECORD IS RECORD (ID VARCHAR2(36), NAME VARCHAR2(200));\n"
+                + "  V_SPEC_ROW TR_EQUIP_SPEC_RECORD;\n"
+                + "BEGIN\n"
+                + "  NULL;\n"
+                + "END;";
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "oracle");
+        assertEquals(1, stmts.size());
+    }
+}


### PR DESCRIPTION
## What

Oracle PL/SQL `TYPE ... IS RECORD (...)` type declarations now parse, instead of failing with `TODO ... token IDENTIFIER RECORD`.

## Why

PL/SQL record types are a common Oracle idiom:

```sql
DECLARE
  TYPE TR_EQUIP_SPEC_RECORD IS RECORD (ID VARCHAR2(36), NAME VARCHAR2(200));
  V_SPEC_ROW TR_EQUIP_SPEC_RECORD;
BEGIN
  NULL;
END;
```

The parser's `parserParameters()` recognized `TYPE ... IS REF CURSOR` and `TYPE ... IS TABLE OF ...`, but had no branch for `RECORD`, so it fell through to the catch-all `TODO`:

```
ParserException: TODO :  pos 43, line 1, column 38, token IDENTIFIER RECORD
```

## Root cause

`OracleStatementParser.parserParameters()`'s `TYPE` branch handled only `REF CURSOR` and `TABLE OF`, never `RECORD`.

## How

Add a `RECORD` branch next to the `REF CURSOR` branch: consume the `(`-delimited field list and build a `SQLStructDataType` (each field is a `name dataType` pair). This captures the record shape on the AST and lets parsing continue.

Limitation: on round-trip the record is rendered via the struct data type's default form rather than the exact `RECORD(...)` spelling. The primary goal of this change (the issue's report) is that these declarations parse without aborting; the record type is captured on the AST either way.

## Testing

- New test `OracleTypeRecordTest` (2 cases), both fail before the fix with `TODO ... token IDENTIFIER RECORD`, both pass after:
  - `typeIsRecord` — a block declaring a record type and a variable of it.
  - `typeIsRecordInFullBlock` — the issue's full block (REF CURSOR + RECORD + variables).
- `./mvnw -pl core validate` → `0 Checkstyle violations`.
- Regression: `OracleBlockTest*`, `Issue6435` → `Tests run: 2, Failures: 0`.

## Verification of the original issue

Before:
```
DECLARE TYPE TR_EQUIP_SPEC_RECORD IS RECORD (...)  →  TODO ... token IDENTIFIER RECORD
```

After:
```
→ parses successfully
```

Fixes #2755
