### PR TITLE
fix(postgresql): support GRANT/REVOKE ... ON DATABASE / ON SCHEMA

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/SQLStatementParser.java
@@ -1593,6 +1593,10 @@ public class SQLStatementParser extends SQLParser {
                     lexer.nextToken();
                     stmt.setResourceType(SQLObjectType.DATABASE);
                     break;
+                case SCHEMA:
+                    lexer.nextToken();
+                    stmt.setResourceType(SQLObjectType.SCHEMA);
+                    break;
                 case IDENTIFIER:
                     if (lexer.identifierEquals("SYSTEM")) {
                         lexer.nextToken();
@@ -2028,6 +2032,14 @@ public class SQLStatementParser extends SQLParser {
                 case USER:
                     lexer.nextToken();
                     stmt.setResourceType(SQLObjectType.USER);
+                    break;
+                case DATABASE:
+                    lexer.nextToken();
+                    stmt.setResourceType(SQLObjectType.DATABASE);
+                    break;
+                case SCHEMA:
+                    lexer.nextToken();
+                    stmt.setResourceType(SQLObjectType.SCHEMA);
                     break;
                 case IDENTIFIER:
                     if (lexer.identifierEquals("SYSTEM")) {

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5964Test.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/postgresql/issues/Issue5964Test.java
@@ -1,0 +1,38 @@
+package com.alibaba.druid.bvt.sql.postgresql.issues;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.statement.SQLGrantStatement;
+import com.alibaba.druid.sql.ast.statement.SQLObjectType;
+import com.alibaba.druid.sql.ast.statement.SQLRevokeStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PostgreSQL GRANT/REVOKE ... ON DATABASE / ON SCHEMA 解析报错。
+ *
+ * @author fudianchn
+ * @see <a href="https://github.com/alibaba/druid/issues/5964">Issue #5964</a>
+ */
+public class Issue5964Test {
+    @Test
+    public void pgGrantOnSchema() {
+        String sql = "GRANT ALL PRIVILEGES ON SCHEMA public TO your_username";
+        SQLGrantStatement stmt = (SQLGrantStatement) SQLUtils.parseStatements(sql, "postgresql").get(0);
+        assertEquals(SQLObjectType.SCHEMA, stmt.getResourceType());
+    }
+
+    @Test
+    public void pgRevokeOnDatabase() {
+        String sql = "REVOKE ALL PRIVILEGES ON DATABASE mydb FROM username";
+        SQLRevokeStatement stmt = (SQLRevokeStatement) SQLUtils.parseStatements(sql, "postgresql").get(0);
+        assertEquals(SQLObjectType.DATABASE, stmt.getResourceType());
+    }
+
+    @Test
+    public void pgRevokeOnSchema() {
+        String sql = "REVOKE ALL PRIVILEGES ON SCHEMA public FROM your_username";
+        SQLRevokeStatement stmt = (SQLRevokeStatement) SQLUtils.parseStatements(sql, "postgresql").get(0);
+        assertEquals(SQLObjectType.SCHEMA, stmt.getResourceType());
+    }
+}


### PR DESCRIPTION
## What
PostgreSQL `GRANT/REVOKE ... ON DATABASE` and `ON SCHEMA` now parse.

## Why
The issue lists several statements that failed; the common failure across PG / openGauss / Kingbase is `GRANT|REVOKE ... ON DATABASE|SCHEMA`:

```sql
REVOKE ALL PRIVILEGES ON DATABASE mydb FROM username;       -- PG/openGauss
GRANT  ALL PRIVILEGES ON SCHEMA public TO your_username;    -- Kingbase
REVOKE ALL PRIVILEGES ON SCHEMA public FROM your_username;  -- Kingbase
```

Issue #5964.

## Root cause
The ON-resource `switch` in `parseGrant` recognised `DATABASE` but **not** `SCHEMA`; `parseRevoke` recognised **neither**. Both fell through to the default branch, so `ON SCHEMA`, and `ON DATABASE` in REVOKE, left the resource token unhandled and parsing failed.

## How
Add the missing `case SCHEMA` to `parseGrant`, and `case DATABASE` + `case SCHEMA` to `parseRevoke`. Both map to the existing `SQLObjectType.DATABASE` / `SQLObjectType.SCHEMA`.

## Scope
This covers the PG-family GRANT/REVOKE ON DATABASE|SCHEMA statements (PG / openGauss / Kingbase, all parsed via the postgresql dialect). Two items from the issue are left out as separate concerns:
- DM `GRANT DBA TO username` — that's a role grant, not `ON <resource>`, and needs DM-dialect handling.
- `CREATE USER ... WITH PASSWORD` — a separate code path (`parseCreateUser`), worth its own look.

Happy to follow up on either if useful.

## Testing
- New `Issue5964Test`: GRANT ON SCHEMA, REVOKE ON DATABASE, REVOKE ON SCHEMA all parse with the correct `resourceType`.
- `./mvnw -pl core test`: full core suite green.

Fixes #5964
