### PR TITLE
fix(sql): refactor rewrites table name in nested property owners

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -2331,6 +2331,20 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
             print('.');
         }
         String name = replaceQuota(x.getName());
+        if (tableMapping != null && x.getParent() instanceof SQLPropertyExpr) {
+            // x is the owner of another property (middle of db.tbl.col); its name
+            // is a table reference and must be rewritten, not only the FROM clause
+            String mappedName = tableMapping.get(x.getName());
+            if (mappedName == null) {
+                String raw = x.getName();
+                if (raw.length() > 2 && raw.charAt(0) == '`' && raw.charAt(raw.length() - 1) == '`') {
+                    mappedName = tableMapping.get(raw.substring(1, raw.length() - 1));
+                }
+            }
+            if (mappedName != null) {
+                name = replaceQuota(mappedName);
+            }
+        }
         if ("*".equals(name)) {
             print0(name);
         } else {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/issues/Issue6119Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/issues/Issue6119Test.java
@@ -1,0 +1,37 @@
+package com.alibaba.druid.bvt.sql.issues;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SQLUtils.refactor 改写表名时，select item 中三段式 {@code db.tbl.col} 的
+ * 中段表名未被改写的问题。
+ *
+ * @author fudianchn
+ * @see <a href="https://github.com/alibaba/druid/issues/6119">Issue #6119</a>
+ */
+public class Issue6119Test {
+    @Test
+    public void refactorThreePartTableName() {
+        Map<String, String> mapping = Collections.singletonMap("tbl_b", "xxx");
+        String out = SQLUtils.refactor("select db_a.tbl_b.col_c from db_a.tbl_b", DbType.mysql, mapping);
+        // both the FROM table and the select-item owner chain must be rewritten
+        assertFalse(out.contains("tbl_b"), "table name should be rewritten everywhere, was: " + out);
+        assertTrue(out.contains("db_a.xxx.col_c"), "select-item owner must be rewritten, was: " + out);
+    }
+
+    @Test
+    public void refactorTwoPartTableName() {
+        Map<String, String> mapping = Collections.singletonMap("user_extra", "renamed");
+        String out = SQLUtils.refactor("select user_extra.col from user_extra", DbType.mysql, mapping);
+        assertFalse(out.contains("user_extra"), "was: " + out);
+        assertTrue(out.contains("renamed.col"), "was: " + out);
+    }
+}


### PR DESCRIPTION
## What
`SQLUtils.refactor` now rewrites the table name everywhere it appears, including the middle of a three-part property chain like `db.tbl.col`.

## Why
Before this change, `refactor` rewrote the FROM table but left the select-item owner unchanged:

```java
Map<String, String> mapping = Collections.singletonMap("tbl_b", "xxx");
SQLUtils.refactor("select db_a.tbl_b.col_c from db_a.tbl_b", DbType.mysql, mapping);
// was:  SELECT db_a.tbl_b.col_c FROM db_a.xxx   ← tbl_b not rewritten in the item
// now:  SELECT db_a.xxx.col_c  FROM db_a.xxx
```

Issue #6119.

## Root cause
`visit(SQLPropertyExpr)` only consulted `tableMapping` when the property's owner was a `SQLIdentifierExpr`. For `db.tbl.col` the AST nests as `SQLPropertyExpr(col, owner=SQLPropertyExpr(tbl, owner=Ident(db)))`: `tbl` is the **name** of the inner property, never any layer's ownerName, so it was never looked up in the mapping.

## How
In `visit(SQLPropertyExpr)`, when the current property is itself the owner of another property (`x.getParent() instanceof SQLPropertyExpr`), its name is part of a table-reference chain and is looked up in `tableMapping` (with the same backtick-stripping fallback used for owner names). Leaf columns are untouched — their parent is a `SQLSelectItem` / expression, not a `SQLPropertyExpr`.

## Testing
- New `Issue6119Test`: three-part chain `db.tbl.col` rewrites in both item and FROM; two-part `tbl.col` still rewrites (regression guard).
- `./mvnw -pl core test`: full core suite green (0 failures).

Fixes #6119
