### PR TITLE
fix(postgresql): support CREATE TABLE LIKE ... INCLUDING DEFAULTS/CONSTRAINTS/INDEXES

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLTableLike.java
+++ b/core/src/main/java/com/alibaba/druid/sql/ast/statement/SQLTableLike.java
@@ -9,6 +9,18 @@ public class SQLTableLike extends SQLObjectImpl implements SQLTableElement {
     private boolean includeDistribution;
     private boolean excludeProperties;
     private boolean excludeDistribution;
+    private boolean includeDefaults;
+    private boolean includeConstraints;
+    private boolean includeIndexes;
+    private boolean includeStorage;
+    private boolean includeComments;
+    private boolean includeAll;
+    private boolean excludeDefaults;
+    private boolean excludeConstraints;
+    private boolean excludeIndexes;
+    private boolean excludeStorage;
+    private boolean excludeComments;
+    private boolean excludeAll;
 
     @Override
     protected void accept0(SQLASTVisitor v) {
@@ -23,7 +35,22 @@ public class SQLTableLike extends SQLObjectImpl implements SQLTableElement {
         if (table != null) {
             x.setTable(table.clone());
         }
-
+        x.includeProperties = includeProperties;
+        x.includeDistribution = includeDistribution;
+        x.excludeProperties = excludeProperties;
+        x.excludeDistribution = excludeDistribution;
+        x.includeDefaults = includeDefaults;
+        x.includeConstraints = includeConstraints;
+        x.includeIndexes = includeIndexes;
+        x.includeStorage = includeStorage;
+        x.includeComments = includeComments;
+        x.includeAll = includeAll;
+        x.excludeDefaults = excludeDefaults;
+        x.excludeConstraints = excludeConstraints;
+        x.excludeIndexes = excludeIndexes;
+        x.excludeStorage = excludeStorage;
+        x.excludeComments = excludeComments;
+        x.excludeAll = excludeAll;
         return x;
     }
 
@@ -68,5 +95,101 @@ public class SQLTableLike extends SQLObjectImpl implements SQLTableElement {
 
     public void setExcludeDistribution(boolean excludeDistribution) {
         this.excludeDistribution = excludeDistribution;
+    }
+
+    public boolean isIncludeDefaults() {
+        return includeDefaults;
+    }
+
+    public void setIncludeDefaults(boolean includeDefaults) {
+        this.includeDefaults = includeDefaults;
+    }
+
+    public boolean isExcludeDefaults() {
+        return excludeDefaults;
+    }
+
+    public void setExcludeDefaults(boolean excludeDefaults) {
+        this.excludeDefaults = excludeDefaults;
+    }
+
+    public boolean isIncludeConstraints() {
+        return includeConstraints;
+    }
+
+    public void setIncludeConstraints(boolean includeConstraints) {
+        this.includeConstraints = includeConstraints;
+    }
+
+    public boolean isExcludeConstraints() {
+        return excludeConstraints;
+    }
+
+    public void setExcludeConstraints(boolean excludeConstraints) {
+        this.excludeConstraints = excludeConstraints;
+    }
+
+    public boolean isIncludeIndexes() {
+        return includeIndexes;
+    }
+
+    public void setIncludeIndexes(boolean includeIndexes) {
+        this.includeIndexes = includeIndexes;
+    }
+
+    public boolean isExcludeIndexes() {
+        return excludeIndexes;
+    }
+
+    public void setExcludeIndexes(boolean excludeIndexes) {
+        this.excludeIndexes = excludeIndexes;
+    }
+
+    public boolean isIncludeStorage() {
+        return includeStorage;
+    }
+
+    public void setIncludeStorage(boolean includeStorage) {
+        this.includeStorage = includeStorage;
+    }
+
+    public boolean isExcludeStorage() {
+        return excludeStorage;
+    }
+
+    public void setExcludeStorage(boolean excludeStorage) {
+        this.excludeStorage = excludeStorage;
+    }
+
+    public boolean isIncludeComments() {
+        return includeComments;
+    }
+
+    public void setIncludeComments(boolean includeComments) {
+        this.includeComments = includeComments;
+    }
+
+    public boolean isExcludeComments() {
+        return excludeComments;
+    }
+
+    public void setExcludeComments(boolean excludeComments) {
+        this.excludeComments = excludeComments;
+    }
+
+    public boolean isIncludeAll() {
+        return includeAll;
+    }
+
+    public void setIncludeAll(boolean includeAll) {
+        this.includeAll = includeAll;
+    }
+
+    public boolean isExcludeAll() {
+        return excludeAll;
+    }
+
+    public void setExcludeAll(boolean excludeAll) {
+        this.excludeAll = excludeAll;
     }
 }

--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLCreateTableParser.java
@@ -143,19 +143,51 @@ public class SQLCreateTableParser extends SQLDDLParser {
             tableLike.setParent(createTable);
             createTable.getTableElementList().add(tableLike);
 
-            if (lexer.identifierEquals(FnvHash.Constants.INCLUDING)) {
-                lexer.nextToken();
-                if (lexer.nextIfIdentifier(FnvHash.Constants.PROPERTIES)) {
-                    tableLike.setIncludeProperties(true);
-                } else if (lexer.nextIfIdentifier("DISTRIBUTION")) {
-                    tableLike.setIncludeDistribution(true);
-                }
-            } else if (lexer.identifierEquals(FnvHash.Constants.EXCLUDING)) {
-                lexer.nextToken();
-                if (lexer.nextIfIdentifier(FnvHash.Constants.PROPERTIES)) {
-                    tableLike.setExcludeProperties(true);
-                } else if (lexer.nextIfIdentifier("DISTRIBUTION")) {
-                    tableLike.setExcludeDistribution(true);
+            for (;;) {
+                if (lexer.identifierEquals(FnvHash.Constants.INCLUDING)) {
+                    lexer.nextToken();
+                    if (lexer.nextIfIdentifier(FnvHash.Constants.PROPERTIES)) {
+                        tableLike.setIncludeProperties(true);
+                    } else if (lexer.nextIfIdentifier("DISTRIBUTION")) {
+                        tableLike.setIncludeDistribution(true);
+                    } else if (lexer.nextIfIdentifier("DEFAULTS")) {
+                        tableLike.setIncludeDefaults(true);
+                    } else if (lexer.nextIfIdentifier("CONSTRAINTS")) {
+                        tableLike.setIncludeConstraints(true);
+                    } else if (lexer.nextIfIdentifier("INDEXES")) {
+                        tableLike.setIncludeIndexes(true);
+                    } else if (lexer.nextIfIdentifier("STORAGE")) {
+                        tableLike.setIncludeStorage(true);
+                    } else if (lexer.nextIfIdentifier("COMMENTS")) {
+                        tableLike.setIncludeComments(true);
+                    } else if (lexer.nextIfIdentifier("ALL")) {
+                        tableLike.setIncludeAll(true);
+                    } else {
+                        break;
+                    }
+                } else if (lexer.identifierEquals(FnvHash.Constants.EXCLUDING)) {
+                    lexer.nextToken();
+                    if (lexer.nextIfIdentifier(FnvHash.Constants.PROPERTIES)) {
+                        tableLike.setExcludeProperties(true);
+                    } else if (lexer.nextIfIdentifier("DISTRIBUTION")) {
+                        tableLike.setExcludeDistribution(true);
+                    } else if (lexer.nextIfIdentifier("DEFAULTS")) {
+                        tableLike.setExcludeDefaults(true);
+                    } else if (lexer.nextIfIdentifier("CONSTRAINTS")) {
+                        tableLike.setExcludeConstraints(true);
+                    } else if (lexer.nextIfIdentifier("INDEXES")) {
+                        tableLike.setExcludeIndexes(true);
+                    } else if (lexer.nextIfIdentifier("STORAGE")) {
+                        tableLike.setExcludeStorage(true);
+                    } else if (lexer.nextIfIdentifier("COMMENTS")) {
+                        tableLike.setExcludeComments(true);
+                    } else if (lexer.nextIfIdentifier("ALL")) {
+                        tableLike.setExcludeAll(true);
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
                 }
             }
         } else if (lexer.token() == Token.INDEX) {

--- a/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
+++ b/core/src/main/java/com/alibaba/druid/sql/visitor/SQLASTOutputVisitor.java
@@ -11796,12 +11796,51 @@ public class SQLASTOutputVisitor extends SQLASTVisitorAdapter implements Paramet
 
         if (x.isIncludeProperties()) {
             print0(ucase ? " INCLUDING PROPERTIES" : " including properties");
-        } else if (x.isExcludeProperties()) {
+        }
+        if (x.isExcludeProperties()) {
             print0(ucase ? " EXCLUDING PROPERTIES" : " excluding properties");
-        } else if (x.isIncludeDistribution()) {
+        }
+        if (x.isIncludeDistribution()) {
             print0(ucase ? " INCLUDING DISTRIBUTION" : " including distribution");
-        } else if (x.isExcludeDistribution()) {
+        }
+        if (x.isExcludeDistribution()) {
             print0(ucase ? " EXCLUDING DISTRIBUTION" : " excluding distribution");
+        }
+        if (x.isIncludeDefaults()) {
+            print0(ucase ? " INCLUDING DEFAULTS" : " including defaults");
+        }
+        if (x.isExcludeDefaults()) {
+            print0(ucase ? " EXCLUDING DEFAULTS" : " excluding defaults");
+        }
+        if (x.isIncludeConstraints()) {
+            print0(ucase ? " INCLUDING CONSTRAINTS" : " including constraints");
+        }
+        if (x.isExcludeConstraints()) {
+            print0(ucase ? " EXCLUDING CONSTRAINTS" : " excluding constraints");
+        }
+        if (x.isIncludeIndexes()) {
+            print0(ucase ? " INCLUDING INDEXES" : " including indexes");
+        }
+        if (x.isExcludeIndexes()) {
+            print0(ucase ? " EXCLUDING INDEXES" : " excluding indexes");
+        }
+        if (x.isIncludeStorage()) {
+            print0(ucase ? " INCLUDING STORAGE" : " including storage");
+        }
+        if (x.isExcludeStorage()) {
+            print0(ucase ? " EXCLUDING STORAGE" : " excluding storage");
+        }
+        if (x.isIncludeComments()) {
+            print0(ucase ? " INCLUDING COMMENTS" : " including comments");
+        }
+        if (x.isExcludeComments()) {
+            print0(ucase ? " EXCLUDING COMMENTS" : " excluding comments");
+        }
+        if (x.isIncludeAll()) {
+            print0(ucase ? " INCLUDING ALL" : " including all");
+        }
+        if (x.isExcludeAll()) {
+            print0(ucase ? " EXCLUDING ALL" : " excluding all");
         }
         return false;
     }

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6168Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue6168Test.java
@@ -1,0 +1,50 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
+import com.alibaba.druid.sql.ast.statement.SQLTableLike;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PostgreSQL CREATE TABLE 的 LIKE 子句 INCLUDING DEFAULTS/CONSTRAINTS/INDEXES 解析失败。
+ *
+ * @author fudianchn
+ * @see <a href="https://github.com/alibaba/druid/issues/6168">Issue #6168</a>
+ * @see <a href="https://www.postgresql.org/docs/current/sql-createtable.html">CREATE TABLE ... LIKE</a>
+ */
+public class Issue6168Test {
+    @Test
+    public void pgLikeIncludingMultiple() {
+        String sql = "CREATE TABLE new_table (\n"
+            + "\tLIKE existing_table INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES\n"
+            + ")";
+        SQLCreateTableStatement stmt = (SQLCreateTableStatement)
+                SQLUtils.parseStatements(sql, "postgresql").get(0);
+
+        SQLTableLike tableLike = (SQLTableLike) stmt.getTableElementList().get(0);
+        assertTrue(tableLike.isIncludeDefaults());
+        assertTrue(tableLike.isIncludeConstraints());
+        assertTrue(tableLike.isIncludeIndexes());
+
+        String out = stmt.toString();
+        assertTrue(out.contains("INCLUDING DEFAULTS"), out);
+        assertTrue(out.contains("INCLUDING CONSTRAINTS"), out);
+        assertTrue(out.contains("INCLUDING INDEXES"), out);
+    }
+
+    @Test
+    public void pgLikeMixedWithColumns() {
+        String sql = "CREATE TABLE archived_orders (\n"
+            + "\tLIKE orders INCLUDING CONSTRAINTS,\n"
+            + "\tarchived_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n"
+            + ")";
+        SQLCreateTableStatement stmt = (SQLCreateTableStatement)
+                SQLUtils.parseStatements(sql, "postgresql").get(0);
+        assertEquals(2, stmt.getTableElementList().size());
+        SQLTableLike tableLike = (SQLTableLike) stmt.getTableElementList().get(0);
+        assertTrue(tableLike.isIncludeConstraints());
+    }
+}


### PR DESCRIPTION
## What
PostgreSQL `CREATE TABLE ... (LIKE other INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)` now parses.

## Why
```sql
CREATE TABLE new_table (
  LIKE existing_table INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES
);
CREATE TABLE archived_orders (
  LIKE orders INCLUDING CONSTRAINTS,
  archived_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);
```
Both raised a parse error. Issue #6168.

## Root cause
`SQLTableLike` only modelled `INCLUDING/EXCLUDING PROPERTIES` and `DISTRIBUTION` (Hive/ODPS options) — none of the PostgreSQL options. On top of that, the LIKE branch in `SQLCreateTableParser.createTableBody` consumed a single `INCLUDING/EXCLUDING <option>` instead of looping, so once `INCLUDING DEFAULTS` was read, the next `INCLUDING` keyword was left dangling and parsing failed.

## How
- `SQLTableLike`: add PG flags `includeDefaults/includeConstraints/includeIndexes/includeStorage/includeComments/includeAll` (and the `exclude` counterparts), mirroring the existing PROPERTIES/DISTRIBUTION ones. Also copy all boolean flags in `clone()` — the previous `clone()` dropped every flag.
- `SQLCreateTableParser`: the LIKE branch now loops over `INCLUDING/EXCLUDING` clauses, so multiple options parse; the new PG options are recognised alongside PROPERTIES/DISTRIBUTION (backward compatible).
- `SQLASTOutputVisitor.visit(SQLTableLike)`: render each flag independently (the previous `else if` chain rendered at most one option, which would lose options on round-trip).

## Testing
- New `Issue6168Test`: multi-option `INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES` parses and round-trips; `LIKE ... INCLUDING CONSTRAINTS` mixed with column definitions also parses.
- `./mvnw -pl core test`: full core suite green.

Fixes #6168
