### PR TITLE
fix(hive): allow COMMENT between PARTITIONED BY and LOCATION in CREATE TABLE

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/hive/parser/HiveCreateTableParser.java
@@ -292,6 +292,10 @@ public class HiveCreateTableParser extends SQLCreateTableParser {
             stmt.setRbracketUse(true);
             lexer.nextToken();
         }
+        if (lexer.nextIf(Token.COMMENT)) {
+            SQLExpr comment = this.exprParser.expr();
+            stmt.setComment(comment);
+        }
         if (lexer.identifierEquals(FnvHash.Constants.LOCATION)) {
             lexer.nextToken();
             SQLExpr location = this.exprParser.primary();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/hive/issues/Issue6071Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/hive/issues/Issue6071Test.java
@@ -1,0 +1,47 @@
+package com.alibaba.druid.bvt.sql.hive.issues;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Hive CREATE TABLE 在 PARTITIONED BY 与 LOCATION 之间出现 COMMENT 时解析失败的问题。
+ *
+ * @author fudianchn
+ * @see <a href="https://github.com/alibaba/druid/issues/6071">Issue #6071</a>
+ */
+public class Issue6071Test {
+    @Test
+    public void commentBetweenPartitionedByAndLocation() {
+        String sql = "CREATE TABLE IF NOT EXISTS test.t (\n"
+            + "  bat_no string COMMENT '批号'\n"
+            + ")\n"
+            + "PARTITIONED BY (acct_prd string comment '会计期')\n"
+            + "COMMENT '明细表'\n"
+            + "LOCATION 'obs://bucket/path'\n"
+            + "TBLPROPERTIES ('type'='mor')";
+
+        List<SQLStatement> stmts = SQLUtils.parseStatements(sql, "hive");
+        assertEquals(1, stmts.size());
+
+        SQLCreateTableStatement stmt = (SQLCreateTableStatement) stmts.get(0);
+        assertNotNull(stmt.getComment(), "table COMMENT must be captured");
+        assertNotNull(stmt.getLocation(), "LOCATION must be captured");
+    }
+
+    @Test
+    public void commentAfterLocationStillWorks() {
+        // regression guard: COMMENT after LOCATION (the previously supported order) still parses
+        String sql = "CREATE TABLE t (id int) LOCATION 'loc' COMMENT 'c'";
+        SQLCreateTableStatement stmt = (SQLCreateTableStatement)
+                SQLUtils.parseStatements(sql, "hive").get(0);
+        assertNotNull(stmt.getComment());
+        assertNotNull(stmt.getLocation());
+    }
+}


### PR DESCRIPTION
## What
Hive `CREATE TABLE` now accepts a table-level `COMMENT` placed between `PARTITIONED BY` and `LOCATION`.

## Why
```sql
CREATE TABLE IF NOT EXISTS test.t (
  bat_no string COMMENT '批号'
)
PARTITIONED BY (acct_prd string comment '会计期')
COMMENT '明细表'
LOCATION 'obs://bucket/path'
TBLPROPERTIES ('type'='mor')
```
raised `not supported ... token IDENTIFIER LOCATION`. Issue #6071.

## Root cause
`HiveCreateTableParser.parseCreateTableRest` is a linear chain of `if` guards that each recognise a clause once. `COMMENT` was only recognised in two positions — before `PARTITIONED BY` (line 153) and after `LOCATION`/`TBLPROPERTIES` (line 337). When `COMMENT` sat between `PARTITIONED BY` and `LOCATION`, it slipped through every intermediate guard and was consumed by the trailing `COMMENT` branch — after which the `LOCATION` token had no matching branch left (the only `LOCATION` guard sits before that point) and the parser failed.

## How
Recognise `COMMENT` once more, immediately before the `LOCATION` branch, so the clause is consumed in the order the user wrote it. The pre-existing COMMENT branches (before PARTITIONED BY, and after TBLPROPERTIES) are untouched, so previously supported orderings keep working.

## Testing
- New `Issue6071Test`: the issue's `PARTITIONED BY ... COMMENT ... LOCATION ...` ordering now parses, capturing both COMMENT and LOCATION; a regression guard checks the previously supported `LOCATION ... COMMENT` ordering still works.
- `./mvnw -pl core test`: full core suite green.

Fixes #6071
